### PR TITLE
feat: baseline training pipeline — preprocessing, logging, eval, comparison

### DIFF
--- a/modules/dreamerv3/train.py
+++ b/modules/dreamerv3/train.py
@@ -10,11 +10,16 @@ import numpy as np
 from .configs import DreamerConfig
 from .agent import DreamerAgent
 from .replay_buffer import ReplayBuffer
+from modules.shared.wandb_utils import EpisodeTracker
 
 
 def greedy_eval(agent, env, rng_key, num_episodes=10, max_steps=500):
     """Run greedy evaluation episodes, return mean metrics."""
+    from collections import defaultdict
+
     rewards, successes, spls, lengths = [], [], [], []
+    cat_successes = defaultdict(list)
+    cat_spls = defaultdict(list)
     for _ in range(num_episodes):
         obs = env.reset()
         ep_reward, steps = 0.0, 0
@@ -24,16 +29,27 @@ def greedy_eval(agent, env, rng_key, num_episodes=10, max_steps=500):
             obs = env.step(action)
             ep_reward += obs["reward"]
             steps += 1
+        category = getattr(env._env.current_episode, "object_category", "unknown")
+        success = obs.get("success", 0.0)
+        spl = obs.get("spl", 0.0)
         rewards.append(ep_reward)
-        successes.append(obs.get("success", 0.0))
-        spls.append(obs.get("spl", 0.0))
+        successes.append(success)
+        spls.append(spl)
         lengths.append(steps)
-    return {
+        cat_successes[category].append(success)
+        cat_spls[category].append(spl)
+
+    metrics = {
         "eval/reward": np.mean(rewards),
         "eval/success": np.mean(successes),
         "eval/spl": np.mean(spls),
         "eval/episode_length": np.mean(lengths),
     }
+    for cat, vals in cat_successes.items():
+        metrics[f"eval/goal/{cat}/sr"] = np.mean(vals)
+    for cat, vals in cat_spls.items():
+        metrics[f"eval/goal/{cat}/spl"] = np.mean(vals)
+    return metrics
 
 
 def main():
@@ -119,6 +135,7 @@ def main():
     batch_steps = config.batch_size * config.seq_len
     train_credit = 0.0
     metrics = {}
+    tracker = EpisodeTracker(window=100)
 
     for step in range(start_step, config.total_steps):
         rng_key, act_key = jax.random.split(rng_key)
@@ -131,17 +148,26 @@ def main():
 
         if next_obs["done"]:
             episode_count += 1
-            log_data = {
-                "episode_reward": episode_reward,
-                "episode_count": episode_count,
-                "success": next_obs.get("success", 0.0),
-                "spl": next_obs.get("spl", 0.0),
-            }
+            success = next_obs.get("success", 0.0)
+            spl = next_obs.get("spl", 0.0)
+
+            # Capture metadata BEFORE reset clears current episode
+            category = getattr(env._env.current_episode, "object_category", "unknown")
+            scene_id = getattr(env._env.current_episode, "scene_id", "")
+
+            log_data = tracker.record(
+                reward=episode_reward,
+                success=success,
+                spl=spl,
+                category=category,
+                scene_id=scene_id,
+            )
             if use_wandb:
                 wandb.log(log_data, step=step)
             if step % config.log_every == 0:
                 print(f"[step {step}] ep={episode_count} reward={episode_reward:.2f} "
-                      f"success={next_obs.get('success', 0):.1f}")
+                      f"success={success:.1f} SR={log_data['metrics/sr']:.3f} "
+                      f"goal={category}")
             episode_reward = 0.0
             obs = env.reset()
         else:

--- a/modules/r2dreamer/scripts/run_jax_habitat.py
+++ b/modules/r2dreamer/scripts/run_jax_habitat.py
@@ -19,6 +19,7 @@ from modules.r2dreamer.config import R2DreamerConfig
 from modules.dreamerv3.configs import DreamerConfig
 from modules.envs.habitat import HabitatObjectNavEnv
 from modules.dreamerv3.replay_buffer import ReplayBuffer, ValReplayDataset
+from modules.shared.wandb_utils import EpisodeTracker
 
 
 def _convert_batch(batch: dict, num_actions: int) -> dict:
@@ -155,6 +156,7 @@ def main():
         batch_steps = config.batch_size * config.seq_len
         train_credit = 0.0
         metrics = {}
+        tracker = EpisodeTracker(window=100)
 
         for step in range(config.total_steps):
             rng_key, act_key = jax.random.split(rng_key)
@@ -173,22 +175,35 @@ def main():
                 success = next_obs.get("success", 0.0)
                 spl = next_obs.get("spl", 0.0)
 
+                # Capture metadata BEFORE reset clears current episode
+                category = getattr(env._env.current_episode, "object_category", "unknown")
+                scene_raw = getattr(env._env.current_episode, "scene_id", "")
+
+                tracked = tracker.record(
+                    reward=episode_reward,
+                    success=success,
+                    spl=spl,
+                    category=category,
+                    scene_id=scene_raw,
+                )
+
                 # CSV
                 writer.writerow([step, "episode/reward", episode_reward])
                 writer.writerow([step, "episode/success", success])
                 writer.writerow([step, "episode/spl", spl])
                 writer.writerow([step, "episode/steps", episode_steps])
+                writer.writerow([step, "episode/goal", category])
+                writer.writerow([step, "episode/scene", tracked["episode/scene"]])
+                writer.writerow([step, "metrics/sr", tracked["metrics/sr"]])
+                writer.writerow([step, "metrics/spl", tracked["metrics/spl"]])
                 f.flush()
 
-                # WandB — episode metrics + action distribution
+                # WandB — episode metrics + rolling averages + per-category + actions
                 action_pcts = action_counts / max(episode_steps, 1)
                 action_names = {0: "stop", 1: "forward", 2: "left", 3: "right"}
                 wandb.log({
-                    "episode/reward": episode_reward,
-                    "episode/success": success,
-                    "episode/spl": spl,
+                    **tracked,
                     "episode/steps": episode_steps,
-                    "episode/count": episode_count,
                     **{f"action/{action_names[i]}_pct": float(action_pcts[i])
                        for i in range(config.num_actions)},
                 }, step=step)
@@ -196,7 +211,8 @@ def main():
                 print(
                     f"[step {step:>8d}] episode {episode_count}: "
                     f"reward={episode_reward:.2f} success={success:.0f} "
-                    f"spl={spl:.3f} steps={episode_steps}"
+                    f"spl={spl:.3f} steps={episode_steps} "
+                    f"SR={tracked['metrics/sr']:.3f} goal={category}"
                 )
 
                 episode_reward = 0.0

--- a/modules/shared/wandb_utils.py
+++ b/modules/shared/wandb_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import defaultdict, deque
 from typing import Any
 
 import numpy as np
@@ -18,6 +19,58 @@ def init_run(
     return wandb.init(project=project, config=config, tags=tags, group=group)
 
 
+class EpisodeTracker:
+    """Track per-episode metrics with rolling averages and per-category breakdown."""
+
+    def __init__(self, window: int = 100):
+        self._window = window
+        self._rewards: deque[float] = deque(maxlen=window)
+        self._successes: deque[float] = deque(maxlen=window)
+        self._spls: deque[float] = deque(maxlen=window)
+        self._cat_successes: dict[str, deque[float]] = defaultdict(
+            lambda: deque(maxlen=window)
+        )
+        self._cat_rewards: dict[str, deque[float]] = defaultdict(
+            lambda: deque(maxlen=window)
+        )
+        self._episode_count = 0
+
+    def record(
+        self,
+        reward: float,
+        success: float,
+        spl: float,
+        category: str,
+        scene_id: str,
+    ) -> dict[str, Any]:
+        """Record a completed episode, return dict of all metrics to log."""
+        self._episode_count += 1
+        self._rewards.append(reward)
+        self._successes.append(success)
+        self._spls.append(spl)
+        self._cat_successes[category].append(success)
+        self._cat_rewards[category].append(reward)
+
+        scene = scene_id.split("/")[-1].replace(".basis.glb", "")
+
+        metrics: dict[str, Any] = {
+            "episode/reward": reward,
+            "episode/success": success,
+            "episode/spl": spl,
+            "episode/count": self._episode_count,
+            "episode/goal": category,
+            "episode/scene": scene,
+            "metrics/sr": float(np.mean(self._successes)),
+            "metrics/spl": float(np.mean(self._spls)),
+            "metrics/reward": float(np.mean(self._rewards)),
+        }
+        for cat, succ_deque in self._cat_successes.items():
+            metrics[f"goal/{cat}/sr"] = float(np.mean(succ_deque))
+        for cat, rew_deque in self._cat_rewards.items():
+            metrics[f"goal/{cat}/reward"] = float(np.mean(rew_deque))
+        return metrics
+
+
 def log_episode(
     step: int,
     reward: float,
@@ -25,6 +78,8 @@ def log_episode(
     spl: float,
     observations: dict[str, np.ndarray] | None = None,
     vggt_features: np.ndarray | None = None,
+    goal: str | None = None,
+    scene: str | None = None,
 ) -> None:
     """Log per-episode metrics + optional obs images and VGGT stats."""
     metrics: dict[str, Any] = {
@@ -32,6 +87,11 @@ def log_episode(
         "episode/success": int(success),
         "episode/spl": spl,
     }
+
+    if goal is not None:
+        metrics["episode/goal"] = goal
+    if scene is not None:
+        metrics["episode/scene"] = scene
 
     if vggt_features is not None:
         metrics["episode/vggt_norm"] = float(np.linalg.norm(vggt_features))


### PR DESCRIPTION
Phase 1: Precompute episode step counts (precompute_episode_steps.py),
filter broken episodes (>=200 steps) in HabitatObjectNavEnv.

Phase 2: Add action distribution and latent diagnostics (prior/posterior
entropy, KL divergence) to WandB logging during training.

Phase 3: Record agent trajectory, start/goal positions in eval. Add
--random flag to eval_habitat.py for random baseline comparison.
Evaluation notebook with semantic top-down maps. Comparison notebook
for random-vs-trained on all 4 success criteria.

Phase 4: Updated SLURM script with filtering, 50 eval episodes.

Addresses #49. Closes #51 (already implemented).