### PR TITLE
VGGT JAX port: Steps 1-8 + jit aggregator with padded KV-cache (WIP)

### DIFF
--- a/docs/plans/l4-profiling.md
+++ b/docs/plans/l4-profiling.md
@@ -1,0 +1,109 @@
+# Plan: L4 pipeline profiling + KV-cache audit
+
+> Source PRD: #74
+> Related stubs: #72 (VGGT JAX port — blocked by findings here), #73 (paper deliverables — independent)
+
+## Architectural decisions
+
+These are locked for the whole plan — do not re-open in later slices.
+
+- **Timer primitives**:
+  - PyTorch/CUDA phases (`vggt_forward`, `vggt_wrapper`): `torch.cuda.Event` pairs. Start + end events on the current stream, read via `end.elapsed_time(start)` after `torch.cuda.synchronize()`. GPU-side timing, no CPU overhead in the fast path.
+  - JAX phases (`jax_upload`, `wm_inference`, `wm_training`): `time.perf_counter()` brackets around a call that ends with `.block_until_ready()` on the returned array. Without `block_until_ready`, async-dispatch times only dispatch, not execution.
+  - CPU-only phases (`env_step`, `buffer_add`): plain `time.perf_counter()`.
+- **Instrumentation placement**: optional `phase_times: dict[str, list[float]] | None = None` kwarg on `VGGTFeatureExtractor.extract()`. When `None` (production path) behavior is bitwise unchanged.
+- **Phase list (7, final)**: `env_step`, `vggt_forward`, `vggt_wrapper`, `jax_upload`, `wm_inference`, `buffer_add`, `wm_training`. CNN runs have zeros for `vggt_*` and `jax_upload`.
+- **Encoder dispatch**: `--encoder {vggt,cnn}` flag on the profile script. Two runs are invoked separately and their JSONs merged at report time.
+- **Output**: per-run JSON at `output/profiling/vggt_vs_cnn_<timestamp>.json` (raw per-call timings + aggregates) + stdout table (mean / p50 / p95 / delta_ms).
+- **Runner**: `modules/r2dreamer/scripts/profile_training.py` — reimplements the loop body inline rather than wrapping `Trainer`, because CUDA-Event timing must bracket individual sub-steps. Keeps `Trainer` untouched.
+- **Run length defaults**: `prefill_steps=2000`, `acting_steps=2000`. CLI-configurable.
+- **Execution**: interactive H100 session. No SLURM sbatch — the whole run is ~15 min wall time.
+
+---
+
+## Phase 1: CNN-path plumbing
+
+### What to build
+
+An end-to-end profile script that runs the training loop for **CNN only** and produces the full output artifacts (JSON + stdout table), but with only the 4 CNN-path phases populated: `env_step`, `wm_inference`, `buffer_add`, `wm_training`. This validates every piece of the pipeline (timer plumbing, JSON schema, stdout formatting, CLI handling) against the simpler encoder before touching `feature_extractor.py`.
+
+Files created:
+- `modules/r2dreamer/scripts/profile_training.py` with:
+  - `PhaseTimer` (context manager, two modes: `cpu` and `jax_block`)
+  - `RunResult` dataclass (phase_times dict-of-lists, kv_audit counts, episode stats)
+  - `run_loop(encoder: str, prefill_steps: int, acting_steps: int, ...) -> RunResult`
+  - `aggregate(results: RunResult) -> dict` (mean/p50/p95 per phase)
+  - `format_report(results_by_encoder: dict) -> str`
+  - `save_json(results_by_encoder: dict, output_dir: Path) -> Path`
+  - `main()` parses CLI, runs one encoder, saves JSON, prints table
+
+KV-cache audit counters are wired in the loop (reset_count, boundary_count) but not yet asserted — the CNN path has no `extractor.reset()` so the counts are zero.
+
+### Acceptance criteria
+
+- [ ] `uv run python modules/r2dreamer/scripts/profile_training.py --encoder cnn --prefill_steps 200 --acting_steps 200` completes end-to-end on the H100 session.
+- [ ] JSON written to `output/profiling/vggt_vs_cnn_<timestamp>.json` containing keys: `{"cnn": {"phase_times": {...}, "aggregate": {...}, "kv_audit": {...}, "episodes": {...}}}`.
+- [ ] Stdout table prints 7 rows (with vggt rows showing `—` / zeros for CNN-only run) and columns: `phase, cnn_mean_ms, cnn_p50_ms, cnn_p95_ms, vggt_mean_ms, vggt_p50_ms, vggt_p95_ms, delta_ms`.
+- [ ] `wm_inference` and `wm_training` phase values are non-zero and reasonable (wm_training fires only after buffer reaches `batch_size * seq_len`).
+- [ ] `block_until_ready` is called on every JAX-phase measurement — verified by reading the code, no per-call `<1µs` artifacts in the timing distributions.
+
+---
+
+## Phase 2: Add VGGT path + KV-cache audit
+
+### What to build
+
+Extend the script to cover the VGGT encoder and the three PyTorch/boundary phases. Touch `feature_extractor.py` once — add the `phase_times` kwarg — and use it from the loop.
+
+Files modified:
+- `modules/vggt/feature_extractor.py`:
+  - Add optional `phase_times: dict[str, list[float]] | None = None` parameter to `extract()`.
+  - When provided, create two `torch.cuda.Event` pairs: one around the aggregator+camera_head+point_head forward (`vggt_forward`), one around the pool+permute+`.cpu().numpy()` (`vggt_wrapper`). Record `event.elapsed_time` / 1000 into the list (convert ms → s or keep ms consistent with JAX phases; pick one unit and document).
+  - When `None`, no events created — production path is branchless.
+
+Files extended:
+- `modules/r2dreamer/scripts/profile_training.py`:
+  - `--encoder vggt` branch: constructs `VGGTFeatureExtractor` + `VGGTObsAdapter`, passes `phase_times` into each `extract()` call.
+  - Three new phases wired: `vggt_forward` and `vggt_wrapper` (populated by the kwarg), `jax_upload` (measured in the loop by bracketing `jnp.asarray(features).block_until_ready()` *before* `agent.act`).
+  - KV-cache audit becomes active: `reset_count` increments each time `obs_adapter.on_episode_reset` fires, `boundary_count` increments on `is_first=True` transitions. At end of loop, assert `reset_count == boundary_count + 1` (the +1 is the initial env.reset before the loop). On failure, raise `AssertionError` with both counts + episode list — the script exits non-zero.
+  - The `_flatten_vggt` call is timed inside the `vggt_wrapper` span (via `perf_counter`, merged into the same phase list slot — the CUDA event covers the `.cpu().numpy()`, perf_counter adds the tiny numpy reshape/concat).
+
+Files unchanged (guaranteed):
+- `Trainer`, `R2DreamerAgent`, buffer, env wrappers — the profile script reimplements the loop body inline.
+
+### Acceptance criteria
+
+- [ ] `uv run python modules/r2dreamer/scripts/profile_training.py --encoder vggt --prefill_steps 200 --acting_steps 200` completes end-to-end.
+- [ ] JSON now contains keys for both `cnn` and `vggt` once both runs have been invoked (two separate invocations; script appends to the same run file by reading-then-merging, OR emits per-encoder JSON and `format_report` loads both — choose simpler, pick at implementation time).
+- [ ] All 7 phases populated for VGGT: `env_step`, `vggt_forward`, `vggt_wrapper`, `jax_upload`, `wm_inference`, `buffer_add`, `wm_training`.
+- [ ] KV-cache audit assertion passes under curriculum scene switching: `reset_count == boundary_count + 1`. If it fails, script exits non-zero and the mismatch is printed.
+- [ ] `pytest modules/vggt/tests/test_feature_extractor.py` passes unchanged (production path behavior preserved).
+- [ ] VGGT stdout table shows the 7 rows with non-zero values for all phases, and a non-zero `delta_ms` column versus the CNN run.
+
+---
+
+## Phase 3: Data + written conclusion
+
+### What to build
+
+Execute the full diagnostic on the H100 session (using the real curriculum configs — L1-VGGT for VGGT, stock L1 for CNN, at `prefill=2000, acting=2000`) and document the findings.
+
+Files created:
+- `docs/wiki/methods/l4-profiling.md`:
+  - **Hardware**: H100 node name, GPU name from `nvidia-smi`, driver/CUDA version.
+  - **Run config**: encoder, prefill_steps, acting_steps, curriculum, seed, timestamp.
+  - **Results table**: the stdout table verbatim + a one-paragraph interpretation per row (which phase dominates, which surprises vs. expectation).
+  - **KV-cache audit**: reset_count, boundary_count, pass/fail.
+  - **Recommendation for #72**: go/no-go on the VGGT JAX port. Concretely: if `vggt_wrapper + jax_upload` together account for >30% of per-step wall time, #72 is go. If `vggt_forward` dominates independently, #72 won't help enough and the follow-up is instead a distilled/smaller encoder (new PRD).
+
+Files modified:
+- `docs/wiki/index.md`: add a row for the new page.
+- `docs/wiki/log.md`: append an entry per conventions.
+
+### Acceptance criteria
+
+- [ ] Real diagnostic run executed at `prefill=2000, acting=2000` for both encoders. JSON lives under `output/profiling/` and is referenced from the wiki page.
+- [ ] `docs/wiki/methods/l4-profiling.md` exists with all five sections (hardware, run config, results table, KV-cache audit, recommendation for #72).
+- [ ] `docs/wiki/index.md` lists the new page.
+- [ ] `docs/wiki/log.md` has a dated entry summarizing the finding.
+- [ ] Recommendation in the wiki page is unambiguous (go / no-go / alternative path) and grounded in the table numbers.

--- a/docs/wiki/experiments/vggt_jax_port_step8_bench.md
+++ b/docs/wiki/experiments/vggt_jax_port_step8_bench.md
@@ -1,0 +1,26 @@
+# VGGT JAX port — Step 8 initial benchmark
+
+`modules/vggt/jax/benchmark_streaming.py`, 10-frame episode on H100, synthetic uint8 frames.
+
+| Backend | Config | Mean ms/frame | Median ms/frame | Peak mem |
+|---|---|---|---|---|
+| PyTorch | bf16 autocast (production) | 98.5 | 94.9 | 8.0 GB |
+| JAX     | eager fp32 (no jit)        | 5395.9 | 5959.6 | n/a |
+
+JAX is ~55× slower than PyTorch at this configuration. The gap is expected given:
+
+- JAX runs eager — the Python graph is rebuilt per frame; no kernel fusion.
+- JAX runs fp32 — PyTorch uses bf16 autocast, which on Ampere+ GPUs is 2-3× faster.
+- PyTorch's aggregator uses `F.scaled_dot_product_attention` (fused SDPA); our JAX attention is a manual einsum.
+
+To meet the plan's "not slower than PyTorch compile + bf16" latency floor, follow-up work needs:
+
+1. `jax.jit` wrap of the per-frame forward in `JAXVGGTFeatureExtractor.extract`.
+2. Bf16 autocast for aggregator matmuls with fp32-preserved softmax and fp32 heads.
+3. Optionally a Pallas or flash-attention kernel for the global blocks with large KV caches.
+
+The benchmark CSV lives at `output/comparison/` (gitignored). Re-run with:
+
+```bash
+uv run python -m modules.vggt.jax.benchmark_streaming --seq-lens 10 50 100
+```

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -14,6 +14,7 @@
 - [Claude Code Workflow](methods/workflow.md) — Full pipeline, skill inventory, TDD rules, wiki conventions
 - [World Model Training Loop](methods/world-model-training-loop.md) — How 64-step windows, 15-step imagination, and full episodes fit together
 - [Training Orchestration](methods/training-orchestration.md) — Unified buffer, Trainer module, ObsAdapter pattern (RFC #68)
+- [L4 Pipeline Profiling](methods/l4-profiling.md) — VGGT vs CNN per-phase timing on H100; vggt_forward = 168ms p50 dominates; PyTorch↔JAX boundary is 0.4ms (not the bottleneck)
 
 ## Meetings
 

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -1,5 +1,8 @@
 # Wiki Log
 
+## [2026-04-20] ingest | L4 Pipeline Profiling (VGGT vs CNN) | source: /plan Slice 3 (PRD #74)
+Full 2000/2000 diagnostic on H100. VGGT forward = 168.3 ms p50 — 90% of the VGGT-vs-CNN slowdown. PyTorch↔JAX boundary (vggt_wrapper + jax_upload) = 0.44 ms — disproves the original #72 motivation. KV-cache reset contract verified (9 resets, 9 boundaries). Recommendation: repurpose #72 away from JAX port toward torch.compile / frame-skip / distillation. Created methods/l4-profiling.md. JSON: output/profiling/vggt_vs_cnn_20260420_{102405,103840}.json.
+
 ## [2026-04-16] ingest | Curriculum Scaling (L1-rerun, L2, L3) | source: /reporter
 Updated experiments/l1-rerun-buffix.md, experiments/l2-1house-6goals.md, experiments/l3-10houses-chair.md with completed status. Semantic floor plan data collected for fK2vEV32Lag (L2 scene). Plot scripts and combined slide deck created.
 

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -1,5 +1,8 @@
 # Wiki Log
 
+## [2026-04-20] update | torch.compile spike on VGGT | source: /plan Slice 3 follow-up (PRD #74)
+`VGGTFeatureExtractor(compile=True)` wraps aggregator/camera_head with dynamic=True, point_head static. Measured 11% p50 reduction on vggt_forward (168.3 → 149.8 ms), p95 also 11%, more consistent frame-to-frame. Per-step p50: 190.7 → 171.0 ms. Shipped as opt-in flag + `--compile` CLI. Wiki section appended to methods/l4-profiling.md. JSON: output/profiling/vggt_vs_cnn_20260420_120455.json.
+
 ## [2026-04-20] ingest | L4 Pipeline Profiling (VGGT vs CNN) | source: /plan Slice 3 (PRD #74)
 Full 2000/2000 diagnostic on H100. VGGT forward = 168.3 ms p50 — 90% of the VGGT-vs-CNN slowdown. PyTorch↔JAX boundary (vggt_wrapper + jax_upload) = 0.44 ms — disproves the original #72 motivation. KV-cache reset contract verified (9 resets, 9 boundaries). Recommendation: repurpose #72 away from JAX port toward torch.compile / frame-skip / distillation. Created methods/l4-profiling.md. JSON: output/profiling/vggt_vs_cnn_20260420_{102405,103840}.json.
 

--- a/docs/wiki/methods/l4-profiling.md
+++ b/docs/wiki/methods/l4-profiling.md
@@ -114,6 +114,35 @@ Rationale: the hypothesis motivating #72 was that the PyTorch↔JAX boundary cro
 
 Suggested next step: comment on #72 with this finding and rename it to *"VGGT forward acceleration (torch.compile, frame-skip, or distillation)"*. Start with `torch.compile` — one-line change, quickest to falsify. If it yields ≥20%, ship it. If not, move to frame-skip.
 
+## Update 2026-04-20 — `torch.compile` spike
+
+Tested the 1-day `torch.compile` lever recommended above. Applied via `VGGTFeatureExtractor(compile=True)` — wraps `model.aggregator` + `model.camera_head` with `dynamic=True` (KV cache grows each frame), and `model.point_head` statically. Same 2000/2000 L1-VGGT configuration. JSON: `output/profiling/vggt_vs_cnn_20260420_120455.json`.
+
+| Metric | Uncompiled | Compiled | Δ |
+|---|--:|--:|--:|
+| `vggt_forward` mean | 161.6 | 170.9 | +9.3 *(compile warmup in first N calls)* |
+| `vggt_forward` **p50** | **168.3** | **149.8** | **−18.5 ms (−11%)** |
+| `vggt_forward` p95 | 170.8 | 151.8 | −19.0 ms (−11%) |
+| `vggt_wrapper` p50 | 0.15 | 0.42 | +0.27 ms *(deferred-work artifact, irrelevant)* |
+| `wm_inference` p50 | 1.44 | 1.17 | −0.27 ms (noise) |
+| `wm_training` p50 | 35.76 | 34.09 | −1.67 ms (noise) |
+| KV-cache audit | 9=9 ✓ | 9=9 ✓ | unchanged |
+
+Per-step total (p50): **190.7 ms → 171.0 ms ≈ −10.3%** → projects ~1 M → 1.1 M steps in 48 h.
+
+### Interpretation
+
+- Real 11% speedup on the bottleneck, with the forward also becoming more consistent frame-to-frame (p95 essentially equals p50 after compile).
+- Mean vs p50 gap is expected: dynamo recompiles on new KV-cache shape buckets during warmup; steady-state matters.
+- Modest but cheap. Consistent with the mechanism argument: at this model size, both PyTorch and JAX call the same cuBLAS / FlashAttention kernels; framework-level speedup tops out around 10–30%.
+- PyTorch also printed a warning: `Consider setting torch.set_float32_matmul_precision('high')`. Not explored — possible further gain.
+
+### Action
+
+`compile` is shipped as an opt-in flag on `VGGTFeatureExtractor` (default `False` to keep dev runs warm-free). Enable in production L4 sbatch via `--compile`. Use as a stacking multiplier with upcoming frame-skip / FastVGGT work, which attacks *how often* the forward runs, orthogonal to how fast a single forward is.
+
+Updated recommendation for #72 repurpose order: **compile ✅ → frame-skip (next) → FastVGGT → distillation**.
+
 ## Caveats
 
 - `wm_training` mean vs p50 differ by 5× for both encoders — that's JIT-compile on the first call (visible as XLA `slow_operation_alarm` lines in stderr). Always use p50 / p95, not mean, for steady-state interpretation. Mean values in the JSON are informative for understanding the warmup tax but not representative of sustained throughput.

--- a/docs/wiki/methods/l4-profiling.md
+++ b/docs/wiki/methods/l4-profiling.md
@@ -1,0 +1,121 @@
+# L4 Pipeline Profiling (VGGT vs CNN)
+
+**Date**: 2026-04-20
+**Source PRD**: [#74](https://github.com/LSailer/Master-Thesis-3D-VLA/issues/74)
+**Script**: `modules/r2dreamer/scripts/profile_training.py`
+**Plan**: [`docs/plans/l4-profiling.md`](../../plans/l4-profiling.md)
+
+## Motivation
+
+L4 VGGT training was observed reaching only ~1M steps in 48h on H100, well below the CNN baseline. Before committing weeks to a VGGT→JAX port (#72), we instrumented the training loop with per-phase timers to identify which phase of the per-step pipeline is actually slow.
+
+## Hardware & Environment
+
+| Field | Value |
+|---|---|
+| Host | `uc3n074.localdomain` |
+| GPU | NVIDIA H100 (95 GB) |
+| Driver | 570.195.03 |
+| PyTorch | bf16 autocast, `torch.no_grad`, InfiniteVGGT / StreamVGGT checkpoint `lch01/StreamVGGT` |
+| JAX | XLA backend, async dispatch |
+
+## Run Configuration
+
+| Field | CNN | VGGT |
+|---|---|---|
+| Curriculum | `data/curriculum/level1_1house_1goal.json` | same |
+| `prefill_steps` | 2000 | 2000 |
+| `acting_steps` | 2000 | 2000 |
+| `render_resolution` | 64 | 518 |
+| Seed | 0 | 0 |
+| Total env steps | 4000 | 4000 |
+| Episodes | 8 | 8 |
+| JSON | `output/profiling/vggt_vs_cnn_20260420_102405.json` | `output/profiling/vggt_vs_cnn_20260420_103840.json` |
+
+## Results — Per-Phase Wall Time (milliseconds)
+
+Both p50 and p95 are shown; `p50` is the steady-state number after JIT warmup. `delta_ms` column uses p50.
+
+| Phase | CNN p50 | CNN p95 | VGGT p50 | VGGT p95 | delta_ms (p50) |
+|---|--:|--:|--:|--:|--:|
+| `env_step`      | 1.45   | 2.56   | 2.49   | 3.22   | +1.04 |
+| `vggt_forward`  | —      | —      | **168.32** | **170.83** | **+168.32** |
+| `vggt_wrapper`  | —      | —      | 0.15   | 0.16   | +0.15 |
+| `jax_upload`    | —      | —      | 0.29   | 0.40   | +0.29 |
+| `wm_inference`  | 1.52   | 1.69   | 1.44   | 1.63   | −0.08 |
+| `buffer_add`    | 0.02   | 0.03   | 0.04   | 0.05   | +0.02 |
+| `wm_training`   | 60.41  | 65.14  | 35.76  | 38.50  | −24.65 |
+
+### KV-cache audit
+
+| Encoder | `reset_count` | `boundary_count` | Status |
+|---|--:|--:|---|
+| CNN | 0 | 9 | N/A (no extractor.reset hook wired) |
+| VGGT | 9 | 9 | **PASS** — every `env.reset()` triggers `VGGTFeatureExtractor.reset()` |
+
+### Per-step totals (p50)
+
+Approximate steady-state wall clock per acting step (excluding amortized training):
+- **CNN**: env + wm_inference + buffer_add ≈ **3.0 ms** → ~330 steps/s peak
+- **VGGT**: env + vggt_forward + vggt_wrapper + jax_upload + wm_inference + buffer_add ≈ **172.7 ms** → ~5.8 steps/s peak
+
+Adding amortized train step (fires every ~2 acting steps at `train_ratio=512 / batch*seq=1024`):
+- **CNN**: 3.0 + 30.2 = **33.2 ms/step** → **~30 FPS**
+- **VGGT**: 172.7 + 17.9 = **190.6 ms/step** → **~5.2 FPS**
+
+5.2 FPS × 86 400 s × 2 d ≈ **900 k steps in 48 h** — matches the observed ~1 M from wandb run `87u0l6dy`.
+
+## Interpretation
+
+### Finding 1 — `vggt_forward` is ~100% of the VGGT slowdown
+
+- VGGT runs **5.8× slower per step than CNN**.
+- Of the `+187 ms/step` slowdown, **`vggt_forward` alone accounts for +168 ms (90%)**.
+- Every *other* VGGT-specific phase (`vggt_wrapper`, `jax_upload`) is under 0.5 ms combined — **less than 0.3% of the forward pass**.
+
+### Finding 2 — The PyTorch↔JAX boundary is effectively free
+
+- `vggt_wrapper` (pool + permute + `.cpu().numpy()` + flatten) = **0.15 ms p50**.
+- `jax_upload` (numpy → JAX GPU transfer) = **0.29 ms p50**.
+- Combined: **0.44 ms p50**, ~0.26% of the forward pass.
+
+Our original hypothesis — that `.cpu().numpy()` + JAX re-upload was a dominant cost — is **disproven by the data**. The H100's GPU↔CPU bandwidth is high enough, and the tensors small enough (37×37×3 float32 = ~16 KB), that the round trip is negligible.
+
+### Finding 3 — `wm_training` is actually *faster* for VGGT than CNN
+
+- VGGT `wm_training` p50 = 35.76 ms
+- CNN  `wm_training` p50 = 60.41 ms
+
+VGGT features (4116 floats) are *smaller* than CNN RGB batches (16×64×3×64×64 = 12 MB normalized) to the world model's encoder. So the world-model training step is actually lighter in the VGGT path. Encoder input size, not feature semantics, drives this.
+
+### Finding 4 — `wm_inference` is essentially identical
+
+- CNN p50 = 1.52 ms, VGGT p50 = 1.44 ms.
+- The world model's inference cost is dominated by the RSSM + actor, not the encoder. Encoder choice has sub-ms impact here.
+
+### Finding 5 — KV-cache reset contract is correctly wired
+
+9 episode boundaries → 9 VGGT cache resets. The `VGGTObsAdapter(extractor).on_episode_reset = extractor.reset` hook fires on every `env.reset()` — both the initial reset and every post-episode reset during curriculum scene switching. No bug.
+
+## Recommendation for PRD #72 (VGGT JAX port)
+
+**NO-GO as originally scoped.**
+
+Rationale: the hypothesis motivating #72 was that the PyTorch↔JAX boundary crossing dominated the per-step cost. The data shows it's 0.44 ms out of ~173 ms — structurally impossible for a JAX port to meaningfully change the bottom line. Even if a JAX port made `vggt_wrapper` and `jax_upload` literally zero, the per-step cost would drop from 190.6 → 190.2 ms. Not worth weeks of high-risk porting work.
+
+**Repurpose #72 instead.** The actionable paths for reducing `vggt_forward`, in increasing order of effort:
+
+| Option | Expected speedup | Effort | Risk |
+|---|---|---|---|
+| **`torch.compile(extractor.model)`** with mode=`reduce-overhead` | 10–30% | 1 day | low (try first) |
+| **Frame-skip**: run VGGT every *K* env steps, cache features between | 2×–4× at K=2–4 | 1 day | medium (quality) |
+| **Async pipeline**: VGGT in a separate process feeding features to the agent loop, agent runs one step behind with stale features | effective ~1× with quality | 1 week | medium (system complexity) |
+| **Distilled / pruned VGGT** (student model) | 2×–10× | weeks | high (requires training, quality validation) |
+
+Suggested next step: comment on #72 with this finding and rename it to *"VGGT forward acceleration (torch.compile, frame-skip, or distillation)"*. Start with `torch.compile` — one-line change, quickest to falsify. If it yields ≥20%, ship it. If not, move to frame-skip.
+
+## Caveats
+
+- `wm_training` mean vs p50 differ by 5× for both encoders — that's JIT-compile on the first call (visible as XLA `slow_operation_alarm` lines in stderr). Always use p50 / p95, not mean, for steady-state interpretation. Mean values in the JSON are informative for understanding the warmup tax but not representative of sustained throughput.
+- `jax_upload` is measured as a separate probe (`jnp.asarray(features).block_until_ready()`) immediately before `agent.act`. The actual upload inside `agent.act` may be deduplicated by JAX; the probe gives a faithful worst-case of "what a fresh upload of this tensor costs" on this hardware.
+- Both runs used the same L1 curriculum (`level1_1house_1goal.json`). A larger curriculum (L3/L4) would see more scene switches per unit time, which the profiling result scales linearly with — the per-step breakdown is insensitive to curriculum size.

--- a/modules/r2dreamer/scripts/profile_training.py
+++ b/modules/r2dreamer/scripts/profile_training.py
@@ -1,0 +1,444 @@
+"""Fine-grained phase-timing diagnostic for the R2-Dreamer training loop.
+
+Covers CNN and VGGT encoders back-to-back. Emits per-phase timing
+distributions (7 phases) + KV-cache audit for the VGGT path.
+See docs/plans/l4-profiling.md and issue #74.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from statistics import mean
+from typing import Any
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from modules.dreamerv3.configs import DreamerConfig
+from modules.dreamerv3.replay_buffer import BufferConfig, ReplayBuffer
+from modules.envs.habitat import HabitatObjectNavEnv
+from modules.r2dreamer.agent import R2DreamerAgent
+from modules.r2dreamer.config import R2DreamerConfig
+from modules.r2dreamer.trainer import ObsAdapter, convert_batch
+
+VGGT_FEATURE_DIM = 4116  # 37*37*3 + 9 — matches run_jax_habitat_vggt.py
+
+
+# 7-phase list locked in PRD #74.
+# Slice 1 populates only: env_step, wm_inference, buffer_add, wm_training.
+# Slice 2 adds: vggt_forward, vggt_wrapper, jax_upload.
+ALL_PHASES = (
+    "env_step",
+    "vggt_forward",
+    "vggt_wrapper",
+    "jax_upload",
+    "wm_inference",
+    "buffer_add",
+    "wm_training",
+)
+
+
+def init_phase_times() -> dict[str, list[float]]:
+    return {p: [] for p in ALL_PHASES}
+
+
+@contextmanager
+def timed(phase_times: dict[str, list[float]], phase: str):
+    """Wall-clock timer, records milliseconds.
+
+    agent.act returns a Python int (int() cast forces device->host sync) and
+    agent.train_step returns a dict of Python floats (same), so bracketing
+    them with perf_counter alone correctly captures execution time — no
+    explicit block_until_ready needed.
+    """
+    t0 = time.perf_counter()
+    yield
+    phase_times[phase].append((time.perf_counter() - t0) * 1000.0)
+
+
+@dataclass
+class RunResult:
+    encoder: str
+    phase_times: dict[str, list[float]]
+    kv_audit: dict[str, int]
+    episodes: dict[str, Any]
+    config: dict[str, Any]
+
+
+def _build_cnn(
+    seed: int, curriculum_path: str | None,
+) -> tuple[Any, Any, Any, ObsAdapter, R2DreamerConfig, Any]:
+    agent_cfg = R2DreamerConfig(
+        encoder_type="cnn",
+        obs_shape=(3, 64, 64),
+        num_actions=4,
+        batch_size=16,
+        seq_len=64,
+        buffer_capacity=100_000,
+        seed=seed,
+    )
+    hab_cfg = DreamerConfig(
+        obs_shape=(3, 64, 64),
+        max_episode_steps=500,
+        split="train",
+        reward_type="geodesic_delta",
+    )
+    env = HabitatObjectNavEnv(
+        hab_cfg,
+        curriculum_path=curriculum_path,
+        curriculum_mode="train",
+    )
+    buffer = ReplayBuffer(agent_cfg)
+    init_key = jax.random.PRNGKey(seed)
+    agent = R2DreamerAgent(agent_cfg, init_key)
+    obs_adapter = ObsAdapter()
+    return env, agent, buffer, obs_adapter, agent_cfg, None
+
+
+def _flatten_vggt(out: dict) -> np.ndarray:
+    """Concatenate VGGT output into a single (4116,) float32 feature vector.
+
+    Duplicated from run_jax_habitat_vggt.py to keep this script self-contained.
+    """
+    wp = out["world_points"].reshape(-1)  # (4107,)
+    cp = out["camera_pose"]                # (9,)
+    return np.concatenate([wp, cp]).astype(np.float32)
+
+
+def _build_vggt(
+    seed: int, curriculum_path: str | None, render_resolution: int,
+) -> tuple[Any, Any, Any, ObsAdapter, R2DreamerConfig, Any]:
+    """Construct env (518 res), agent (VGGT encoder), buffer (float32 features),
+    obs_adapter with on_episode_reset hook wired to extractor.reset, and the
+    raw VGGTFeatureExtractor (needed by the loop for instrumented extract calls).
+    """
+    from modules.vggt.feature_extractor import VGGTFeatureExtractor
+
+    agent_cfg = R2DreamerConfig(
+        encoder_type="vggt",
+        obs_shape=(VGGT_FEATURE_DIM,),
+        num_actions=4,
+        batch_size=16,
+        seq_len=64,
+        buffer_capacity=100_000,
+        seed=seed,
+    )
+    hab_cfg = DreamerConfig(
+        obs_shape=(3, render_resolution, render_resolution),
+        max_episode_steps=500,
+        split="train",
+        reward_type="geodesic_delta",
+    )
+    env = HabitatObjectNavEnv(
+        hab_cfg,
+        curriculum_path=curriculum_path,
+        curriculum_mode="train",
+    )
+    print("Loading InfiniteVGGT model...")
+    extractor = VGGTFeatureExtractor(device="cuda")
+    print("InfiniteVGGT loaded.")
+
+    # ObsAdapter wired so Trainer-style reset hook fires extractor.reset.
+    # transform() is NOT used — the loop inlines extract(..., phase_times=...).
+    obs_adapter = ObsAdapter(
+        buffer_dtype="float32",
+        buffer_shape=(VGGT_FEATURE_DIM,),
+        normalize_on_sample=False,
+        on_episode_reset=extractor.reset,
+    )
+    buffer = ReplayBuffer(BufferConfig(
+        capacity=agent_cfg.buffer_capacity,
+        obs_shape=(VGGT_FEATURE_DIM,),
+        obs_dtype="float32",
+        normalize_obs=False,
+    ))
+    init_key = jax.random.PRNGKey(seed)
+    agent = R2DreamerAgent(agent_cfg, init_key)
+    return env, agent, buffer, obs_adapter, agent_cfg, extractor
+
+
+def run_loop(
+    encoder: str,
+    prefill_steps: int,
+    acting_steps: int,
+    seed: int = 0,
+    curriculum_path: str | None = None,
+    render_resolution: int = 518,
+) -> RunResult:
+    if encoder == "cnn":
+        env, agent, buffer, obs_adapter, acfg, extractor = _build_cnn(
+            seed, curriculum_path,
+        )
+    elif encoder == "vggt":
+        env, agent, buffer, obs_adapter, acfg, extractor = _build_vggt(
+            seed, curriculum_path, render_resolution,
+        )
+    else:
+        raise ValueError(f"Unknown encoder: {encoder!r}")
+
+    phase_times = init_phase_times()
+    reset_count = 0
+    boundary_count = 0
+    total_steps = 0
+    total_reward = 0.0
+    episode_count = 0
+
+    rng_key = jax.random.PRNGKey(seed + 1)
+
+    def transform(obs_dict: dict) -> tuple[np.ndarray, dict]:
+        """Build (buffer_obs, agent_obs). For VGGT, time VGGT phases inline."""
+        if encoder != "vggt":
+            return obs_adapter.transform(obs_dict)
+
+        # VGGT path: extract() records vggt_forward + vggt_wrapper via kwarg.
+        # _flatten_vggt is tiny CPU work — fold into vggt_wrapper's last entry
+        # so vggt_wrapper represents the full "output → numpy feature" cost.
+        out = extractor.extract(obs_dict["image"], phase_times=phase_times)
+        t0 = time.perf_counter()
+        features = _flatten_vggt(out)
+        phase_times["vggt_wrapper"][-1] += (time.perf_counter() - t0) * 1000.0
+        agent_obs = {"features": features, "is_first": obs_dict.get("is_first", False)}
+        return features, agent_obs
+
+    def do_reset() -> tuple[dict, np.ndarray, dict]:
+        nonlocal reset_count, boundary_count
+        obs = env.reset()
+        boundary_count += 1
+        if obs_adapter.on_episode_reset is not None:
+            obs_adapter.on_episode_reset()
+            reset_count += 1
+        buffer_obs, agent_obs = transform(obs)
+        return obs, buffer_obs, agent_obs
+
+    def probe_jax_upload(features: np.ndarray) -> None:
+        """Measure numpy → JAX GPU transfer cost (proxy for what happens
+        inside agent.act for VGGT features). Only makes sense for VGGT."""
+        if encoder != "vggt":
+            return
+        with timed(phase_times, "jax_upload"):
+            probe = jnp.asarray(features[None])
+            probe.block_until_ready()
+
+    print(f"[{encoder}] Prefilling {prefill_steps} steps (random actions)...")
+    obs, buffer_obs, agent_obs = do_reset()
+    for _ in range(prefill_steps):
+        action = int(np.random.randint(0, acfg.num_actions))
+
+        with timed(phase_times, "env_step"):
+            next_obs = env.step(action)
+        next_buffer_obs, next_agent_obs = transform(next_obs)
+
+        with timed(phase_times, "buffer_add"):
+            buffer.add(
+                buffer_obs, action, next_obs["reward"],
+                next_obs["done"], terminal=(next_obs.get("success", 0.0) > 0),
+            )
+        total_steps += 1
+        total_reward += next_obs["reward"]
+
+        if next_obs["done"]:
+            episode_count += 1
+            obs, buffer_obs, agent_obs = do_reset()
+        else:
+            obs, buffer_obs, agent_obs = next_obs, next_buffer_obs, next_agent_obs
+
+    print(f"[{encoder}] Acting {acting_steps} steps with interleaved training...")
+    batch_steps = acfg.batch_size * acfg.seq_len
+    train_credit = 0.0
+    for _ in range(acting_steps):
+        rng_key, act_key = jax.random.split(rng_key)
+
+        # Probe the numpy→JAX upload cost (VGGT only; no-op for CNN).
+        if encoder == "vggt":
+            probe_jax_upload(buffer_obs)
+
+        with timed(phase_times, "wm_inference"):
+            action = agent.act(agent_obs, act_key)
+
+        with timed(phase_times, "env_step"):
+            next_obs = env.step(action)
+        next_buffer_obs, next_agent_obs = transform(next_obs)
+
+        with timed(phase_times, "buffer_add"):
+            buffer.add(
+                buffer_obs, action, next_obs["reward"],
+                next_obs["done"], terminal=(next_obs.get("success", 0.0) > 0),
+            )
+        total_steps += 1
+        total_reward += next_obs["reward"]
+
+        if next_obs["done"]:
+            episode_count += 1
+            obs, buffer_obs, agent_obs = do_reset()
+        else:
+            obs, buffer_obs, agent_obs = next_obs, next_buffer_obs, next_agent_obs
+
+        if buffer.size >= batch_steps:
+            train_credit += acfg.train_ratio / batch_steps
+            while train_credit >= 1.0:
+                rng_key, train_key = jax.random.split(rng_key)
+                with timed(phase_times, "wm_training"):
+                    batch = buffer.sample(acfg.batch_size, acfg.seq_len)
+                    batch = convert_batch(batch, acfg.num_actions)
+                    _ = agent.train_step(batch, train_key)
+                train_credit -= 1.0
+
+    env.close()
+
+    # KV-cache audit: for VGGT, the reset hook must fire exactly once per
+    # env.reset(). For CNN there is no hook so reset_count stays 0 — skip.
+    if encoder == "vggt":
+        assert reset_count == boundary_count, (
+            f"KV-cache audit FAILED: reset_count={reset_count} "
+            f"!= boundary_count={boundary_count}. Every env.reset() must "
+            f"trigger VGGTFeatureExtractor.reset()."
+        )
+
+    return RunResult(
+        encoder=encoder,
+        phase_times=phase_times,
+        kv_audit={"reset_count": reset_count, "boundary_count": boundary_count},
+        episodes={
+            "count": episode_count,
+            "total_steps": total_steps,
+            "avg_reward": total_reward / max(1, total_steps),
+        },
+        config={
+            "prefill_steps": prefill_steps,
+            "acting_steps": acting_steps,
+            "seed": seed,
+            "curriculum_path": curriculum_path,
+            "render_resolution": render_resolution if encoder == "vggt" else None,
+        },
+    )
+
+
+def _pct(values: list[float], p: float) -> float:
+    if not values:
+        return 0.0
+    s = sorted(values)
+    return s[min(len(s) - 1, int(p * len(s)))]
+
+
+def aggregate(result: RunResult) -> dict[str, dict[str, float]]:
+    out: dict[str, dict[str, float]] = {}
+    for phase, values in result.phase_times.items():
+        if values:
+            out[phase] = {
+                "mean_ms": mean(values),
+                "p50_ms": _pct(values, 0.50),
+                "p95_ms": _pct(values, 0.95),
+                "n_calls": float(len(values)),
+            }
+        else:
+            out[phase] = {"mean_ms": 0.0, "p50_ms": 0.0, "p95_ms": 0.0, "n_calls": 0.0}
+    return out
+
+
+def format_report(results_by_encoder: dict[str, RunResult]) -> str:
+    aggs = {enc: aggregate(r) for enc, r in results_by_encoder.items()}
+    has_cnn = "cnn" in aggs
+    has_vggt = "vggt" in aggs
+
+    header = ["phase"]
+    if has_cnn:
+        header += ["cnn_mean_ms", "cnn_p50_ms", "cnn_p95_ms"]
+    if has_vggt:
+        header += ["vggt_mean_ms", "vggt_p50_ms", "vggt_p95_ms"]
+    if has_cnn and has_vggt:
+        header.append("delta_ms")
+
+    col_w = 16
+    lines = [
+        " | ".join(f"{h:>{col_w}}" for h in header),
+        "-+-".join("-" * col_w for _ in header),
+    ]
+    for phase in ALL_PHASES:
+        row = [phase]
+        if has_cnn:
+            a = aggs["cnn"][phase]
+            row += [f"{a['mean_ms']:.3f}", f"{a['p50_ms']:.3f}", f"{a['p95_ms']:.3f}"]
+        if has_vggt:
+            a = aggs["vggt"][phase]
+            row += [f"{a['mean_ms']:.3f}", f"{a['p50_ms']:.3f}", f"{a['p95_ms']:.3f}"]
+        if has_cnn and has_vggt:
+            d = aggs["vggt"][phase]["mean_ms"] - aggs["cnn"][phase]["mean_ms"]
+            row.append(f"{d:+.3f}")
+        lines.append(" | ".join(f"{c:>{col_w}}" for c in row))
+
+    lines.append("")
+    for enc, r in results_by_encoder.items():
+        lines.append(
+            f"[{enc}] episodes={r.episodes['count']} "
+            f"total_steps={r.episodes['total_steps']} "
+            f"avg_reward={r.episodes['avg_reward']:.3f}"
+        )
+        lines.append(
+            f"[{enc}] kv_audit: reset_count={r.kv_audit['reset_count']} "
+            f"boundary_count={r.kv_audit['boundary_count']}"
+        )
+    return "\n".join(lines)
+
+
+def save_json(results_by_encoder: dict[str, RunResult], output_dir: Path) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    path = output_dir / f"vggt_vs_cnn_{ts}.json"
+    payload = {
+        enc: {
+            "phase_times": r.phase_times,
+            "aggregate": aggregate(r),
+            "kv_audit": r.kv_audit,
+            "episodes": r.episodes,
+            "config": r.config,
+        }
+        for enc, r in results_by_encoder.items()
+    }
+    with path.open("w") as f:
+        json.dump(payload, f, indent=2)
+    return path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="R2-Dreamer training-loop profiler")
+    parser.add_argument("--encoder", choices=("cnn", "vggt"), required=True)
+    parser.add_argument("--prefill_steps", type=int, default=2000)
+    parser.add_argument("--acting_steps", type=int, default=2000)
+    parser.add_argument("--output_dir", type=str, default="output/profiling")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--curriculum_path", type=str, default=None)
+    parser.add_argument(
+        "--render_resolution", type=int, default=518,
+        help="Habitat render resolution (VGGT only; ignored for CNN).",
+    )
+    args = parser.parse_args()
+
+    result = run_loop(
+        encoder=args.encoder,
+        prefill_steps=args.prefill_steps,
+        acting_steps=args.acting_steps,
+        seed=args.seed,
+        curriculum_path=args.curriculum_path,
+        render_resolution=args.render_resolution,
+    )
+
+    json_path = save_json({args.encoder: result}, Path(args.output_dir))
+    print()
+    print(format_report({args.encoder: result}))
+    print()
+    print(f"JSON saved to: {json_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/r2dreamer/scripts/profile_training.py
+++ b/modules/r2dreamer/scripts/profile_training.py
@@ -118,6 +118,7 @@ def _flatten_vggt(out: dict) -> np.ndarray:
 
 def _build_vggt(
     seed: int, curriculum_path: str | None, render_resolution: int,
+    compile: bool = False,
 ) -> tuple[Any, Any, Any, ObsAdapter, R2DreamerConfig, Any]:
     """Construct env (518 res), agent (VGGT encoder), buffer (float32 features),
     obs_adapter with on_episode_reset hook wired to extractor.reset, and the
@@ -145,8 +146,8 @@ def _build_vggt(
         curriculum_path=curriculum_path,
         curriculum_mode="train",
     )
-    print("Loading InfiniteVGGT model...")
-    extractor = VGGTFeatureExtractor(device="cuda")
+    print(f"Loading InfiniteVGGT model (compile={compile})...")
+    extractor = VGGTFeatureExtractor(device="cuda", compile=compile)
     print("InfiniteVGGT loaded.")
 
     # ObsAdapter wired so Trainer-style reset hook fires extractor.reset.
@@ -175,6 +176,7 @@ def run_loop(
     seed: int = 0,
     curriculum_path: str | None = None,
     render_resolution: int = 518,
+    compile: bool = False,
 ) -> RunResult:
     if encoder == "cnn":
         env, agent, buffer, obs_adapter, acfg, extractor = _build_cnn(
@@ -182,7 +184,7 @@ def run_loop(
         )
     elif encoder == "vggt":
         env, agent, buffer, obs_adapter, acfg, extractor = _build_vggt(
-            seed, curriculum_path, render_resolution,
+            seed, curriculum_path, render_resolution, compile=compile,
         )
     else:
         raise ValueError(f"Unknown encoder: {encoder!r}")
@@ -422,6 +424,10 @@ def main() -> None:
         "--render_resolution", type=int, default=518,
         help="Habitat render resolution (VGGT only; ignored for CNN).",
     )
+    parser.add_argument(
+        "--compile", action="store_true",
+        help="Apply torch.compile to VGGT sub-modules (VGGT only).",
+    )
     args = parser.parse_args()
 
     result = run_loop(
@@ -431,6 +437,7 @@ def main() -> None:
         seed=args.seed,
         curriculum_path=args.curriculum_path,
         render_resolution=args.render_resolution,
+        compile=args.compile,
     )
 
     json_path = save_json({args.encoder: result}, Path(args.output_dir))

--- a/modules/r2dreamer/scripts/run_jax_habitat_vggt.py
+++ b/modules/r2dreamer/scripts/run_jax_habitat_vggt.py
@@ -65,7 +65,14 @@ def main():
                         help="Path to pre-collected val .npz for val loss")
     parser.add_argument("--val_loss_every", type=int, default=10_000,
                         help="Compute val loss every N steps")
+    parser.add_argument("--resume_from", type=str, default=None,
+                        help="Path to a checkpoint .pkl to restore agent state from")
+    parser.add_argument("--wandb_id", type=str, default=None,
+                        help="W&B run-id to reattach to (resume='must')")
     args = parser.parse_args()
+
+    if args.resume_from is not None and not os.path.exists(args.resume_from):
+        sys.exit(f"--resume_from path does not exist: {args.resume_from}")
 
     # --- Config (VGGT encoder) ---
     config = R2DreamerConfig(
@@ -123,8 +130,10 @@ def main():
             wandb_project=args.wandb_project,
             wandb_name=args.wandb_name,
             wandb_tags=tags,
+            wandb_id=args.wandb_id,
             val_data=args.val_data,
             val_loss_every=args.val_loss_every,
+            resume_from=args.resume_from,
         ),
         obs_adapter=VGGTObsAdapter(extractor),
         episode_metrics_fn=hab["episode_metrics_fn"],

--- a/modules/r2dreamer/scripts/slurm/train_curriculum_l1_rerun.sbatch
+++ b/modules/r2dreamer/scripts/slurm/train_curriculum_l1_rerun.sbatch
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --job-name=r2d-L1-rerun-spl
+#SBATCH --job-name=r2d-L1-rerun-buffix
 #SBATCH --partition=gpu_h100
 #SBATCH --gres=gpu:1
 #SBATCH --ntasks=1
@@ -20,9 +20,10 @@ if [ ! -f data/curriculum/level1_1house_1goal.json ]; then
     uv run python modules/envs/scripts/generate_curriculum.py
 fi
 
-# Level 1 re-run: same config as L1 but with enhanced SPL logging
-# 1 house (fK2vEV32Lag), chair only, 7499 train episodes
-# 2.4M steps, single scene = focused learning
+# Level 1 re-run with buffer bug fixes:
+# - write-head crossing fix (no corrupted sequences after buffer wraps)
+# - ema_state checkpoint fix (return normalization preserved on resume)
+# Same config as original L1 baseline (2.4M steps, 1 house, chair only)
 uv run python modules/r2dreamer/scripts/run_jax_habitat.py \
     --steps 2400000 \
     --prefill 5000 \
@@ -31,8 +32,8 @@ uv run python modules/r2dreamer/scripts/run_jax_habitat.py \
     --seed "${SLURM_JOB_ID}" \
     --log_every 250 \
     --wandb_project 3d-vla-objectnav \
-    --wandb_name "r2d-L1-rerun-spl-${SLURM_JOB_ID}" \
-    --wandb_tags "curriculum,level1,1house,chair-only,spl-analysis,rerun" \
+    --wandb_name "r2d-L1-buffix-${SLURM_JOB_ID}" \
+    --wandb_tags "curriculum,level1,1house,chair-only,buffer-fix,rerun" \
     --curriculum_path data/curriculum/level1_1house_1goal.json \
     --curriculum_mode train \
     --val_data data/val_replay/val_200ep.npz \

--- a/modules/r2dreamer/scripts/slurm/train_curriculum_l1_vggt.sbatch
+++ b/modules/r2dreamer/scripts/slurm/train_curriculum_l1_vggt.sbatch
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --job-name=r2d-L1-vggt
+#SBATCH --job-name=r2d-L1-vggt-buffix
 #SBATCH --partition=gpu_h100
 #SBATCH --gres=gpu:1
 #SBATCH --ntasks=1
@@ -31,8 +31,8 @@ uv run python modules/r2dreamer/scripts/run_jax_habitat_vggt.py \
     --seed "${SLURM_JOB_ID}" \
     --log_every 250 \
     --wandb_project 3d-vla-objectnav \
-    --wandb_name "r2d-L1-vggt-${SLURM_JOB_ID}" \
-    --wandb_tags "curriculum,level1,1house,chair-only,vggt,3d-encoder" \
+    --wandb_name "r2d-L1-vggt-buffix-${SLURM_JOB_ID}" \
+    --wandb_tags "curriculum,level1,1house,chair-only,vggt,3d-encoder,buffer-fix,rerun" \
     --curriculum_path data/curriculum/level1_1house_1goal.json \
     --curriculum_mode train \
     --render_resolution 518

--- a/modules/r2dreamer/scripts/slurm/train_curriculum_l1_vggt_resume.sbatch
+++ b/modules/r2dreamer/scripts/slurm/train_curriculum_l1_vggt_resume.sbatch
@@ -1,0 +1,46 @@
+#!/bin/bash
+#SBATCH --job-name=r2d-L1-vggt-resume
+#SBATCH --partition=gpu_h100
+#SBATCH --gres=gpu:1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=64G
+#SBATCH --time=36:00:00
+#SBATCH --output=output/r2dreamer-curriculum-l1-vggt/slurm-%j.out
+#SBATCH --error=output/r2dreamer-curriculum-l1-vggt/slurm-%j.err
+
+mkdir -p output/r2dreamer-curriculum-l1-vggt
+
+echo "Job $SLURM_JOB_ID on $(hostname) at $(date)"
+echo "GPU: $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || echo 'N/A')"
+
+# Resume L1 VGGT run 87u0l6dy from step 900_000 to 2_400_000.
+# - Reuses run-3957756 logdir → checkpoints land alongside step_000{100..900}000.pkl
+#   and metrics.csv is appended (not clobbered).
+# - --wandb_id 87u0l6dy + resume="must" reattaches to the same W&B run; the
+#   chart continues without a split. Fails loudly if the id is wrong.
+# - Skips the random prefill: trained policy refills the buffer until it
+#   contains >= batch_size*seq_len transitions, then training resumes.
+RESUME_RUN_DIR="output/r2dreamer-curriculum-l1-vggt/run-3957756"
+RESUME_CKPT="${RESUME_RUN_DIR}/checkpoints/step_000900000.pkl"
+
+if [ ! -f "${RESUME_CKPT}" ]; then
+    echo "ERROR: resume checkpoint missing: ${RESUME_CKPT}" >&2
+    exit 1
+fi
+
+uv run python modules/r2dreamer/scripts/run_jax_habitat_vggt.py \
+    --steps 2400000 \
+    --prefill 5000 \
+    --checkpoint_every 100000 \
+    --output_dir "${RESUME_RUN_DIR}" \
+    --seed "${SLURM_JOB_ID}" \
+    --log_every 250 \
+    --wandb_project 3d-vla-objectnav \
+    --wandb_name "r2d-L1-vggt-resume-${SLURM_JOB_ID}" \
+    --wandb_tags "curriculum,level1,1house,chair-only,vggt,3d-encoder,resume-from-900k" \
+    --wandb_id 87u0l6dy \
+    --resume_from "${RESUME_CKPT}" \
+    --curriculum_path data/curriculum/level1_1house_1goal.json \
+    --curriculum_mode train \
+    --render_resolution 518

--- a/modules/r2dreamer/scripts/slurm/train_curriculum_l1_vggt_resume_smoke.sbatch
+++ b/modules/r2dreamer/scripts/slurm/train_curriculum_l1_vggt_resume_smoke.sbatch
@@ -1,0 +1,55 @@
+#!/bin/bash
+#SBATCH --job-name=r2d-L1-vggt-resume-smoke
+#SBATCH --partition=dev_gpu_h100
+#SBATCH --gres=gpu:1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=64G
+#SBATCH --time=00:30:00
+#SBATCH --output=output/r2dreamer-curriculum-l1-vggt/slurm-smoke-%j.out
+#SBATCH --error=output/r2dreamer-curriculum-l1-vggt/slurm-smoke-%j.err
+
+mkdir -p output/r2dreamer-curriculum-l1-vggt
+
+echo "Job $SLURM_JOB_ID on $(hostname) at $(date)"
+echo "GPU: $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || echo 'N/A')"
+
+# Smoke test for the resume mechanism: 5_000 steps past step 900_000.
+# - Throwaway --output_dir → does NOT touch run-3957756/metrics.csv or its
+#   checkpoint dir.
+# - WANDB_MODE=disabled → does NOT pollute the real W&B run 87u0l6dy with
+#   smoke data (the wandb_id="must" resume path is therefore NOT exercised
+#   here; that path is small and exercised by review + the unit test that
+#   passes wandb_project=None).
+# - On success the smoke logdir contains:
+#     metrics.csv (header-less because resume_step > 0, with rows at step >= 900k)
+#     checkpoints/step_000905000.pkl (the run()-final save)
+# - Goal: confirm Trainer.__init__ loads agent state, _train_loop offsets to
+#   step 900_000, and CSV append-mode write succeeds end-to-end on real GPU.
+RESUME_RUN_DIR="output/r2dreamer-curriculum-l1-vggt/run-3957756"
+RESUME_CKPT="${RESUME_RUN_DIR}/checkpoints/step_000900000.pkl"
+SMOKE_DIR="output/r2dreamer-curriculum-l1-vggt/smoke-${SLURM_JOB_ID}"
+
+if [ ! -f "${RESUME_CKPT}" ]; then
+    echo "ERROR: resume checkpoint missing: ${RESUME_CKPT}" >&2
+    exit 1
+fi
+
+export WANDB_MODE=disabled
+
+uv run python modules/r2dreamer/scripts/run_jax_habitat_vggt.py \
+    --steps 905000 \
+    --prefill 5000 \
+    --checkpoint_every 100000 \
+    --output_dir "${SMOKE_DIR}" \
+    --seed "${SLURM_JOB_ID}" \
+    --log_every 250 \
+    --wandb_project 3d-vla-objectnav \
+    --wandb_name "r2d-L1-vggt-resume-smoke-${SLURM_JOB_ID}" \
+    --wandb_tags "smoke,resume-test" \
+    --resume_from "${RESUME_CKPT}" \
+    --curriculum_path data/curriculum/level1_1house_1goal.json \
+    --curriculum_mode train \
+    --render_resolution 518
+
+echo "Smoke complete. Inspect ${SMOKE_DIR}/metrics.csv and ${SMOKE_DIR}/checkpoints/"

--- a/modules/r2dreamer/scripts/slurm/train_curriculum_l2.sbatch
+++ b/modules/r2dreamer/scripts/slurm/train_curriculum_l2.sbatch
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --job-name=r2d-L2-1house-6goals
+#SBATCH --job-name=r2d-L2-buffix
 #SBATCH --partition=gpu_h100
 #SBATCH --gres=gpu:1
 #SBATCH --ntasks=1
@@ -30,8 +30,8 @@ uv run python modules/r2dreamer/scripts/run_jax_habitat.py \
     --seed "${SLURM_JOB_ID}" \
     --log_every 250 \
     --wandb_project 3d-vla-objectnav \
-    --wandb_name "r2d-L2-1house-6goals-${SLURM_JOB_ID}" \
-    --wandb_tags "curriculum,level2,1house,6goals" \
+    --wandb_name "r2d-L2-buffix-${SLURM_JOB_ID}" \
+    --wandb_tags "curriculum,level2,1house,6goals,buffer-fix,rerun" \
     --curriculum_path data/curriculum/level2_1house_6goals.json \
     --curriculum_mode train \
     --val_data data/val_replay/val_200ep.npz \

--- a/modules/r2dreamer/scripts/slurm/train_curriculum_l3.sbatch
+++ b/modules/r2dreamer/scripts/slurm/train_curriculum_l3.sbatch
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH --job-name=r2d-L3-10houses-chair
+#SBATCH --job-name=r2d-L3-buffix
 #SBATCH --partition=gpu_h100
 #SBATCH --gres=gpu:1
 #SBATCH --ntasks=1
@@ -30,8 +30,8 @@ uv run python modules/r2dreamer/scripts/run_jax_habitat.py \
     --seed "${SLURM_JOB_ID}" \
     --log_every 250 \
     --wandb_project 3d-vla-objectnav \
-    --wandb_name "r2d-L3-10houses-chair-${SLURM_JOB_ID}" \
-    --wandb_tags "curriculum,level3,10houses,chair-only" \
+    --wandb_name "r2d-L3-buffix-${SLURM_JOB_ID}" \
+    --wandb_tags "curriculum,level3,10houses,chair-only,buffer-fix,rerun" \
     --curriculum_path data/curriculum/level3_10houses_1goal.json \
     --curriculum_mode train \
     --val_data data/val_replay/val_200ep.npz \

--- a/modules/r2dreamer/scripts/slurm/train_curriculum_l4.sbatch
+++ b/modules/r2dreamer/scripts/slurm/train_curriculum_l4.sbatch
@@ -1,0 +1,38 @@
+#!/bin/bash
+#SBATCH --job-name=r2d-L4-buffix
+#SBATCH --partition=gpu_h100
+#SBATCH --gres=gpu:1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=64G
+#SBATCH --time=24:00:00
+#SBATCH --output=output/r2dreamer-curriculum-l4/slurm-%j.out
+#SBATCH --error=output/r2dreamer-curriculum-l4/slurm-%j.err
+
+mkdir -p output/r2dreamer-curriculum-l4
+
+echo "Job $SLURM_JOB_ID on $(hostname) at $(date)"
+echo "GPU: $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || echo 'N/A')"
+
+# Generate curriculum configs if not present
+if [ ! -f data/curriculum/level4_10houses_6goals.json ]; then
+    echo "Generating curriculum configs..."
+    uv run python modules/envs/scripts/generate_curriculum.py
+fi
+
+# Level 4: 10 houses (4 easy, 4 medium, 2 hard) x 6 goal categories
+# 2.4M steps, full curriculum — combines multi-scene (L3) + multi-goal (L2) generalization
+uv run python modules/r2dreamer/scripts/run_jax_habitat.py \
+    --steps 2400000 \
+    --prefill 5000 \
+    --checkpoint_every 100000 \
+    --output_dir "output/r2dreamer-curriculum-l4/run-${SLURM_JOB_ID}" \
+    --seed "${SLURM_JOB_ID}" \
+    --log_every 250 \
+    --wandb_project 3d-vla-objectnav \
+    --wandb_name "r2d-L4-buffix-${SLURM_JOB_ID}" \
+    --wandb_tags "curriculum,level4,10houses,6goals,buffer-fix,rerun" \
+    --curriculum_path data/curriculum/level4_10houses_6goals.json \
+    --curriculum_mode train \
+    --val_data data/val_replay/val_200ep.npz \
+    --val_loss_every 10000

--- a/modules/r2dreamer/tests/test_trainer.py
+++ b/modules/r2dreamer/tests/test_trainer.py
@@ -10,7 +10,31 @@ import pytest
 
 from modules.r2dreamer.config import R2DreamerConfig
 from modules.r2dreamer.agent import R2DreamerAgent
-from modules.r2dreamer.trainer import convert_batch, save_checkpoint, load_checkpoint
+from modules.r2dreamer.trainer import (
+    Trainer,
+    TrainerConfig,
+    convert_batch,
+    load_checkpoint,
+    save_checkpoint,
+)
+
+
+class _DummyEnv:
+    """Minimal env stub — Trainer.__init__ does not call any of these methods."""
+
+    def reset(self) -> dict:
+        return {"image": np.zeros((3, 64, 64), dtype=np.uint8), "is_first": True}
+
+    def step(self, action: int) -> dict:
+        return {
+            "image": np.zeros((3, 64, 64), dtype=np.uint8),
+            "reward": 0.0,
+            "done": False,
+            "success": 0.0,
+        }
+
+    def close(self) -> None:
+        pass
 
 
 class TestConvertBatch:
@@ -102,4 +126,75 @@ class TestCheckpoint:
             jax.tree.map(
                 lambda a, b: np.testing.assert_allclose(a, b, atol=1e-6),
                 agent.slow_critic_params, data["slow_critic_params"],
+            )
+
+
+class TestResume:
+    """Trainer with resume_from restores agent state and offsets the step counter."""
+
+    @pytest.fixture
+    def cfg(self):
+        return R2DreamerConfig(obs_shape=(3, 64, 64), num_actions=4)
+
+    @pytest.fixture
+    def saved_agent(self, cfg, tmp_path):
+        """Build an agent, save its checkpoint, return (agent, ckpt_path, step)."""
+        agent = R2DreamerAgent(cfg, jax.random.PRNGKey(0))
+        step = 12345
+        ckpt_path = save_checkpoint(agent, step=step, output_dir=str(tmp_path))
+        return agent, ckpt_path, step
+
+    def test_resume_restores_params_and_step(self, cfg, saved_agent, tmp_path):
+        original, ckpt_path, step = saved_agent
+
+        # Build a fresh agent with a different init seed so its weights differ.
+        fresh = R2DreamerAgent(cfg, jax.random.PRNGKey(99))
+        before = [np.asarray(x) for x in jax.tree.leaves(fresh.params)]
+        target = [np.asarray(x) for x in jax.tree.leaves(original.params)]
+        assert not all(np.allclose(a, b) for a, b in zip(before, target))
+
+        tcfg = TrainerConfig(
+            output_dir=str(tmp_path / "logdir"),
+            total_steps=step + 1,
+            wandb_project=None,
+            resume_from=ckpt_path,
+        )
+        trainer = Trainer(
+            agent=fresh, env=_DummyEnv(), agent_config=cfg, trainer_config=tcfg,
+        )
+
+        assert trainer._resume_step == step
+        after_params = [np.asarray(x) for x in jax.tree.leaves(fresh.params)]
+        for a, b in zip(after_params, target):
+            np.testing.assert_allclose(a, b, atol=1e-6)
+        for a, b in zip(jax.tree.leaves(fresh.slow_critic_params),
+                        jax.tree.leaves(original.slow_critic_params)):
+            np.testing.assert_allclose(np.asarray(a), np.asarray(b), atol=1e-6)
+        np.testing.assert_allclose(
+            np.asarray(fresh.ema_state), np.asarray(original.ema_state), atol=1e-6,
+        )
+
+    def test_no_resume_keeps_step_zero(self, cfg, tmp_path):
+        agent = R2DreamerAgent(cfg, jax.random.PRNGKey(7))
+        tcfg = TrainerConfig(
+            output_dir=str(tmp_path / "logdir"),
+            total_steps=1,
+            wandb_project=None,
+        )
+        trainer = Trainer(
+            agent=agent, env=_DummyEnv(), agent_config=cfg, trainer_config=tcfg,
+        )
+        assert trainer._resume_step == 0
+
+    def test_missing_resume_path_raises(self, cfg, tmp_path):
+        agent = R2DreamerAgent(cfg, jax.random.PRNGKey(7))
+        tcfg = TrainerConfig(
+            output_dir=str(tmp_path / "logdir"),
+            total_steps=1,
+            wandb_project=None,
+            resume_from=str(tmp_path / "nope.pkl"),
+        )
+        with pytest.raises(FileNotFoundError):
+            Trainer(
+                agent=agent, env=_DummyEnv(), agent_config=cfg, trainer_config=tcfg,
             )

--- a/modules/r2dreamer/trainer.py
+++ b/modules/r2dreamer/trainer.py
@@ -123,10 +123,17 @@ class TrainerConfig:
     wandb_project: str | None = "3d-vla-objectnav"
     wandb_name: str | None = None
     wandb_tags: list[str] = field(default_factory=lambda: ["r2dreamer"])
+    # Resume an existing W&B run (e.g. "87u0l6dy"). Requires the run to exist.
+    wandb_id: str | None = None
 
     # Validation (None = disabled)
     val_data: str | None = None
     val_loss_every: int = 10_000
+
+    # Resume from checkpoint (.pkl produced by save_checkpoint). When set,
+    # restores agent.{params, opt_state, slow_critic_params, ema_state} and
+    # offsets the train loop to start at the checkpoint's step.
+    resume_from: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -221,17 +228,42 @@ class Trainer:
             normalize_obs=self.obs_adapter.normalize_on_sample,
         ))
 
+        # Resume from checkpoint (overwrite freshly-initialised agent state).
+        self._resume_step = 0
+        if trainer_config.resume_from is not None:
+            if not os.path.exists(trainer_config.resume_from):
+                raise FileNotFoundError(
+                    f"resume_from points at non-existent path: {trainer_config.resume_from}"
+                )
+            state = load_checkpoint(trainer_config.resume_from)
+            self.agent.params = jax.tree.map(jnp.asarray, state["params"])
+            self.agent.opt_state = jax.tree.map(jnp.asarray, state["opt_state"])
+            self.agent.slow_critic_params = jax.tree.map(
+                jnp.asarray, state["slow_critic_params"]
+            )
+            self.agent.ema_state = jax.tree.map(jnp.asarray, state["ema_state"])
+            self._resume_step = int(state["step"])
+            print(
+                f"Resumed agent state from {trainer_config.resume_from} "
+                f"at step {self._resume_step}"
+            )
+
         # Optional WandB
         self._wandb = None
         if trainer_config.wandb_project is not None:
             import wandb
             self._wandb = wandb
-            wandb.init(
+            init_kwargs: dict[str, Any] = dict(
                 project=trainer_config.wandb_project,
                 name=trainer_config.wandb_name,
                 config=vars(agent_config) if hasattr(agent_config, "__dict__") else {},
                 tags=trainer_config.wandb_tags,
             )
+            if trainer_config.wandb_id is not None:
+                # resume="must" fails loudly if the run-id does not exist,
+                # which is what we want — silent re-creation orphans runs.
+                init_kwargs.update(id=trainer_config.wandb_id, resume="must")
+            wandb.init(**init_kwargs)
 
         # Optional val dataset
         self._val_dataset = None
@@ -251,11 +283,21 @@ class Trainer:
 
         rng_key = jax.random.PRNGKey(tcfg.seed)
 
-        with open(csv_path, "w", newline="") as f:
+        # Append to existing CSV when resuming so the prior rows survive.
+        is_resume = self._resume_step > 0
+        csv_mode = "a" if is_resume else "w"
+        with open(csv_path, csv_mode, newline="") as f:
             writer = csv.writer(f)
-            writer.writerow(["step", "metric", "value"])
+            if not is_resume:
+                writer.writerow(["step", "metric", "value"])
 
-            self._prefill(rng_key, writer, f)
+            if is_resume:
+                # Skip random prefill — the trained policy collects on-policy
+                # transitions in _train_loop until buffer >= batch_steps.
+                # env.reset() / extractor.reset() fire at _train_loop entry.
+                print(f"Resume mode: skipping prefill, jumping to step {self._resume_step}")
+            else:
+                self._prefill(rng_key, writer, f)
             rng_key = self._train_loop(rng_key, writer, f)
 
         save_checkpoint(self.agent, tcfg.total_steps, tcfg.output_dir)
@@ -302,7 +344,8 @@ class Trainer:
     def _train_loop(self, rng_key: jnp.ndarray, writer: Any, f: Any) -> jnp.ndarray:
         acfg, tcfg = self.acfg, self.tcfg
 
-        print(f"Training for {tcfg.total_steps} steps...")
+        start_step = self._resume_step
+        print(f"Training from step {start_step} to {tcfg.total_steps}...")
         obs = self.env.reset()
         if self.obs_adapter.on_episode_reset:
             self.obs_adapter.on_episode_reset()
@@ -317,7 +360,7 @@ class Trainer:
         train_credit = 0.0
         metrics: dict[str, Any] = {}
 
-        for step in range(tcfg.total_steps):
+        for step in range(start_step, tcfg.total_steps):
             rng_key, act_key = jax.random.split(rng_key)
             action = self.agent.act(agent_obs, act_key)
             next_obs = self.env.step(action)
@@ -415,7 +458,8 @@ class Trainer:
             self._wandb.log(metrics, step=step)
 
         elapsed = time.time() - self._t0
-        fps = (step + 1) / elapsed if elapsed > 0 else 0
+        steps_this_run = step + 1 - self._resume_step
+        fps = steps_this_run / elapsed if elapsed > 0 else 0
         print(
             f"[step {step:>8d}/{self.tcfg.total_steps}] "
             f"total={metrics.get('total_loss', 0):.3f} "

--- a/modules/vggt/autoresearch/bench_fast.py
+++ b/modules/vggt/autoresearch/bench_fast.py
@@ -1,0 +1,149 @@
+"""Fitness command for the JAX VGGT autoresearch loop: cached PT baseline vs fresh JAX timing."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+
+
+SEQ_LEN = 50
+WARMUP_FRAMES = 3
+TIMED_FRAMES = 20
+CACHE_PATH = Path(__file__).parent / ".pt_baseline.json"
+
+
+def _make_frame(seed: int, size: int = 518) -> np.ndarray:
+    rng = np.random.RandomState(seed)
+    return rng.randint(0, 256, size=(3, size, size), dtype=np.uint8)
+
+
+def bench_pytorch() -> dict:
+    import torch
+
+    from modules.vggt.feature_extractor import VGGTFeatureExtractor
+
+    ext = VGGTFeatureExtractor(device="cuda")
+
+    ext.reset()
+    for i in range(WARMUP_FRAMES):
+        ext.extract(_make_frame(i))
+    torch.cuda.synchronize()
+
+    ext.reset()
+    torch.cuda.reset_peak_memory_stats()
+    latencies = []
+    for i in range(TIMED_FRAMES):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        ext.extract(_make_frame(1000 + i))
+        torch.cuda.synchronize()
+        latencies.append((time.perf_counter() - t0) * 1000.0)
+    peak_mem = torch.cuda.max_memory_allocated() / 1e6
+
+    del ext
+    gc.collect()
+    torch.cuda.empty_cache()
+
+    return {
+        "median_ms": float(np.median(latencies)),
+        "mean_ms": float(np.mean(latencies)),
+        "peak_mem_mb": peak_mem,
+    }
+
+
+def bench_jax() -> dict:
+    import jax
+
+    jax.config.update("jax_default_matmul_precision", "highest")
+    from modules.vggt.jax import JAXVGGTFeatureExtractor
+
+    ext = JAXVGGTFeatureExtractor(device="cuda")
+
+    ext.reset()
+    for i in range(WARMUP_FRAMES):
+        out = ext.extract(_make_frame(i))
+        _ = np.asarray(out["world_points"])
+
+    ext.reset()
+    latencies = []
+    for i in range(TIMED_FRAMES):
+        t0 = time.perf_counter()
+        out = ext.extract(_make_frame(1000 + i))
+        _ = np.asarray(out["world_points"])  # force device sync
+        latencies.append((time.perf_counter() - t0) * 1000.0)
+
+    del ext
+    gc.collect()
+
+    return {
+        "median_ms": float(np.median(latencies)),
+        "mean_ms": float(np.mean(latencies)),
+        "peak_mem_mb": 0.0,
+    }
+
+
+def save_baseline(stats: dict) -> None:
+    payload = {
+        "pt_baseline_ms": stats["median_ms"],
+        "pt_mean_ms": stats["mean_ms"],
+        "peak_mem_mb": stats["peak_mem_mb"],
+        "seq_len": SEQ_LEN,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    CACHE_PATH.write_text(json.dumps(payload, indent=2))
+
+
+def load_baseline() -> dict:
+    if not CACHE_PATH.exists():
+        raise FileNotFoundError(str(CACHE_PATH))
+    return json.loads(CACHE_PATH.read_text())
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--setup",
+        action="store_true",
+        help="Time PyTorch once and cache the result, then exit.",
+    )
+    args = p.parse_args()
+
+    if args.setup:
+        stats = bench_pytorch()
+        save_baseline(stats)
+        print(f"pt_baseline_ms: {stats['median_ms']:.2f}")
+        print(f"pt_mean_ms:     {stats['mean_ms']:.2f}")
+        print(f"peak_mem_mb:    {stats['peak_mem_mb']:.1f}")
+        print(f"cached_to:      {CACHE_PATH.resolve()}")
+        return 0
+
+    try:
+        baseline = load_baseline()
+    except FileNotFoundError:
+        print(
+            "ERROR: .pt_baseline.json not found. Run with --setup first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    jax_stats = bench_jax()
+    pt_baseline_ms = float(baseline["pt_baseline_ms"])
+    speedup = pt_baseline_ms / jax_stats["median_ms"]
+
+    print(f"jax_median_ms:  {jax_stats['median_ms']:.2f}")
+    print(f"jax_mean_ms:    {jax_stats['mean_ms']:.2f}")
+    print(f"pt_baseline_ms: {pt_baseline_ms:.2f}")
+    print(f"speedup:        {speedup:.3f}")
+    print(f"peak_mem_mb:    {jax_stats['peak_mem_mb']:.1f}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/modules/vggt/autoresearch/program.md
+++ b/modules/vggt/autoresearch/program.md
@@ -1,0 +1,178 @@
+# autoresearch: JAX VGGT forward-pass speedup
+
+This is an experiment to have the LLM optimize the JAX port of VGGT for forward-pass throughput.
+
+## Setup
+
+To set up a new experiment, work with the user to:
+
+1. **Agree on a run tag**: propose a tag based on today's date, lowercase abbreviated (e.g. `apr23`, `may07`). The branch `autoresearch/vggt-jax-<tag>` must not already exist — this is a fresh run.
+2. **Create the branch**: `git checkout -b autoresearch/vggt-jax-<tag>` off `feat/vggt-jax-port` (NOT main).
+3. **Verify the HF checkpoint cache**: check that `/tmp/vggt_test_cache` exists. If not, tell the human to run the parity tests once manually — that populates the cache.
+4. **Cache the PyTorch baseline**: run `uv run python -m modules.vggt.autoresearch.bench_fast --setup` ONCE. This caches the PyTorch baseline timing so every iteration measures only JAX.
+5. **Initialize results.tsv**: create `modules/vggt/autoresearch/results.tsv` with this tab-separated header (8 columns):
+   ```
+   commit	jax_ms	pt_ms	speedup	parity_maxabs	peak_mem_gb	status	description
+   ```
+6. **Confirm and go**: confirm setup looks good.
+
+Once you get confirmation, kick off the experimentation.
+
+## Experimentation
+
+Each experiment runs on a single GPU. The fitness metric is `speedup = pt_baseline_ms / jax_median_ms` at n=50 frames. Higher speedup is better. Target: speedup >= 1.0 means JAX beats the PyTorch baseline. You launch a run simply as: `uv run python -m modules.vggt.autoresearch.bench_fast`.
+
+**What you CAN do — modify exactly these 6 files:**
+- `modules/vggt/jax/attention.py`
+- `modules/vggt/jax/block.py`
+- `modules/vggt/jax/aggregator.py`
+- `modules/vggt/jax/backbone.py`
+- `modules/vggt/jax/rope.py`
+- `modules/vggt/jax/feature_extractor.py`
+
+Everything inside those files is fair game: kernels, layouts, dtypes, fusion, sharding, compile flags, attention implementations, rope formulation, scan vs unroll, etc.
+
+**What you CANNOT do:**
+- Modify `modules/vggt/jax/weight_transfer.py`. Changing this breaks parity silently — the weight-loading invariant must be untouchable.
+- Modify anything under `modules/vggt/tests/`. The parity tests are the referee; they cannot rewrite the rules they are graded by.
+- Modify `modules/vggt/jax/benchmark_streaming.py`. It defines the metric for guardrail sweeps.
+- Modify `modules/vggt/autoresearch/bench_fast.py`. It defines the fitness metric.
+- Modify `modules/vggt/autoresearch/program.md` (this file).
+- Relax `jax_default_matmul_precision='highest'` in the parity test. That is the correctness invariant.
+- Add packages, edit `pyproject.toml`, or install anything. You use only what is already installed.
+
+**The goal is simple: maximize `speedup` at n=50 frames while keeping parity green.** Peak memory is a soft constraint — some increase is acceptable for meaningful speedup, but it should not blow up dramatically.
+
+**Simplicity criterion**: All else being equal, simpler is better. A small improvement that adds ugly complexity is not worth it. Conversely, removing something and getting equal or better results is a great outcome — that's a simplification win. When evaluating whether to keep a change, weigh the complexity cost against the improvement magnitude. A 0.001 speedup improvement that adds 20 lines of hacky code? Probably not worth it. A 0.001 speedup improvement from deleting code? Definitely keep. An improvement of ~0 but much simpler code? Keep.
+
+**The first run**: your first run establishes the baseline. No code changes. Just run `bench_fast` and record row 1 with `status=baseline` and description `eager fp32 baseline (Step 8 HEAD)`. If `smoke.sbatch` already wrote that baseline row, skip this and start with a real experimental change.
+
+## Output format
+
+Once `bench_fast` finishes it prints a summary. Extract the key lines:
+
+```
+grep "^speedup:\|^jax_median_ms:\|^pt_baseline_ms:\|^parity_maxabs:\|^peak_mem_mb:" run.log
+```
+
+Expected lines:
+
+```
+speedup:          1.21
+jax_median_ms:    98.1
+pt_baseline_ms:   118.7
+parity_maxabs:    3.1e-6
+peak_mem_mb:      8601.6
+```
+
+## Logging results
+
+When an experiment is done, append a row to `modules/vggt/autoresearch/results.tsv` (tab-separated, NOT comma-separated).
+
+The TSV has a header row and 8 columns:
+
+```
+commit	jax_ms	pt_ms	speedup	parity_maxabs	peak_mem_gb	status	description
+```
+
+1. git commit hash (short, 7 chars)
+2. jax_median_ms (e.g. 98.1) — use 0.0 for crashes
+3. pt_baseline_ms (e.g. 118.7) — use 0.0 for crashes
+4. speedup (e.g. 1.21) — use 0.0 for crashes
+5. parity_maxabs (e.g. 3.1e-6) — write `n/a` if not measured this iteration
+6. peak memory in GB, round to .1f (divide peak_mem_mb by 1024) — use 0.0 for crashes
+7. status: one of `baseline`, `keep`, `discard`, `crash_parity`, `crash_bench`, `crash_full`
+8. short text description of what this experiment tried
+
+Example:
+
+```
+commit	jax_ms	pt_ms	speedup	parity_maxabs	peak_mem_gb	status	description
+a1b2c3d	142.3	118.7	0.83	3.2e-6	8.4	baseline	eager fp32 baseline (Step 8 HEAD)
+b2c3d4e	98.1	118.7	1.21	3.1e-6	8.4	keep	jax.nn.dot_product_attention
+c3d4e5f	0.0	118.7	0.0	n/a	0.0	crash_parity	bf16 without rescaling rope
+```
+
+Do NOT `git add` results.tsv — leave it untracked.
+
+## The experiment loop
+
+The experiment runs on the dedicated branch `autoresearch/vggt-jax-<tag>`.
+
+LOOP FOREVER. Each iteration is exactly 8 steps:
+
+1. **Inspect state.** Look at git state: current branch, last commit. Run `tail -5 modules/vggt/autoresearch/results.tsv` to see recent experiments.
+2. **Propose one idea.** Pick ONE experimental idea. Edit 1-3 files in the CAN list. Keep the diff small.
+3. **Fast parity gate.**
+   ```
+   uv run pytest modules/vggt/tests/test_jax_parity.py::TestLevel1WeightTransfer modules/vggt/tests/test_jax_parity.py::TestLevel2SharedBlockParity -q
+   ```
+   If fail: `git reset --hard HEAD`, append a `crash_parity` row, return to step 1.
+4. **Bench.**
+   ```
+   uv run python -m modules.vggt.autoresearch.bench_fast > run.log 2>&1
+   ```
+5. **Parse.**
+   ```
+   grep "^speedup:\|^jax_median_ms:\|^peak_mem_mb:" run.log
+   ```
+   If the grep is empty, the run crashed. Run `tail -n 50 run.log`, attempt ONE fix, re-run. If still broken: `git reset --hard HEAD`, append a `crash_bench` row, return to step 1.
+6. **Compare vs best.** Find the best `speedup` value (column 4) across all `keep` rows in `results.tsv` so far.
+   - If `new_speedup <= best_speedup * 1.02`: `git reset --hard HEAD`, append a `discard` row, return to step 1.
+   - Else continue.
+7. **Full parity gate.**
+   ```
+   uv run pytest modules/vggt/tests/ -q
+   ```
+   If fail: `git reset --hard HEAD`, append a `crash_full` row, return to step 1.
+8. **Commit + log.** `git commit -am "<concise description>"`. Append a `keep` row to `results.tsv`. Return to step 1.
+
+The idea is that you are a completely autonomous researcher trying things out. If they work, keep. If they don't, discard. You are advancing the branch so that you can iterate.
+
+## Advisor — when to ask Opus for help
+
+Escalate to Opus in exactly three situations, each enumerated separately:
+
+**(a) Three consecutive `discard` rows in `results.tsv`.** You are stuck and need new ideas.
+
+**(b) A parity failure you cannot diagnose in 2 fix attempts.** A numerical mystery — get another set of eyes.
+
+**(c) A planned change would touch >50 lines OR >2 files.** Big commit, get the plan reviewed before burning compute.
+
+**Invocation.** Use the `Agent` tool with `subagent_type: "general-purpose"` and `model: "opus"`. The prompt MUST be self-contained — Opus has no memory of this run. Include:
+- the last 5 rows of `results.tsv`
+- `git diff` of the last `keep` commit (for triggers a and b) OR the planned change (for trigger c)
+- your current hypothesis in one sentence
+
+**Required response format for Opus** — embed this verbatim in your prompt to enforce it:
+```
+HYPOTHESIS: <one sentence — what's bottlenecking>
+EXPERIMENT: <concrete code change, <= 20 lines>
+FALSIFIABLE BY: <what number tells us if the hypothesis was right>
+```
+
+This format is load-bearing. If Opus returns an essay instead, re-prompt and demand the three-line format.
+
+## Guardrail — run every ~10 keep commits
+
+After every ~10 `keep` commits, run once:
+
+```
+uv run python -m modules.vggt.jax.benchmark_streaming --seq-lens 10 50 100 --backends jax > guardrail.log
+```
+
+Verify that the n=10 and n=100 medians have not regressed more than 20% vs the baseline sweep. If they have, note it in `results.tsv` and consider reverting a recent change.
+
+## Timeout
+
+Each experiment should take a few minutes total. If a run exceeds 10 minutes, kill it and treat it as a failure (discard and revert).
+
+## Crashes
+
+If a run crashes (OOM, or a bug, or etc.), use your judgment: If it's something dumb and easy to fix (e.g. a typo, a missing import), fix it and re-run. If the idea itself is fundamentally broken, just skip it, log the appropriate `crash_*` status in the tsv, and move on.
+
+## NEVER STOP
+
+Once the experiment loop has begun (after the initial setup), do NOT pause to ask the human if you should continue. Do NOT ask "should I keep going?" or "is this a good stopping point?". The human might be asleep, or gone from a computer and expects you to continue working *indefinitely* until you are manually stopped. You are autonomous. If you run out of ideas, think harder — read papers referenced in the code, re-read the in-scope files for new angles, try combining previous near-misses, try more radical architectural changes. The loop runs until the human interrupts you, period.
+
+As an example use case, a user might leave you running while they sleep. If each experiment takes you a few minutes then you can run many dozens per night. The user then wakes up to experimental results, all completed by you while they slept.

--- a/modules/vggt/autoresearch/program.md
+++ b/modules/vggt/autoresearch/program.md
@@ -107,7 +107,7 @@ LOOP FOREVER. Each iteration is exactly 8 steps:
    ```
    uv run pytest modules/vggt/tests/test_jax_parity.py::TestLevel1WeightTransfer modules/vggt/tests/test_jax_parity.py::TestLevel2SharedBlockParity -q
    ```
-   If fail: `git reset --hard HEAD`, append a `crash_parity` row, return to step 1.
+   If fail: `git restore modules/vggt/jax/`, append a `crash_parity` row, return to step 1.
 4. **Bench.**
    ```
    uv run python -m modules.vggt.autoresearch.bench_fast > run.log 2>&1
@@ -116,15 +116,15 @@ LOOP FOREVER. Each iteration is exactly 8 steps:
    ```
    grep "^speedup:\|^jax_median_ms:\|^peak_mem_mb:" run.log
    ```
-   If the grep is empty, the run crashed. Run `tail -n 50 run.log`, attempt ONE fix, re-run. If still broken: `git reset --hard HEAD`, append a `crash_bench` row, return to step 1.
+   If the grep is empty, the run crashed. Run `tail -n 50 run.log`, attempt ONE fix, re-run. If still broken: `git restore modules/vggt/jax/`, append a `crash_bench` row, return to step 1.
 6. **Compare vs best.** Find the best `speedup` value (column 4) across all `keep` rows in `results.tsv` so far.
-   - If `new_speedup <= best_speedup * 1.02`: `git reset --hard HEAD`, append a `discard` row, return to step 1.
+   - If `new_speedup <= best_speedup * 1.02`: `git restore modules/vggt/jax/`, append a `discard` row, return to step 1.
    - Else continue.
 7. **Full parity gate.**
    ```
    uv run pytest modules/vggt/tests/ -q
    ```
-   If fail: `git reset --hard HEAD`, append a `crash_full` row, return to step 1.
+   If fail: `git restore modules/vggt/jax/`, append a `crash_full` row, return to step 1.
 8. **Commit + log.** `git commit -am "<concise description>"`. Append a `keep` row to `results.tsv`. Return to step 1.
 
 The idea is that you are a completely autonomous researcher trying things out. If they work, keep. If they don't, discard. You are advancing the branch so that you can iterate.
@@ -165,7 +165,19 @@ Verify that the n=10 and n=100 medians have not regressed more than 20% vs the b
 
 ## Timeout
 
-Each experiment should take a few minutes total. If a run exceeds 10 minutes, kill it and treat it as a failure (discard and revert).
+Each experiment should take a few minutes total. The outer SLURM wrapper enforces a **hard 15-minute cap per iteration via `timeout(1)`** — if your iteration exceeds 900 seconds, the outer process will kill your invocation and advance. Within an iteration, if a single pytest / bench call has been running for more than 8 minutes, kill it yourself, treat it as a failure (discard and revert via `git restore modules/vggt/jax/`), and move on.
+
+## JIT compilation — expect a one-time cost
+
+First-time `jax.jit` compilation of the full aggregator at `matmul_precision=highest` on an H100 can take **5-15 minutes** (XLA tracing, HLO optimization, kernel selection). This cost is real but amortized across subsequent invocations. Two rules to keep jit experiments inside the 15-min iteration cap:
+
+- **AOT-compile inside the extractor's `__init__` or a one-time warmup, NOT inside the timed bench.** Idiom:
+  ```python
+  self._fn = jax.jit(self._forward)
+  # Warmup call with a dummy input so compilation happens before anything timed
+  _ = self._fn(dummy_input).block_until_ready()
+  ```
+- **The fast parity gate also triggers compilation** (once, on the first test that hits a new shape). Its ~45s budget assumes eager. When you enable jit, the first fast-gate run may take 5-10 min — this is expected and doesn't count as a "slow experiment."
 
 ## Crashes
 

--- a/modules/vggt/autoresearch/run_autoresearch.sbatch
+++ b/modules/vggt/autoresearch/run_autoresearch.sbatch
@@ -43,15 +43,21 @@ TIME_LIMIT_SECONDS="${TIME_LIMIT_SECONDS:-100000}"
 ITER=0
 PROMPT="Read modules/vggt/autoresearch/program.md and execute ONE iteration of the experiment loop. Commit or reset based on results. Return when the iteration is complete."
 
+ITER_TIMEOUT_SECONDS="${ITER_TIMEOUT_SECONDS:-900}"   # 15 min hard cap per iteration
 while [ $SECONDS -lt $TIME_LIMIT_SECONDS ]; do
     ITER=$((ITER+1))
+    ITER_LOG="output/autoresearch/iter-${SLURM_JOB_ID}-${ITER}.log"
     echo ""
-    echo "=== Iteration $ITER at $(date) (elapsed: ${SECONDS}s) ==="
-    if claude -p --dangerously-skip-permissions "$PROMPT"; then
+    echo "=== Iteration $ITER at $(date) (elapsed: ${SECONDS}s, log: $ITER_LOG) ==="
+    if timeout "$ITER_TIMEOUT_SECONDS" claude -p --dangerously-skip-permissions "$PROMPT" > "$ITER_LOG" 2>&1; then
         echo "Iteration $ITER returned 0"
     else
         RC=$?
-        echo "Iteration $ITER returned non-zero ($RC) - continuing"
+        if [ "$RC" -eq 124 ]; then
+            echo "Iteration $ITER TIMEOUT after ${ITER_TIMEOUT_SECONDS}s - continuing (see $ITER_LOG)"
+        else
+            echo "Iteration $ITER returned non-zero ($RC) - continuing (see $ITER_LOG)"
+        fi
     fi
 done
 

--- a/modules/vggt/autoresearch/run_autoresearch.sbatch
+++ b/modules/vggt/autoresearch/run_autoresearch.sbatch
@@ -37,7 +37,9 @@ case "$CUR_BRANCH" in
 esac
 
 # Outer loop: call claude -p until time runs out.
-TIME_LIMIT_SECONDS=100000   # 27.7h, leaves 2.3h headroom on 30h allocation
+# TIME_LIMIT_SECONDS can be overridden via --export=ALL,TIME_LIMIT_SECONDS=... at submit time
+# (e.g. 1500 for a 25-min shake-out on dev_gpu_h100). Default 100000 = 27.7h on a 30h allocation.
+TIME_LIMIT_SECONDS="${TIME_LIMIT_SECONDS:-100000}"
 ITER=0
 PROMPT="Read modules/vggt/autoresearch/program.md and execute ONE iteration of the experiment loop. Commit or reset based on results. Return when the iteration is complete."
 

--- a/modules/vggt/autoresearch/run_autoresearch.sbatch
+++ b/modules/vggt/autoresearch/run_autoresearch.sbatch
@@ -1,0 +1,70 @@
+#!/bin/bash
+#SBATCH --job-name=vggt-autoresearch-main
+#SBATCH --partition=gpu_h100
+#SBATCH --gres=gpu:1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=64G
+#SBATCH --time=30:00:00
+#SBATCH --output=output/autoresearch/run-%j.out
+#SBATCH --error=output/autoresearch/run-%j.err
+
+# Main 30h VGGT JAX autoresearch loop.
+# Prerequisites: smoke.sbatch must have been run (.pt_baseline.json cached,
+# row 1 of results.tsv seeded, on an autoresearch/vggt-jax-* branch).
+
+set -uo pipefail
+
+if [ -n "${SLURM_SUBMIT_DIR:-}" ]; then
+    cd "$SLURM_SUBMIT_DIR"
+fi
+
+mkdir -p output/autoresearch
+
+echo "Job $SLURM_JOB_ID on $(hostname) at $(date)"
+echo "GPU: $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || echo 'N/A')"
+echo "Branch: $(git rev-parse --abbrev-ref HEAD)"
+echo "HEAD: $(git log -1 --oneline)"
+
+# Fail fast if smoke.sbatch hasn't run.
+[ -f modules/vggt/autoresearch/.pt_baseline.json ] || { echo "ERROR: .pt_baseline.json missing - run smoke.sbatch first"; exit 1; }
+[ -f modules/vggt/autoresearch/results.tsv ] || { echo "ERROR: results.tsv missing - run smoke.sbatch first"; exit 1; }
+[ "$(wc -l < modules/vggt/autoresearch/results.tsv)" -ge 2 ] || { echo "ERROR: results.tsv has no baseline row"; exit 1; }
+CUR_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+case "$CUR_BRANCH" in
+    autoresearch/vggt-jax-*) echo "On branch $CUR_BRANCH, OK";;
+    *) echo "ERROR: must run from an autoresearch/vggt-jax-* branch, currently on $CUR_BRANCH"; exit 1;;
+esac
+
+# Outer loop: call claude -p until time runs out.
+TIME_LIMIT_SECONDS=100000   # 27.7h, leaves 2.3h headroom on 30h allocation
+ITER=0
+PROMPT="Read modules/vggt/autoresearch/program.md and execute ONE iteration of the experiment loop. Commit or reset based on results. Return when the iteration is complete."
+
+while [ $SECONDS -lt $TIME_LIMIT_SECONDS ]; do
+    ITER=$((ITER+1))
+    echo ""
+    echo "=== Iteration $ITER at $(date) (elapsed: ${SECONDS}s) ==="
+    if claude -p --dangerously-skip-permissions "$PROMPT"; then
+        echo "Iteration $ITER returned 0"
+    else
+        RC=$?
+        echo "Iteration $ITER returned non-zero ($RC) - continuing"
+    fi
+done
+
+echo ""
+echo "=== Loop ended after $ITER iterations, $SECONDS seconds ==="
+
+# Summary.
+TSV=modules/vggt/autoresearch/results.tsv
+echo "Results summary:"
+echo "  total rows:    $(($(wc -l < "$TSV") - 1))"
+echo "  keep:          $(grep -c '	keep	' "$TSV" || true)"
+echo "  discard:       $(grep -c '	discard	' "$TSV" || true)"
+echo "  crash_parity:  $(grep -c '	crash_parity	' "$TSV" || true)"
+echo "  crash_bench:   $(grep -c '	crash_bench	' "$TSV" || true)"
+echo "  crash_full:    $(grep -c '	crash_full	' "$TSV" || true)"
+echo ""
+echo "Best speedup so far:"
+awk -F'\t' '$7=="keep" {print $4, $1, $8}' "$TSV" | sort -rn | head -5

--- a/modules/vggt/autoresearch/smoke.sbatch
+++ b/modules/vggt/autoresearch/smoke.sbatch
@@ -1,6 +1,6 @@
 #!/bin/bash
 #SBATCH --job-name=vggt-autoresearch-smoke
-#SBATCH --partition=gpu_h100
+#SBATCH --partition=dev_gpu_h100
 #SBATCH --gres=gpu:1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=8

--- a/modules/vggt/autoresearch/smoke.sbatch
+++ b/modules/vggt/autoresearch/smoke.sbatch
@@ -1,0 +1,66 @@
+#!/bin/bash
+#SBATCH --job-name=vggt-autoresearch-smoke
+#SBATCH --partition=gpu_h100
+#SBATCH --gres=gpu:1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=64G
+#SBATCH --time=00:30:00
+#SBATCH --output=output/autoresearch/smoke-%j.out
+#SBATCH --error=output/autoresearch/smoke-%j.err
+
+# 30-min sanity check for the VGGT JAX autoresearch harness.
+# Caches the PyTorch baseline, runs the fast parity gate, executes one
+# bench_fast pass, and seeds row 1 of results.tsv for the main loop.
+
+set -euo pipefail
+
+if [ -n "${SLURM_SUBMIT_DIR:-}" ]; then
+    cd "$SLURM_SUBMIT_DIR"
+fi
+
+mkdir -p output/autoresearch
+
+echo "Job $SLURM_JOB_ID on $(hostname) at $(date)"
+echo "GPU: $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || echo 'N/A')"
+echo "Branch: $(git rev-parse --abbrev-ref HEAD)"
+echo "HEAD: $(git log -1 --oneline)"
+
+# Create (or reset) the autoresearch branch idempotently.
+TAG=$(date +%b%d | tr A-Z a-z)
+BRANCH="autoresearch/vggt-jax-${TAG}"
+echo "Creating/resetting branch $BRANCH from feat/vggt-jax-port"
+git checkout feat/vggt-jax-port
+git checkout -B "$BRANCH"
+
+# Cache PyTorch baseline (.pt_baseline.json).
+echo "Caching PyTorch baseline..."
+uv run python -m modules.vggt.autoresearch.bench_fast --setup
+
+# Fast parity gate.
+echo "Running fast parity gate..."
+uv run pytest \
+    modules/vggt/tests/test_jax_parity.py::TestLevel1WeightTransfer \
+    modules/vggt/tests/test_jax_parity.py::TestLevel2SharedBlockParity \
+    -q
+
+# Baseline JAX bench run — capture output for parsing.
+BASELINE_LOG="output/autoresearch/baseline-${SLURM_JOB_ID}.log"
+echo "Running baseline bench_fast, logging to $BASELINE_LOG"
+uv run python -m modules.vggt.autoresearch.bench_fast > "$BASELINE_LOG" 2>&1
+grep "^speedup:\|^jax_median_ms:\|^pt_baseline_ms:\|^peak_mem_mb:" "$BASELINE_LOG"
+
+# Seed results.tsv with baseline row.
+TSV=modules/vggt/autoresearch/results.tsv
+JAX_MS=$(grep "^jax_median_ms:" "$BASELINE_LOG" | awk '{print $2}')
+PT_MS=$(grep "^pt_baseline_ms:" "$BASELINE_LOG" | awk '{print $2}')
+SPEEDUP=$(grep "^speedup:" "$BASELINE_LOG" | awk '{print $2}')
+PEAK_MB=$(grep "^peak_mem_mb:" "$BASELINE_LOG" | awk '{print $2}')
+PEAK_GB=$(awk -v mb="$PEAK_MB" 'BEGIN {printf "%.1f", mb/1024}')
+COMMIT=$(git rev-parse --short HEAD)
+
+printf "commit\tjax_ms\tpt_ms\tspeedup\tparity_maxabs\tpeak_mem_gb\tstatus\tdescription\n" > "$TSV"
+printf "%s\t%s\t%s\t%s\tn/a\t%s\tbaseline\teager fp32 baseline (Step 8 HEAD)\n" \
+    "$COMMIT" "$JAX_MS" "$PT_MS" "$SPEEDUP" "$PEAK_GB" >> "$TSV"
+echo "Wrote baseline row to $TSV:"
+cat "$TSV"

--- a/modules/vggt/feature_extractor.py
+++ b/modules/vggt/feature_extractor.py
@@ -30,11 +30,15 @@ class VGGTFeatureExtractor:
     Then call :meth:`extract` once per step with the current 518x518 RGB frame.
     """
 
-    def __init__(self, device: str = "cuda"):
+    def __init__(self, device: str = "cuda", compile: bool = False):
         """Load frozen InfiniteVGGT model.
 
         Args:
             device: Torch device string (default ``"cuda"``).
+            compile: If True, wrap aggregator / camera_head / point_head with
+                ``torch.compile``. Aggregator and camera_head use ``dynamic=True``
+                (their KV-cache grows each frame). point_head is static.
+                First few calls are slow (tracing); steady-state may be faster.
         """
         self.device = torch.device(device)
 
@@ -43,6 +47,12 @@ class VGGTFeatureExtractor:
         self.model = self.model.to(self.device).eval()
         for p in self.model.parameters():
             p.requires_grad = False
+
+        if compile:
+            print("Compiling VGGT sub-modules with torch.compile...")
+            self.model.aggregator = torch.compile(self.model.aggregator, dynamic=True)
+            self.model.camera_head = torch.compile(self.model.camera_head, dynamic=True)
+            self.model.point_head = torch.compile(self.model.point_head)
 
         # Aggregator depth drives the per-layer KV-cache list length.
         self._agg_depth: int = self.model.aggregator.depth

--- a/modules/vggt/feature_extractor.py
+++ b/modules/vggt/feature_extractor.py
@@ -70,16 +70,33 @@ class VGGTFeatureExtractor:
         self._frame_idx: int = 0
         torch.cuda.empty_cache()
 
-    def extract(self, rgb: np.ndarray) -> dict[str, np.ndarray]:
+    def extract(
+        self,
+        rgb: np.ndarray,
+        phase_times: dict[str, list[float]] | None = None,
+    ) -> dict[str, np.ndarray]:
         """Single-frame streaming inference.
 
         Args:
             rgb: ``(3, 518, 518)`` uint8 array in CHW format (e.g. from Habitat).
+            phase_times: Optional profiling hook. When provided, records per-call
+                CUDA-Event durations (ms) under keys ``"vggt_forward"`` (input prep
+                + model forward) and ``"vggt_wrapper"`` (pool + permute + .cpu()
+                transfer). When ``None`` (default, production path) no events are
+                created and no extra work is done.
 
         Returns:
             ``{"world_points": (37, 37, 3) float32,
               "camera_pose": (9,) float32}``
         """
+        profiling = phase_times is not None
+        if profiling:
+            fwd_start = torch.cuda.Event(enable_timing=True)
+            fwd_end = torch.cuda.Event(enable_timing=True)
+            wrap_start = torch.cuda.Event(enable_timing=True)
+            wrap_end = torch.cuda.Event(enable_timing=True)
+            fwd_start.record()
+
         # --- prepare input tensor -------------------------------------------
         # uint8 CHW → float32 [0, 1], add batch dim → (1, 3, 518, 518)
         img = torch.from_numpy(rgb).to(dtype=torch.float32, device=self.device) / 255.0
@@ -117,6 +134,10 @@ class VGGTFeatureExtractor:
                 )
                 pts3d = pts3d[:, 0]  # (B, H, W, 3)  — remove sequence dim
 
+        if profiling:
+            fwd_end.record()
+            wrap_start.record()
+
         # --- downsample to patch grid ----------------------------------------
         # pts3d is (1, H, W, 3) with H=W=518.  Pool to 37×37.
         # adaptive_avg_pool2d works on (N, C, H, W) so permute channels.
@@ -127,6 +148,12 @@ class VGGTFeatureExtractor:
         # --- to numpy --------------------------------------------------------
         world_points_np = world_points.cpu().float().numpy()
         camera_pose_np = camera_pose.squeeze(0).cpu().float().numpy()
+
+        if profiling:
+            wrap_end.record()
+            torch.cuda.synchronize()
+            phase_times["vggt_forward"].append(fwd_start.elapsed_time(fwd_end))
+            phase_times["vggt_wrapper"].append(wrap_start.elapsed_time(wrap_end))
 
         # --- bookkeeping -----------------------------------------------------
         self._frame_idx += 1

--- a/modules/vggt/jax/__init__.py
+++ b/modules/vggt/jax/__init__.py
@@ -1,13 +1,21 @@
 """JAX/Flax reimplementation of StreamVGGT (InfiniteVGGT).
 
-Public entry points are exposed here as they land. Step 1 only ships
-weight-transfer; Flax module shells land in subsequent steps.
+Steps 1-6 ship the core model (weight transfer, DINOv2 backbone,
+aggregator, camera head, DPT point head, streaming KV-cache with dynamic
+budget eviction). Step 7 adds ``JAXVGGTFeatureExtractor`` as a drop-in
+replacement for the PyTorch extractor.
 """
 
+from modules.vggt.jax.feature_extractor import JAXVGGTFeatureExtractor
 from modules.vggt.jax.weight_transfer import (
     load_checkpoint,
     load_pytorch_weights,
     V1_EXCLUDE_PREFIXES,
 )
 
-__all__ = ["load_checkpoint", "load_pytorch_weights", "V1_EXCLUDE_PREFIXES"]
+__all__ = [
+    "JAXVGGTFeatureExtractor",
+    "V1_EXCLUDE_PREFIXES",
+    "load_checkpoint",
+    "load_pytorch_weights",
+]

--- a/modules/vggt/jax/__init__.py
+++ b/modules/vggt/jax/__init__.py
@@ -1,0 +1,13 @@
+"""JAX/Flax reimplementation of StreamVGGT (InfiniteVGGT).
+
+Public entry points are exposed here as they land. Step 1 only ships
+weight-transfer; Flax module shells land in subsequent steps.
+"""
+
+from modules.vggt.jax.weight_transfer import (
+    load_checkpoint,
+    load_pytorch_weights,
+    V1_EXCLUDE_PREFIXES,
+)
+
+__all__ = ["load_checkpoint", "load_pytorch_weights", "V1_EXCLUDE_PREFIXES"]

--- a/modules/vggt/jax/aggregator.py
+++ b/modules/vggt/jax/aggregator.py
@@ -5,20 +5,17 @@ Mirrors ``streamvggt.models.aggregator.Aggregator``:
 * **No-cache path** (``use_cache=False``): Processes all S frames at once,
   global attention uses an S*P-length causal mask so frame i only sees
   frames 0..i.
-* **Streaming cache path** (``use_cache=True``, Step 6a): Processes S=1
-  new frame per call. Global blocks receive the prior frames' K/V via
-  ``past_kvs[i]`` and return an updated ``(k, v)`` tuple. The causal mask
-  disappears — the current frame's Q attending to the concatenated (past_k,
-  new_k) preserves causal structure automatically. Eviction is NOT
-  implemented in 6a: caches grow each frame.
+* **Streaming cache path** (``use_cache=True``): Processes S=1 new frame per
+  call. Global blocks receive the prior frames' K/V via ``past_kvs[i]`` and
+  return an updated cache.
 
-Forward pipeline (no-cache):
-    images (B, S, 3, H, W) in [0, 1]
-      -> ResNet normalise
-      -> (B*S, 3, H, W) patch conv via DinoV2Backbone
-      -> prepend camera_token + register_token per frame (slice-expand-flatten)
-      -> 24 alternating (frame, global) block pairs
-      -> output_list: [(B, S, P, 2*C)] * depth  +  patch_start_idx = 5
+  Two cache formats are supported:
+    - Legacy 2-tuple ``(k, v)``: variable-length; eviction yields a compact
+      concat of anchors + kept candidates.
+    - Padded 3-tuple ``(k_pad, v_pad, valid_len)``: fixed ``(B, H, MAX, Dh)``
+      shape with a traced int32 scalar ``valid_len``. Enables jit without
+      shape-polymorphism. Feature_extractor uses this form; parity tests
+      call the aggregator directly with 2-tuples.
 """
 
 from __future__ import annotations
@@ -70,12 +67,7 @@ def _make_position_grid(
 
 
 def _make_causal_global_mask(S: int, P: int, dtype=jnp.float32) -> jnp.ndarray:
-    """Per-block causal frame mask for global attention over S*P tokens.
-
-    Token at position k belongs to frame ``k // P``. Future frames are masked
-    with ``finfo(dtype).min`` additive (pre-softmax). Returns (S*P, S*P) which
-    broadcasts against (B, H, L, L) attention scores.
-    """
+    """Per-block causal frame mask for global attention over S*P tokens."""
     L = S * P
     frame_ids = jnp.arange(L) // P
     future = frame_ids[:, None] < frame_ids[None, :]
@@ -91,10 +83,6 @@ def _calculate_dynamic_budgets(
     ``last_scores``) have low "diversity" and receive a smaller share of
     the global budget. The per-block budget is ``softmax(2*(1-score)) *
     total_budget`` truncated to int.
-
-    When ``last_scores`` is all zeros (initial state / no eviction yet),
-    softmax of a constant vector is uniform, giving every block an equal
-    slice of the budget — which recovers the Step 6b uniform allocation.
     """
     total_budget = max(int(total_budget), 0)
     diversity = 1.0 - last_scores
@@ -105,21 +93,7 @@ def _calculate_dynamic_budgets(
 
 
 class Aggregator(nn.Module):
-    """Alternating frame/global attention tower (no-cache path).
-
-    Attributes:
-        img_size: Fixed input side length (518 for thesis).
-        patch_size: Patch conv stride (14).
-        embed_dim: Token feature dim (1024).
-        depth: Number of (frame, global) block pairs (24).
-        num_heads: Attention heads (16).
-        mlp_ratio: MLP expansion factor (4).
-        num_register_tokens: Register tokens prepended per frame (4).
-        init_values: LayerScale init for aggregator blocks (0.01).
-        norm_eps: LayerNorm epsilon used by frame/global blocks (1e-5).
-        rope_freq: 2D RoPE base frequency (100.0).
-        aa_order: Tuple of attention types; defaults to ("frame", "global").
-    """
+    """Alternating frame/global attention tower."""
 
     img_size: int = 518
     patch_size: int = 14
@@ -143,27 +117,22 @@ class Aggregator(nn.Module):
         past_frame_idx: int = 0,
         total_budget: int | None = None,
         last_scores: jnp.ndarray | None = None,
+        current_budgets_static: tuple[int, ...] | None = None,
     ):
         """Forward pass.
 
         Args:
             images: (B, S, 3, H, W) float in [0, 1]. In cache mode, S must be 1.
-            use_cache: If True, take the streaming path: thread ``past_kvs``
-                through the global blocks, skip the causal mask (causality is
-                implicit in the past/new K split), and return the updated cache.
-            past_kvs: List of length ``depth``; each entry is either None (first
-                frame) or ``(past_k, past_v)`` from the prior call. Required
-                when ``use_cache=True``.
-            past_frame_idx: Zero-based index of the current frame in the full
-                stream. Used to pick the first-frame vs other-frames camera/
-                register token slot.
-            total_budget: Optional global cache size shared across all global
-                blocks. Per-block budget is ``softmax(2*(1-last_scores)) *
-                total_budget`` (Step 6c dynamic allocation). When
-                ``last_scores`` is zeros, this reduces to the uniform
-                allocation of Step 6b. ``None`` disables eviction entirely.
-            last_scores: Optional (depth,) fp32 array of cosine-similarity
-                means from the prior call's eviction. Zeros on first frame.
+            use_cache: If True, take the streaming cache path.
+            past_kvs: List of length ``depth``; entries are None, a 2-tuple
+                (legacy compact), or a 3-tuple (padded).
+            past_frame_idx: Zero-based frame index.
+            total_budget: Optional global cache size. If None, eviction off.
+            last_scores: Optional (depth,) fp32 array from prior call.
+            current_budgets_static: Optional tuple of Python ints (length
+                ``depth``) giving the per-block budgets. When provided, used
+                directly; allows the caller to compute budgets outside jit
+                and pass them as static args so top_k's k stays Python-int.
 
         Returns:
             No-cache:  ``(output_list, patch_start_idx)``.
@@ -187,20 +156,32 @@ class Aggregator(nn.Module):
             )
         if use_cache and last_scores is None:
             last_scores = jnp.zeros((self.depth,), dtype=jnp.float32)
-        # Per-block budgets — uniform on the first-eviction step (zeros
-        # in, uniform softmax out), dynamic after last_scores updates.
-        current_budgets = (
-            _calculate_dynamic_budgets(last_scores, total_budget)
-            if use_cache and total_budget is not None
-            else None
-        )
+
+        # Detect whether any past cache entry is padded (3-tuple) — all must
+        # match. None + any 3-tuples means mixed first-call semantics.
+        padded_mode = False
+        if use_cache and past_kvs is not None:
+            for entry in past_kvs:
+                if entry is not None and isinstance(entry, tuple) and len(entry) == 3:
+                    padded_mode = True
+                    break
+
+        # Per-block budgets.
+        if use_cache and total_budget is not None:
+            if current_budgets_static is not None:
+                # Static Python tuple — used for the jitted path.
+                current_budgets = list(current_budgets_static)
+            else:
+                # Compute from last_scores (non-jit path).
+                current_budgets = _calculate_dynamic_budgets(last_scores, total_budget)
+        else:
+            current_budgets = None
 
         # ResNet normalisation on [0, 1] images.
         mean = jnp.asarray(_RESNET_MEAN, dtype=images.dtype).reshape(1, 1, 3, 1, 1)
         std = jnp.asarray(_RESNET_STD, dtype=images.dtype).reshape(1, 1, 3, 1, 1)
         images = (images - mean) / std
 
-        # Flatten batch/frame for patch conv.
         x = images.reshape(B * S, C_in, H, W)
         patch_tokens = DinoV2Backbone(
             img_size=self.img_size,
@@ -214,9 +195,7 @@ class Aggregator(nn.Module):
             norm_eps=1e-6,     # DINOv2 override
             name="patch_embed",
         )(x)
-        # (B*S, P_patch, embed_dim) where P_patch = (H/patch_size)^2
 
-        # Camera + register tokens (aggregator-level).
         camera_token_full = self.param(
             "camera_token",
             lambda _k, shape: jnp.zeros(shape, dtype=jnp.float32),
@@ -228,7 +207,6 @@ class Aggregator(nn.Module):
             (1, 2, self.num_register_tokens, self.embed_dim),
         )
         if use_cache:
-            # Slot 0 = first-frame query token; slot 1 = all subsequent frames.
             slot = 0 if past_frame_idx == 0 else 1
             n_reg = self.num_register_tokens
             camera = jnp.broadcast_to(
@@ -251,30 +229,25 @@ class Aggregator(nn.Module):
         P = tokens.shape[1]
         patch_start_idx = 1 + self.num_register_tokens  # 5
 
-        # Positions + RoPE tables (precomputed for fixed 37x37 grid).
         grid = self.img_size // self.patch_size
-        positions_bs_p = _make_position_grid(B, S, grid, grid, patch_start_idx)  # (B*S, P, 2)
+        positions_bs_p = _make_position_grid(B, S, grid, grid, patch_start_idx)
         head_dim = self.embed_dim // self.num_heads
         cos_t, sin_t = compute_1d_rope_tables(
             dim=head_dim // 2,
-            max_pos=grid + 1,  # patches shifted to [1, grid+1)
+            max_pos=grid + 1,
             frequency=self.rope_freq,
-            dtype=jnp.float32,
+            dtype=images.dtype,
         )
         rope_tables = (cos_t, sin_t)
 
-        # Per-block causal mask for the no-cache global attention. In cache
-        # mode the rectangular Q-vs-[past_K | new_K] attention is naturally
-        # causal, so we pass attn_mask=None.
         global_mask = None if use_cache else _make_causal_global_mask(
             S, P, dtype=jnp.float32
         )
 
-        # Pre-reshape helpers
-        def _to_frame(t):  # (B, S, P, C) -> (B*S, P, C)
+        def _to_frame(t):
             return t.reshape(B * S, P, self.embed_dim)
 
-        def _to_global(t_flat):  # (B*S, P, C) -> (B, S*P, C)
+        def _to_global(t_flat):
             return t_flat.reshape(B, S, P, self.embed_dim).reshape(
                 B, S * P, self.embed_dim
             )
@@ -282,13 +255,12 @@ class Aggregator(nn.Module):
         positions_b_sp = positions_bs_p.reshape(B, S, P, 2).reshape(B, S * P, 2)
 
         output_list: list[jnp.ndarray] = []
-        new_past_kvs: list = [] if use_cache else []
-        new_scores: list = []  # per-block scores used to update last_scores
+        new_past_kvs: list = []
+        new_scores: list = []
         any_evicted = False
-        # In the reference, aa_block_size defaults to 1 so each outer step
-        # runs exactly one frame-block then one global-block. depth == aa_block_num.
+        any_evicted_traced: jnp.ndarray | None = None  # padded mode
+
         for b in range(self.depth):
-            # ---- Frame attention: (B*S, P, C) — no cache for frame blocks ----
             tokens_frame = (
                 _to_frame(tokens)
                 if tokens.shape == (B, S * P, self.embed_dim)
@@ -305,7 +277,6 @@ class Aggregator(nn.Module):
             )(tokens_frame, rope_tables=rope_tables, positions=positions_bs_p)
             frame_inter = tokens_frame.reshape(B, S, P, self.embed_dim)
 
-            # ---- Global attention: (B, S*P, C) — cached when streaming ----
             tokens_global = _to_global(tokens_frame)
             global_block = Block(
                 dim=self.embed_dim,
@@ -317,31 +288,52 @@ class Aggregator(nn.Module):
                 name=f"global_blocks_{b}",
             )
             if use_cache:
+                # In padded mode, initialize zero-pad on the first frame.
+                past_entry = past_kvs[b] if past_kvs is not None else None
+                if padded_mode and past_entry is None:
+                    # Shouldn't happen — padded mode implies entries are 3-tuples.
+                    # But keep safe: fall through to 2-tuple (legacy) path.
+                    pass
+
                 if current_budgets is not None:
-                    # Anchors = the first frame's P tokens; never evicted.
-                    per_block_budget = int(current_budgets[b])
+                    if isinstance(current_budgets, list):
+                        per_block_budget = int(current_budgets[b])
+                    else:
+                        # jax array — only safe outside jit.
+                        per_block_budget = int(current_budgets[b])
                     tokens_global, new_kv, scores = global_block(
                         tokens_global,
                         rope_tables=rope_tables,
                         positions=positions_b_sp,
                         attn_mask=None,
-                        past_kv=past_kvs[b],
+                        past_kv=past_entry,
                         use_cache=True,
                         cache_budget=per_block_budget,
                         num_anchor_tokens=P,
                     )
-                    if scores is not None:
-                        new_scores.append(scores)
-                        any_evicted = True
+                    # Decode `scores`: legacy → None or scalar; padded →
+                    # (did_evict_bool, score_scalar).
+                    if isinstance(scores, tuple):
+                        did_evict, score_scalar = scores
+                        # Accumulate per-block record.
+                        new_scores.append((did_evict, score_scalar))
+                        if any_evicted_traced is None:
+                            any_evicted_traced = did_evict
+                        else:
+                            any_evicted_traced = any_evicted_traced | did_evict
                     else:
-                        new_scores.append(last_scores[b])
+                        if scores is not None:
+                            new_scores.append(scores)
+                            any_evicted = True
+                        else:
+                            new_scores.append(last_scores[b])
                 else:
                     tokens_global, new_kv = global_block(
                         tokens_global,
                         rope_tables=rope_tables,
                         positions=positions_b_sp,
                         attn_mask=None,
-                        past_kv=past_kvs[b],
+                        past_kv=past_entry,
                         use_cache=True,
                     )
                 new_past_kvs.append(new_kv)
@@ -353,17 +345,27 @@ class Aggregator(nn.Module):
                     attn_mask=global_mask,
                 )
             global_inter = tokens_global.reshape(B, S, P, self.embed_dim)
-
-            # Carry for next iteration (flat-frame layout).
             tokens = _to_frame(global_inter)
 
-            # Each level emits concat([frame, global], axis=-1) -> (B, S, P, 2C).
             output_list.append(jnp.concatenate([frame_inter, global_inter], axis=-1))
 
         if use_cache:
-            # Reference updates self.last_scores only when something was
-            # evicted this frame; otherwise the previous state carries.
-            if any_evicted:
+            if padded_mode and current_budgets is not None:
+                # Padded mode: new_scores is a list of (did_evict, score) pairs.
+                # Build new_last_scores with jnp.where to preserve last_scores
+                # where no eviction fired.
+                per_block_new = []
+                for b, entry in enumerate(new_scores):
+                    if isinstance(entry, tuple):
+                        did_evict, score = entry
+                        per_block_new.append(
+                            jnp.where(did_evict, score, last_scores[b])
+                        )
+                    else:
+                        # Shouldn't occur in padded mode, but be safe.
+                        per_block_new.append(jnp.asarray(entry, dtype=jnp.float32))
+                new_last_scores = jnp.stack(per_block_new).astype(jnp.float32)
+            elif any_evicted:
                 new_last_scores = jnp.stack(
                     [jnp.asarray(s, dtype=jnp.float32) for s in new_scores]
                 )

--- a/modules/vggt/jax/aggregator.py
+++ b/modules/vggt/jax/aggregator.py
@@ -1,19 +1,24 @@
 """Aggregator — alternating frame/global attention over S frames.
 
-Mirrors ``streamvggt.models.aggregator.Aggregator`` for the **no-cache** path
-(``use_cache=False`` in the reference). The cache/eviction/dynamic-budget
-branches land in Step 6a+.
+Mirrors ``streamvggt.models.aggregator.Aggregator``:
 
-Forward pipeline:
+* **No-cache path** (``use_cache=False``): Processes all S frames at once,
+  global attention uses an S*P-length causal mask so frame i only sees
+  frames 0..i.
+* **Streaming cache path** (``use_cache=True``, Step 6a): Processes S=1
+  new frame per call. Global blocks receive the prior frames' K/V via
+  ``past_kvs[i]`` and return an updated ``(k, v)`` tuple. The causal mask
+  disappears — the current frame's Q attending to the concatenated (past_k,
+  new_k) preserves causal structure automatically. Eviction is NOT
+  implemented in 6a: caches grow each frame.
+
+Forward pipeline (no-cache):
     images (B, S, 3, H, W) in [0, 1]
       -> ResNet normalise
       -> (B*S, 3, H, W) patch conv via DinoV2Backbone
       -> prepend camera_token + register_token per frame (slice-expand-flatten)
       -> 24 alternating (frame, global) block pairs
       -> output_list: [(B, S, P, 2*C)] * depth  +  patch_start_idx = 5
-
-Each global block in the no-cache path uses a per-block causal mask over
-``S * P`` tokens (frame i attends only to frames 0..i).
 """
 
 from __future__ import annotations
@@ -107,15 +112,31 @@ class Aggregator(nn.Module):
     aa_order: tuple[str, ...] = ("frame", "global")
 
     @nn.compact
-    def __call__(self, images: jnp.ndarray) -> tuple[list[jnp.ndarray], int]:
+    def __call__(
+        self,
+        images: jnp.ndarray,
+        *,
+        use_cache: bool = False,
+        past_kvs: list | None = None,
+        past_frame_idx: int = 0,
+    ):
         """Forward pass.
 
         Args:
-            images: (B, S, 3, H, W) float in [0, 1].
+            images: (B, S, 3, H, W) float in [0, 1]. In cache mode, S must be 1.
+            use_cache: If True, take the streaming path: thread ``past_kvs``
+                through the global blocks, skip the causal mask (causality is
+                implicit in the past/new K split), and return the updated cache.
+            past_kvs: List of length ``depth``; each entry is either None (first
+                frame) or ``(past_k, past_v)`` from the prior call. Required
+                when ``use_cache=True``.
+            past_frame_idx: Zero-based index of the current frame in the full
+                stream. Used to pick the first-frame vs other-frames camera/
+                register token slot.
 
         Returns:
-            (output_list, patch_start_idx) where output_list has ``depth``
-            tensors of shape (B, S, P, 2*embed_dim) and patch_start_idx = 5.
+            No-cache:  (output_list, patch_start_idx).
+            Cache:     (output_list, patch_start_idx, new_past_kvs).
         """
         B, S, C_in, H, W = images.shape
         if C_in != 3:
@@ -123,6 +144,14 @@ class Aggregator(nn.Module):
         if H != self.img_size or W != self.img_size:
             raise NotImplementedError(
                 f"Aggregator is fixed at {self.img_size}x{self.img_size}; got {H}x{W}."
+            )
+        if use_cache and S != 1:
+            raise ValueError(f"use_cache expects S=1 per call, got S={S}")
+        if use_cache and past_kvs is None:
+            past_kvs = [None] * self.depth
+        if use_cache and len(past_kvs) != self.depth:
+            raise ValueError(
+                f"past_kvs length {len(past_kvs)} != depth {self.depth}"
             )
 
         # ResNet normalisation on [0, 1] images.
@@ -145,7 +174,6 @@ class Aggregator(nn.Module):
             name="patch_embed",
         )(x)
         # (B*S, P_patch, embed_dim) where P_patch = (H/patch_size)^2
-        P_patch = patch_tokens.shape[1]
 
         # Camera + register tokens (aggregator-level).
         camera_token_full = self.param(
@@ -158,10 +186,26 @@ class Aggregator(nn.Module):
             lambda _k, shape: jnp.zeros(shape, dtype=jnp.float32),
             (1, 2, self.num_register_tokens, self.embed_dim),
         )
-        camera = _slice_expand_and_flatten(camera_token_full.astype(patch_tokens.dtype), B, S)
-        register = _slice_expand_and_flatten(
-            register_token_full.astype(patch_tokens.dtype), B, S
-        )
+        if use_cache:
+            # Slot 0 = first-frame query token; slot 1 = all subsequent frames.
+            slot = 0 if past_frame_idx == 0 else 1
+            n_reg = self.num_register_tokens
+            camera = jnp.broadcast_to(
+                camera_token_full[0, slot : slot + 1].astype(patch_tokens.dtype),
+                (B, 1, self.embed_dim),
+            )
+            register = jnp.broadcast_to(
+                register_token_full[0, slot : slot + 1].reshape(1, n_reg, self.embed_dim)
+                .astype(patch_tokens.dtype),
+                (B, n_reg, self.embed_dim),
+            )
+        else:
+            camera = _slice_expand_and_flatten(
+                camera_token_full.astype(patch_tokens.dtype), B, S
+            )
+            register = _slice_expand_and_flatten(
+                register_token_full.astype(patch_tokens.dtype), B, S
+            )
         tokens = jnp.concatenate([camera, register, patch_tokens], axis=1)
         P = tokens.shape[1]
         patch_start_idx = 1 + self.num_register_tokens  # 5
@@ -178,24 +222,35 @@ class Aggregator(nn.Module):
         )
         rope_tables = (cos_t, sin_t)
 
-        # Precompute per-block causal mask for global attention (S*P length).
-        global_mask = _make_causal_global_mask(S, P, dtype=jnp.float32)
+        # Per-block causal mask for the no-cache global attention. In cache
+        # mode the rectangular Q-vs-[past_K | new_K] attention is naturally
+        # causal, so we pass attn_mask=None.
+        global_mask = None if use_cache else _make_causal_global_mask(
+            S, P, dtype=jnp.float32
+        )
 
         # Pre-reshape helpers
         def _to_frame(t):  # (B, S, P, C) -> (B*S, P, C)
             return t.reshape(B * S, P, self.embed_dim)
 
         def _to_global(t_flat):  # (B*S, P, C) -> (B, S*P, C)
-            return t_flat.reshape(B, S, P, self.embed_dim).reshape(B, S * P, self.embed_dim)
+            return t_flat.reshape(B, S, P, self.embed_dim).reshape(
+                B, S * P, self.embed_dim
+            )
 
         positions_b_sp = positions_bs_p.reshape(B, S, P, 2).reshape(B, S * P, 2)
 
         output_list: list[jnp.ndarray] = []
+        new_past_kvs: list = [] if use_cache else []
         # In the reference, aa_block_size defaults to 1 so each outer step
         # runs exactly one frame-block then one global-block. depth == aa_block_num.
         for b in range(self.depth):
-            # ---- Frame attention: (B*S, P, C) ----
-            tokens_frame = _to_frame(tokens) if tokens.shape == (B, S * P, self.embed_dim) else tokens
+            # ---- Frame attention: (B*S, P, C) — no cache for frame blocks ----
+            tokens_frame = (
+                _to_frame(tokens)
+                if tokens.shape == (B, S * P, self.embed_dim)
+                else tokens
+            )
             tokens_frame = Block(
                 dim=self.embed_dim,
                 num_heads=self.num_heads,
@@ -207,9 +262,9 @@ class Aggregator(nn.Module):
             )(tokens_frame, rope_tables=rope_tables, positions=positions_bs_p)
             frame_inter = tokens_frame.reshape(B, S, P, self.embed_dim)
 
-            # ---- Global attention: (B, S*P, C) ----
+            # ---- Global attention: (B, S*P, C) — cached when streaming ----
             tokens_global = _to_global(tokens_frame)
-            tokens_global = Block(
+            global_block = Block(
                 dim=self.embed_dim,
                 num_heads=self.num_heads,
                 mlp_ratio=self.mlp_ratio,
@@ -217,12 +272,24 @@ class Aggregator(nn.Module):
                 init_values=self.init_values,
                 norm_eps=self.norm_eps,
                 name=f"global_blocks_{b}",
-            )(
-                tokens_global,
-                rope_tables=rope_tables,
-                positions=positions_b_sp,
-                attn_mask=global_mask,
             )
+            if use_cache:
+                tokens_global, new_kv = global_block(
+                    tokens_global,
+                    rope_tables=rope_tables,
+                    positions=positions_b_sp,
+                    attn_mask=None,
+                    past_kv=past_kvs[b],
+                    use_cache=True,
+                )
+                new_past_kvs.append(new_kv)
+            else:
+                tokens_global = global_block(
+                    tokens_global,
+                    rope_tables=rope_tables,
+                    positions=positions_b_sp,
+                    attn_mask=global_mask,
+                )
             global_inter = tokens_global.reshape(B, S, P, self.embed_dim)
 
             # Carry for next iteration (flat-frame layout).
@@ -231,4 +298,6 @@ class Aggregator(nn.Module):
             # Each level emits concat([frame, global], axis=-1) -> (B, S, P, 2C).
             output_list.append(jnp.concatenate([frame_inter, global_inter], axis=-1))
 
+        if use_cache:
+            return output_list, patch_start_idx, new_past_kvs
         return output_list, patch_start_idx

--- a/modules/vggt/jax/aggregator.py
+++ b/modules/vggt/jax/aggregator.py
@@ -119,6 +119,7 @@ class Aggregator(nn.Module):
         use_cache: bool = False,
         past_kvs: list | None = None,
         past_frame_idx: int = 0,
+        total_budget: int | None = None,
     ):
         """Forward pass.
 
@@ -133,6 +134,10 @@ class Aggregator(nn.Module):
             past_frame_idx: Zero-based index of the current frame in the full
                 stream. Used to pick the first-frame vs other-frames camera/
                 register token slot.
+            total_budget: Optional global cache size shared across all global
+                blocks. In Step 6b (uniform allocation), each block receives
+                ``total_budget // depth`` slots. None disables eviction —
+                cache grows unboundedly.
 
         Returns:
             No-cache:  (output_list, patch_start_idx).
@@ -274,14 +279,30 @@ class Aggregator(nn.Module):
                 name=f"global_blocks_{b}",
             )
             if use_cache:
-                tokens_global, new_kv = global_block(
-                    tokens_global,
-                    rope_tables=rope_tables,
-                    positions=positions_b_sp,
-                    attn_mask=None,
-                    past_kv=past_kvs[b],
-                    use_cache=True,
-                )
+                if total_budget is not None:
+                    # Uniform per-block budget in Step 6b (dynamic allocation
+                    # lands in 6c). Anchors = the first frame's P tokens; they
+                    # are never evicted.
+                    per_block_budget = total_budget // self.depth
+                    tokens_global, new_kv, _ = global_block(
+                        tokens_global,
+                        rope_tables=rope_tables,
+                        positions=positions_b_sp,
+                        attn_mask=None,
+                        past_kv=past_kvs[b],
+                        use_cache=True,
+                        cache_budget=per_block_budget,
+                        num_anchor_tokens=P,
+                    )
+                else:
+                    tokens_global, new_kv = global_block(
+                        tokens_global,
+                        rope_tables=rope_tables,
+                        positions=positions_b_sp,
+                        attn_mask=None,
+                        past_kv=past_kvs[b],
+                        use_cache=True,
+                    )
                 new_past_kvs.append(new_kv)
             else:
                 tokens_global = global_block(

--- a/modules/vggt/jax/aggregator.py
+++ b/modules/vggt/jax/aggregator.py
@@ -82,6 +82,28 @@ def _make_causal_global_mask(S: int, P: int, dtype=jnp.float32) -> jnp.ndarray:
     return future.astype(dtype) * jnp.finfo(dtype).min
 
 
+def _calculate_dynamic_budgets(
+    last_scores: jnp.ndarray, total_budget: int
+) -> jnp.ndarray:
+    """Port of ``aggregator._calculate_dynamic_budgets``.
+
+    Blocks that evicted high-similarity tokens last frame (high
+    ``last_scores``) have low "diversity" and receive a smaller share of
+    the global budget. The per-block budget is ``softmax(2*(1-score)) *
+    total_budget`` truncated to int.
+
+    When ``last_scores`` is all zeros (initial state / no eviction yet),
+    softmax of a constant vector is uniform, giving every block an equal
+    slice of the budget — which recovers the Step 6b uniform allocation.
+    """
+    total_budget = max(int(total_budget), 0)
+    diversity = 1.0 - last_scores
+    scaled = diversity / 0.5
+    proportions = jax.nn.softmax(scaled, axis=0)
+    budgets = proportions * total_budget
+    return budgets.astype(jnp.int32)
+
+
 class Aggregator(nn.Module):
     """Alternating frame/global attention tower (no-cache path).
 
@@ -120,6 +142,7 @@ class Aggregator(nn.Module):
         past_kvs: list | None = None,
         past_frame_idx: int = 0,
         total_budget: int | None = None,
+        last_scores: jnp.ndarray | None = None,
     ):
         """Forward pass.
 
@@ -135,13 +158,17 @@ class Aggregator(nn.Module):
                 stream. Used to pick the first-frame vs other-frames camera/
                 register token slot.
             total_budget: Optional global cache size shared across all global
-                blocks. In Step 6b (uniform allocation), each block receives
-                ``total_budget // depth`` slots. None disables eviction —
-                cache grows unboundedly.
+                blocks. Per-block budget is ``softmax(2*(1-last_scores)) *
+                total_budget`` (Step 6c dynamic allocation). When
+                ``last_scores`` is zeros, this reduces to the uniform
+                allocation of Step 6b. ``None`` disables eviction entirely.
+            last_scores: Optional (depth,) fp32 array of cosine-similarity
+                means from the prior call's eviction. Zeros on first frame.
 
         Returns:
-            No-cache:  (output_list, patch_start_idx).
-            Cache:     (output_list, patch_start_idx, new_past_kvs).
+            No-cache:  ``(output_list, patch_start_idx)``.
+            Cache:     ``(output_list, patch_start_idx, new_past_kvs,
+                          new_last_scores)``.
         """
         B, S, C_in, H, W = images.shape
         if C_in != 3:
@@ -158,6 +185,15 @@ class Aggregator(nn.Module):
             raise ValueError(
                 f"past_kvs length {len(past_kvs)} != depth {self.depth}"
             )
+        if use_cache and last_scores is None:
+            last_scores = jnp.zeros((self.depth,), dtype=jnp.float32)
+        # Per-block budgets — uniform on the first-eviction step (zeros
+        # in, uniform softmax out), dynamic after last_scores updates.
+        current_budgets = (
+            _calculate_dynamic_budgets(last_scores, total_budget)
+            if use_cache and total_budget is not None
+            else None
+        )
 
         # ResNet normalisation on [0, 1] images.
         mean = jnp.asarray(_RESNET_MEAN, dtype=images.dtype).reshape(1, 1, 3, 1, 1)
@@ -247,6 +283,8 @@ class Aggregator(nn.Module):
 
         output_list: list[jnp.ndarray] = []
         new_past_kvs: list = [] if use_cache else []
+        new_scores: list = []  # per-block scores used to update last_scores
+        any_evicted = False
         # In the reference, aa_block_size defaults to 1 so each outer step
         # runs exactly one frame-block then one global-block. depth == aa_block_num.
         for b in range(self.depth):
@@ -279,12 +317,10 @@ class Aggregator(nn.Module):
                 name=f"global_blocks_{b}",
             )
             if use_cache:
-                if total_budget is not None:
-                    # Uniform per-block budget in Step 6b (dynamic allocation
-                    # lands in 6c). Anchors = the first frame's P tokens; they
-                    # are never evicted.
-                    per_block_budget = total_budget // self.depth
-                    tokens_global, new_kv, _ = global_block(
+                if current_budgets is not None:
+                    # Anchors = the first frame's P tokens; never evicted.
+                    per_block_budget = int(current_budgets[b])
+                    tokens_global, new_kv, scores = global_block(
                         tokens_global,
                         rope_tables=rope_tables,
                         positions=positions_b_sp,
@@ -294,6 +330,11 @@ class Aggregator(nn.Module):
                         cache_budget=per_block_budget,
                         num_anchor_tokens=P,
                     )
+                    if scores is not None:
+                        new_scores.append(scores)
+                        any_evicted = True
+                    else:
+                        new_scores.append(last_scores[b])
                 else:
                     tokens_global, new_kv = global_block(
                         tokens_global,
@@ -320,5 +361,13 @@ class Aggregator(nn.Module):
             output_list.append(jnp.concatenate([frame_inter, global_inter], axis=-1))
 
         if use_cache:
-            return output_list, patch_start_idx, new_past_kvs
+            # Reference updates self.last_scores only when something was
+            # evicted this frame; otherwise the previous state carries.
+            if any_evicted:
+                new_last_scores = jnp.stack(
+                    [jnp.asarray(s, dtype=jnp.float32) for s in new_scores]
+                )
+            else:
+                new_last_scores = last_scores
+            return output_list, patch_start_idx, new_past_kvs, new_last_scores
         return output_list, patch_start_idx

--- a/modules/vggt/jax/aggregator.py
+++ b/modules/vggt/jax/aggregator.py
@@ -1,0 +1,234 @@
+"""Aggregator — alternating frame/global attention over S frames.
+
+Mirrors ``streamvggt.models.aggregator.Aggregator`` for the **no-cache** path
+(``use_cache=False`` in the reference). The cache/eviction/dynamic-budget
+branches land in Step 6a+.
+
+Forward pipeline:
+    images (B, S, 3, H, W) in [0, 1]
+      -> ResNet normalise
+      -> (B*S, 3, H, W) patch conv via DinoV2Backbone
+      -> prepend camera_token + register_token per frame (slice-expand-flatten)
+      -> 24 alternating (frame, global) block pairs
+      -> output_list: [(B, S, P, 2*C)] * depth  +  patch_start_idx = 5
+
+Each global block in the no-cache path uses a per-block causal mask over
+``S * P`` tokens (frame i attends only to frames 0..i).
+"""
+
+from __future__ import annotations
+
+import flax.linen as nn
+import jax
+import jax.numpy as jnp
+
+from modules.vggt.jax.backbone import DinoV2Backbone
+from modules.vggt.jax.block import Block
+from modules.vggt.jax.rope import compute_1d_rope_tables
+
+
+# Frozen ResNet statistics used by the reference (aggregator.py:20-21).
+_RESNET_MEAN = (0.485, 0.456, 0.406)
+_RESNET_STD = (0.229, 0.224, 0.225)
+
+
+def _slice_expand_and_flatten(token_tensor: jnp.ndarray, B: int, S: int) -> jnp.ndarray:
+    """Port of ``aggregator.slice_expand_and_flatten``.
+
+    token_tensor: (1, 2, X, C). First slice is used for frame 0, second for
+    frames 1..S-1. Output: (B*S, X, C).
+    """
+    _, _, X, C = token_tensor.shape
+    query = jnp.broadcast_to(token_tensor[:, 0:1], (B, 1, X, C))
+    if S > 1:
+        others = jnp.broadcast_to(token_tensor[:, 1:2], (B, S - 1, X, C))
+        combined = jnp.concatenate([query, others], axis=1)
+    else:
+        combined = query
+    return combined.reshape(B * S, X, C)
+
+
+def _make_position_grid(
+    B: int, S: int, grid_h: int, grid_w: int, patch_start_idx: int
+) -> jnp.ndarray:
+    """Build positions like ``PositionGetter`` + aggregator's +1 shift.
+
+    Output: (B*S, P, 2) where P = patch_start_idx + grid_h*grid_w. Special
+    tokens (camera + register) get position 0; patch tokens get (y+1, x+1).
+    """
+    ys, xs = jnp.meshgrid(jnp.arange(grid_h), jnp.arange(grid_w), indexing="ij")
+    patch_pos = jnp.stack([ys.reshape(-1), xs.reshape(-1)], axis=-1)  # (P_patch, 2)
+    patch_pos = patch_pos + 1
+    patch_pos = jnp.broadcast_to(patch_pos, (B * S, patch_pos.shape[0], 2))
+    special = jnp.zeros((B * S, patch_start_idx, 2), dtype=patch_pos.dtype)
+    return jnp.concatenate([special, patch_pos], axis=1)
+
+
+def _make_causal_global_mask(S: int, P: int, dtype=jnp.float32) -> jnp.ndarray:
+    """Per-block causal frame mask for global attention over S*P tokens.
+
+    Token at position k belongs to frame ``k // P``. Future frames are masked
+    with ``finfo(dtype).min`` additive (pre-softmax). Returns (S*P, S*P) which
+    broadcasts against (B, H, L, L) attention scores.
+    """
+    L = S * P
+    frame_ids = jnp.arange(L) // P
+    future = frame_ids[:, None] < frame_ids[None, :]
+    return future.astype(dtype) * jnp.finfo(dtype).min
+
+
+class Aggregator(nn.Module):
+    """Alternating frame/global attention tower (no-cache path).
+
+    Attributes:
+        img_size: Fixed input side length (518 for thesis).
+        patch_size: Patch conv stride (14).
+        embed_dim: Token feature dim (1024).
+        depth: Number of (frame, global) block pairs (24).
+        num_heads: Attention heads (16).
+        mlp_ratio: MLP expansion factor (4).
+        num_register_tokens: Register tokens prepended per frame (4).
+        init_values: LayerScale init for aggregator blocks (0.01).
+        norm_eps: LayerNorm epsilon used by frame/global blocks (1e-5).
+        rope_freq: 2D RoPE base frequency (100.0).
+        aa_order: Tuple of attention types; defaults to ("frame", "global").
+    """
+
+    img_size: int = 518
+    patch_size: int = 14
+    embed_dim: int = 1024
+    depth: int = 24
+    num_heads: int = 16
+    mlp_ratio: float = 4.0
+    num_register_tokens: int = 4
+    init_values: float = 0.01
+    norm_eps: float = 1e-5
+    rope_freq: float = 100.0
+    aa_order: tuple[str, ...] = ("frame", "global")
+
+    @nn.compact
+    def __call__(self, images: jnp.ndarray) -> tuple[list[jnp.ndarray], int]:
+        """Forward pass.
+
+        Args:
+            images: (B, S, 3, H, W) float in [0, 1].
+
+        Returns:
+            (output_list, patch_start_idx) where output_list has ``depth``
+            tensors of shape (B, S, P, 2*embed_dim) and patch_start_idx = 5.
+        """
+        B, S, C_in, H, W = images.shape
+        if C_in != 3:
+            raise ValueError(f"expected 3 input channels, got {C_in}")
+        if H != self.img_size or W != self.img_size:
+            raise NotImplementedError(
+                f"Aggregator is fixed at {self.img_size}x{self.img_size}; got {H}x{W}."
+            )
+
+        # ResNet normalisation on [0, 1] images.
+        mean = jnp.asarray(_RESNET_MEAN, dtype=images.dtype).reshape(1, 1, 3, 1, 1)
+        std = jnp.asarray(_RESNET_STD, dtype=images.dtype).reshape(1, 1, 3, 1, 1)
+        images = (images - mean) / std
+
+        # Flatten batch/frame for patch conv.
+        x = images.reshape(B * S, C_in, H, W)
+        patch_tokens = DinoV2Backbone(
+            img_size=self.img_size,
+            patch_size=self.patch_size,
+            embed_dim=self.embed_dim,
+            depth=24,
+            num_heads=16,
+            mlp_ratio=4.0,
+            num_register_tokens=self.num_register_tokens,
+            init_values=1.0,  # DINOv2 default
+            norm_eps=1e-6,     # DINOv2 override
+            name="patch_embed",
+        )(x)
+        # (B*S, P_patch, embed_dim) where P_patch = (H/patch_size)^2
+        P_patch = patch_tokens.shape[1]
+
+        # Camera + register tokens (aggregator-level).
+        camera_token_full = self.param(
+            "camera_token",
+            lambda _k, shape: jnp.zeros(shape, dtype=jnp.float32),
+            (1, 2, 1, self.embed_dim),
+        )
+        register_token_full = self.param(
+            "register_token",
+            lambda _k, shape: jnp.zeros(shape, dtype=jnp.float32),
+            (1, 2, self.num_register_tokens, self.embed_dim),
+        )
+        camera = _slice_expand_and_flatten(camera_token_full.astype(patch_tokens.dtype), B, S)
+        register = _slice_expand_and_flatten(
+            register_token_full.astype(patch_tokens.dtype), B, S
+        )
+        tokens = jnp.concatenate([camera, register, patch_tokens], axis=1)
+        P = tokens.shape[1]
+        patch_start_idx = 1 + self.num_register_tokens  # 5
+
+        # Positions + RoPE tables (precomputed for fixed 37x37 grid).
+        grid = self.img_size // self.patch_size
+        positions_bs_p = _make_position_grid(B, S, grid, grid, patch_start_idx)  # (B*S, P, 2)
+        head_dim = self.embed_dim // self.num_heads
+        cos_t, sin_t = compute_1d_rope_tables(
+            dim=head_dim // 2,
+            max_pos=grid + 1,  # patches shifted to [1, grid+1)
+            frequency=self.rope_freq,
+            dtype=jnp.float32,
+        )
+        rope_tables = (cos_t, sin_t)
+
+        # Precompute per-block causal mask for global attention (S*P length).
+        global_mask = _make_causal_global_mask(S, P, dtype=jnp.float32)
+
+        # Pre-reshape helpers
+        def _to_frame(t):  # (B, S, P, C) -> (B*S, P, C)
+            return t.reshape(B * S, P, self.embed_dim)
+
+        def _to_global(t_flat):  # (B*S, P, C) -> (B, S*P, C)
+            return t_flat.reshape(B, S, P, self.embed_dim).reshape(B, S * P, self.embed_dim)
+
+        positions_b_sp = positions_bs_p.reshape(B, S, P, 2).reshape(B, S * P, 2)
+
+        output_list: list[jnp.ndarray] = []
+        # In the reference, aa_block_size defaults to 1 so each outer step
+        # runs exactly one frame-block then one global-block. depth == aa_block_num.
+        for b in range(self.depth):
+            # ---- Frame attention: (B*S, P, C) ----
+            tokens_frame = _to_frame(tokens) if tokens.shape == (B, S * P, self.embed_dim) else tokens
+            tokens_frame = Block(
+                dim=self.embed_dim,
+                num_heads=self.num_heads,
+                mlp_ratio=self.mlp_ratio,
+                qk_norm=True,
+                init_values=self.init_values,
+                norm_eps=self.norm_eps,
+                name=f"frame_blocks_{b}",
+            )(tokens_frame, rope_tables=rope_tables, positions=positions_bs_p)
+            frame_inter = tokens_frame.reshape(B, S, P, self.embed_dim)
+
+            # ---- Global attention: (B, S*P, C) ----
+            tokens_global = _to_global(tokens_frame)
+            tokens_global = Block(
+                dim=self.embed_dim,
+                num_heads=self.num_heads,
+                mlp_ratio=self.mlp_ratio,
+                qk_norm=True,
+                init_values=self.init_values,
+                norm_eps=self.norm_eps,
+                name=f"global_blocks_{b}",
+            )(
+                tokens_global,
+                rope_tables=rope_tables,
+                positions=positions_b_sp,
+                attn_mask=global_mask,
+            )
+            global_inter = tokens_global.reshape(B, S, P, self.embed_dim)
+
+            # Carry for next iteration (flat-frame layout).
+            tokens = _to_frame(global_inter)
+
+            # Each level emits concat([frame, global], axis=-1) -> (B, S, P, 2C).
+            output_list.append(jnp.concatenate([frame_inter, global_inter], axis=-1))
+
+        return output_list, patch_start_idx

--- a/modules/vggt/jax/attention.py
+++ b/modules/vggt/jax/attention.py
@@ -1,0 +1,114 @@
+"""Attention with optional QK-norm and RoPE — no-cache forward path.
+
+Matches ``streamvggt.layers.attention.Attention`` in the no-cache branch:
+QKV-packed Linear, optional per-head LayerNorm on Q and K, optional 2D RoPE
+on Q and K, manual softmax in fp32, output projection.
+
+The KV-cache path (eviction, anchor tokens, dynamic budgets) lands in
+Step 6a+; for now ``use_cache=True`` raises NotImplementedError.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import flax.linen as nn
+import jax
+import jax.numpy as jnp
+
+from modules.vggt.jax.rope import apply_rope_2d
+
+
+# Per-head LayerNorm on Q and K uses PyTorch's default eps=1e-5.
+# Outer block's norm1 / norm2 may use a different eps (1e-6 for DINOv2) and
+# is configured on the Block, not here.
+_QK_NORM_EPS = 1e-5
+
+
+class Attention(nn.Module):
+    """Multi-head attention without cache.
+
+    Attributes:
+        dim: Token feature dimension.
+        num_heads: Number of attention heads. ``dim`` must be divisible by it.
+        qk_norm: If True, apply LayerNorm to Q and K (per-head, on head_dim).
+        qkv_bias: Whether QKV Linear has a bias term.
+        proj_bias: Whether the output projection Linear has a bias term.
+        softmax_dtype: Precision used for the attention-score softmax.
+            Defaults to fp32 to match PyTorch's ``F.scaled_dot_product_attention``
+            semantics even when inputs are bf16.
+    """
+
+    dim: int
+    num_heads: int
+    qk_norm: bool = False
+    qkv_bias: bool = True
+    proj_bias: bool = True
+    softmax_dtype: Any = jnp.float32
+
+    @nn.compact
+    def __call__(
+        self,
+        x: jnp.ndarray,
+        *,
+        rope_tables: tuple[jnp.ndarray, jnp.ndarray] | None = None,
+        positions: jnp.ndarray | None = None,
+        attn_mask: jnp.ndarray | None = None,
+        use_cache: bool = False,
+    ) -> jnp.ndarray:
+        """Forward pass.
+
+        Args:
+            x: (B, N, dim) input tokens.
+            rope_tables: Optional (cos, sin) pair for 2D RoPE.
+            positions: (B, N, 2) integer positions; required iff rope_tables given.
+            attn_mask: Optional additive attention mask broadcastable to (B, H, N, N).
+            use_cache: Must be False here; cache path lands in Step 6a.
+
+        Returns:
+            (B, N, dim) attended tokens.
+        """
+        if use_cache:
+            raise NotImplementedError("KV-cache path lands in Step 6a of the plan.")
+        if (rope_tables is None) != (positions is None):
+            raise ValueError("rope_tables and positions must be given together.")
+
+        B, N, C = x.shape
+        if C != self.dim:
+            raise ValueError(f"input dim {C} != attention dim {self.dim}")
+        if self.dim % self.num_heads != 0:
+            raise ValueError(
+                f"dim {self.dim} not divisible by num_heads {self.num_heads}"
+            )
+        head_dim = self.dim // self.num_heads
+
+        qkv = nn.Dense(3 * self.dim, use_bias=self.qkv_bias, name="qkv")(x)
+        qkv = qkv.reshape(B, N, 3, self.num_heads, head_dim)
+        qkv = jnp.transpose(qkv, (2, 0, 3, 1, 4))  # (3, B, H, N, Dh)
+        q, k, v = qkv[0], qkv[1], qkv[2]
+
+        if self.qk_norm:
+            q = nn.LayerNorm(epsilon=_QK_NORM_EPS, name="q_norm")(q)
+            k = nn.LayerNorm(epsilon=_QK_NORM_EPS, name="k_norm")(k)
+
+        if rope_tables is not None:
+            cos_table, sin_table = rope_tables
+            q = apply_rope_2d(q, positions, cos_table, sin_table)
+            k = apply_rope_2d(k, positions, cos_table, sin_table)
+
+        # Manual attention with explicit fp32 softmax so bf16 inputs behave
+        # like PyTorch's F.scaled_dot_product_attention (which internally
+        # computes softmax in fp32).
+        orig_dtype = v.dtype
+        scale = jnp.asarray(1.0 / jnp.sqrt(head_dim), dtype=self.softmax_dtype)
+        q_hi = q.astype(self.softmax_dtype) * scale
+        k_hi = k.astype(self.softmax_dtype)
+        scores = jnp.einsum("bhqd,bhkd->bhqk", q_hi, k_hi)
+        if attn_mask is not None:
+            scores = scores + attn_mask.astype(self.softmax_dtype)
+        probs = jax.nn.softmax(scores, axis=-1).astype(orig_dtype)
+        out = jnp.einsum("bhqk,bhkd->bhqd", probs, v)  # (B, H, N, Dh)
+
+        out = jnp.transpose(out, (0, 2, 1, 3)).reshape(B, N, self.dim)
+        out = nn.Dense(self.dim, use_bias=self.proj_bias, name="proj")(out)
+        return out

--- a/modules/vggt/jax/attention.py
+++ b/modules/vggt/jax/attention.py
@@ -1,18 +1,16 @@
-"""Attention with optional QK-norm, 2D RoPE, KV-cache + eviction (Step 6b).
+"""Attention with optional QK-norm, 2D RoPE, KV-cache + eviction.
 
 Matches ``streamvggt.layers.attention.Attention``:
 QKV-packed Linear, optional per-head LayerNorm on Q and K, optional 2D RoPE
 on Q and K, manual softmax in fp32, output projection.
 
 Cache semantics:
-* ``past_kv`` = ``(past_k, past_v)`` from the previous call (already
-  RoPE-applied). Concatenated with the current frame's new K/V before
-  attention.
-* If ``cache_budget`` is given and the concatenated cache exceeds it, the
-  first ``num_anchor_tokens`` entries are preserved as anchors and the
-  remaining candidates are pruned down by cosine-similarity-to-mean
-  scoring (least-similar are retained — "diverse" tokens beat "redundant"
-  ones). Dynamic per-block budget allocation lands in Step 6c.
+* Legacy 2-tuple ``past_kv = (past_k, past_v)``: variable-length concat +
+  compact eviction, manual einsum+softmax. Kept for no-cache parity tests.
+* Padded 3-tuple ``past_kv = (k_pad, v_pad, valid_len)``:
+  ``k_pad, v_pad`` shape ``(B, H, MAX, Dh)`` fixed, ``valid_len`` int32 scalar.
+  Eviction writes back with ``dynamic_update_slice_in_dim``; attention uses
+  ``jax.nn.dot_product_attention`` with ``-inf`` bias over padded slots.
 """
 
 from __future__ import annotations
@@ -26,12 +24,7 @@ import jax.numpy as jnp
 from modules.vggt.jax.rope import apply_rope_2d
 
 
-# Per-head LayerNorm on Q and K uses PyTorch's default eps=1e-5.
-# Outer block's norm1 / norm2 may use a different eps (1e-6 for DINOv2) and
-# is configured on the Block, not here.
 _QK_NORM_EPS = 1e-5
-
-# torch.nn.functional.normalize default eps.
 _L2_NORMALIZE_EPS = 1e-12
 
 
@@ -41,18 +34,13 @@ def _evict_kv(
     cache_budget: int,
     num_anchor_tokens: int,
 ) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray | None]:
-    """Port of ``streamvggt.layers.attention.Attention.eviction``.
+    """Port of ``streamvggt.layers.attention.Attention.eviction`` (legacy path).
 
     If ``k.shape[2] <= cache_budget``: no-op, returns ``(k, v, None)``.
 
     Otherwise: keeps the first ``num_anchor_tokens`` as anchors and prunes
     the remaining candidates to ``cache_budget - num_anchor_tokens`` by
-    cosine-similarity-to-mean scoring. The tokens with the LOWEST similarity
-    to the candidate mean are retained (they carry the most unique
-    information); high-similarity tokens are redundant and evicted.
-
-    Returns the updated ``(k, v)`` plus a scalar ``avg_scores`` used by the
-    dynamic-budget allocator (Step 6c).
+    cosine-similarity-to-mean scoring. Lowest-similarity tokens are retained.
     """
     B, H, N, D = k.shape
     if N <= cache_budget:
@@ -69,18 +57,14 @@ def _evict_kv(
     anchor_k, cand_k = k[:, :, :n_anchor], k[:, :, n_anchor:]
     anchor_v, cand_v = v[:, :, :n_anchor], v[:, :, n_anchor:]
 
-    # L2-normalize candidates (matches torch.nn.functional.normalize dim=-1).
     norm = jnp.linalg.norm(cand_k, axis=-1, keepdims=True)
     cand_k_norm = cand_k / jnp.maximum(norm, _L2_NORMALIZE_EPS)
 
-    # Score = cos-sim to mean candidate direction.
-    mean_vec = jnp.mean(cand_k_norm, axis=2, keepdims=True)  # (B, H, 1, D)
-    scores = jnp.sum(cand_k_norm * mean_vec, axis=-1)  # (B, H, n_cand)
+    mean_vec = jnp.mean(cand_k_norm, axis=2, keepdims=True)
+    scores = jnp.sum(cand_k_norm * mean_vec, axis=-1)
     avg_scores = jnp.mean(scores)
 
-    # Keep lowest-similarity (most diverse) candidates. top_k on -scores.
-    _, top_idx = jax.lax.top_k(-scores, n_keep)  # (B, H, n_keep)
-    # PyTorch sorts indices ascending to keep temporal order stable.
+    _, top_idx = jax.lax.top_k(-scores, n_keep)
     top_idx = jnp.sort(top_idx, axis=-1)
 
     gather_idx = jnp.broadcast_to(top_idx[..., None], (B, H, n_keep, D))
@@ -92,19 +76,79 @@ def _evict_kv(
     return final_k, final_v, avg_scores
 
 
-class Attention(nn.Module):
-    """Multi-head attention without cache.
+def _padded_evict(
+    k_pad: jnp.ndarray,
+    v_pad: jnp.ndarray,
+    valid_len: jnp.ndarray,
+    cache_budget: int,
+    num_anchor_tokens: int,
+) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    """Evict inside the padded cache. Returns (k_pad, v_pad, new_valid_len, score).
 
-    Attributes:
-        dim: Token feature dimension.
-        num_heads: Number of attention heads. ``dim`` must be divisible by it.
-        qk_norm: If True, apply LayerNorm to Q and K (per-head, on head_dim).
-        qkv_bias: Whether QKV Linear has a bias term.
-        proj_bias: Whether the output projection Linear has a bias term.
-        softmax_dtype: Precision used for the attention-score softmax.
-            Defaults to fp32 to match PyTorch's ``F.scaled_dot_product_attention``
-            semantics even when inputs are bf16.
+    ``score`` is the fp32 mean of cosine similarities over valid candidates
+    (matches the legacy ``_evict_kv`` semantics, sans the batch/head reduction
+    behaviour: both implementations take ``jnp.mean`` over all elements).
     """
+    B, H, MAX, Dh = k_pad.shape
+    n_anchor = num_anchor_tokens
+    n_keep = cache_budget - n_anchor
+    if n_keep <= 0:
+        raise ValueError(
+            f"cache_budget ({cache_budget}) must exceed num_anchor_tokens "
+            f"({num_anchor_tokens})"
+        )
+
+    anchor_k = k_pad[:, :, :n_anchor]
+    anchor_v = v_pad[:, :, :n_anchor]
+    cand_k = k_pad[:, :, n_anchor:]
+    cand_v = v_pad[:, :, n_anchor:]
+    n_cand_max = MAX - n_anchor
+
+    slot_idx = jnp.arange(n_cand_max, dtype=jnp.int32)
+    cand_valid = slot_idx < (valid_len - n_anchor)  # (n_cand_max,)
+
+    norm = jnp.linalg.norm(cand_k, axis=-1, keepdims=True)
+    cand_k_norm = cand_k / jnp.maximum(norm, _L2_NORMALIZE_EPS)
+    valid_f = cand_valid.astype(cand_k_norm.dtype)
+    # Mean vector restricted to valid slots.
+    valid_count = jnp.maximum(jnp.sum(valid_f), 1.0)
+    mean_vec = (
+        jnp.sum(cand_k_norm * valid_f[None, None, :, None], axis=2, keepdims=True)
+        / valid_count
+    )
+    scores = jnp.sum(cand_k_norm * mean_vec, axis=-1)
+    # Match legacy jnp.mean(scores) semantics: mean over valid candidates only
+    # (reference code does mean over the full candidate region, which for a
+    # compact 2-tuple is the valid region — here the valid region equals what
+    # that would be in the compact form).
+    score_sum = jnp.sum(scores * valid_f[None, None, :])
+    total_count = valid_count * B * H
+    evict_score = (score_sum / jnp.maximum(total_count, 1.0)).astype(jnp.float32)
+
+    # Invalid slots get +inf so top_k(-scores) avoids them.
+    scores_masked = jnp.where(cand_valid[None, None, :], scores, jnp.inf)
+
+    _, top_idx = jax.lax.top_k(-scores_masked, n_keep)  # (B, H, n_keep)
+    top_idx = jnp.sort(top_idx, axis=-1)
+
+    gather_idx = jnp.broadcast_to(top_idx[..., None], (B, H, n_keep, Dh))
+    kept_cand_k = jnp.take_along_axis(cand_k, gather_idx, axis=2)
+    kept_cand_v = jnp.take_along_axis(cand_v, gather_idx, axis=2)
+
+    # Write back: anchors at [0, n_anchor), kept candidates at
+    # [n_anchor, n_anchor + n_keep), zero out the rest.
+    k_pad_out = jnp.zeros_like(k_pad)
+    v_pad_out = jnp.zeros_like(v_pad)
+    k_pad_out = jax.lax.dynamic_update_slice_in_dim(k_pad_out, anchor_k, 0, axis=2)
+    v_pad_out = jax.lax.dynamic_update_slice_in_dim(v_pad_out, anchor_v, 0, axis=2)
+    k_pad_out = jax.lax.dynamic_update_slice_in_dim(k_pad_out, kept_cand_k, n_anchor, axis=2)
+    v_pad_out = jax.lax.dynamic_update_slice_in_dim(v_pad_out, kept_cand_v, n_anchor, axis=2)
+    new_valid_len = jnp.asarray(n_anchor + n_keep, dtype=jnp.int32)
+    return k_pad_out, v_pad_out, new_valid_len, evict_score
+
+
+class Attention(nn.Module):
+    """Multi-head attention with optional cache."""
 
     dim: int
     num_heads: int
@@ -121,35 +165,11 @@ class Attention(nn.Module):
         rope_tables: tuple[jnp.ndarray, jnp.ndarray] | None = None,
         positions: jnp.ndarray | None = None,
         attn_mask: jnp.ndarray | None = None,
-        past_kv: tuple[jnp.ndarray, jnp.ndarray] | None = None,
+        past_kv: tuple | None = None,
         use_cache: bool = False,
         cache_budget: int | None = None,
         num_anchor_tokens: int = 0,
     ):
-        """Forward pass.
-
-        Args:
-            x: (B, N, dim) input tokens (the *new* frame's tokens when caching).
-            rope_tables: Optional (cos, sin) pair for 2D RoPE.
-            positions: (B, N, 2) integer positions; required iff rope_tables given.
-                In cache mode, these are the positions of the new frame only;
-                past_kv already has RoPE applied from prior calls.
-            attn_mask: Optional additive attention mask broadcastable to
-                (B, H, N, K) where K = past_len + N.
-            past_kv: Optional (past_k, past_v), both shape (B, H, past_len, Dh),
-                returned by the previous call. Prepended to the new K/V.
-            use_cache: If True, return ``(output, (full_k, full_v))`` — or
-                ``(output, (full_k, full_v), avg_scores_or_None)`` if
-                ``cache_budget`` is provided.
-            cache_budget: Optional int. If set and the concatenated cache
-                exceeds this, low-diversity candidates are evicted down to
-                ``cache_budget`` tokens.
-            num_anchor_tokens: Number of leading cache entries that are
-                never evicted (typically the first frame's token count).
-
-        Returns:
-            Tensor, or tuple depending on flags (see ``use_cache``).
-        """
         if (rope_tables is None) != (positions is None):
             raise ValueError("rope_tables and positions must be given together.")
 
@@ -176,24 +196,27 @@ class Attention(nn.Module):
             q = apply_rope_2d(q, positions, cos_table, sin_table)
             k = apply_rope_2d(k, positions, cos_table, sin_table)
 
-        # Prepend cached past K/V (already RoPE-applied) to the new K/V.
+        is_padded_cache = (
+            past_kv is not None
+            and isinstance(past_kv, tuple)
+            and len(past_kv) == 3
+        )
+
+        if use_cache and is_padded_cache:
+            return self._padded_cache_forward(
+                q, k, v, past_kv, cache_budget, num_anchor_tokens, B, N
+            )
+
+        # --- Legacy path (no cache, or 2-tuple past_kv) ---
         if past_kv is not None:
             past_k, past_v = past_kv
             k = jnp.concatenate([past_k, k], axis=2)
             v = jnp.concatenate([past_v, v], axis=2)
 
-        # Optional eviction: prune the cache back to cache_budget tokens.
-        # ``evict_score`` is None when no eviction fired; otherwise a scalar
-        # cosine-similarity mean consumed by the dynamic-budget allocator.
-        # Named distinctly from the attention-score variable below — they are
-        # different quantities and shadowing caused a real bug.
         evict_score: jnp.ndarray | None = None
         if use_cache and cache_budget is not None and k.shape[2] > cache_budget:
             k, v, evict_score = _evict_kv(k, v, cache_budget, num_anchor_tokens)
 
-        # Manual attention with explicit fp32 softmax so bf16 inputs behave
-        # like PyTorch's F.scaled_dot_product_attention (which internally
-        # computes softmax in fp32).
         orig_dtype = v.dtype
         scale = jnp.asarray(1.0 / jnp.sqrt(head_dim), dtype=self.softmax_dtype)
         q_hi = q.astype(self.softmax_dtype) * scale
@@ -211,3 +234,89 @@ class Attention(nn.Module):
                 return out, (k, v), evict_score
             return out, (k, v)
         return out
+
+    def _padded_cache_forward(
+        self,
+        q: jnp.ndarray,
+        new_k: jnp.ndarray,
+        new_v: jnp.ndarray,
+        past_kv: tuple,
+        cache_budget: int | None,
+        num_anchor_tokens: int,
+        B: int,
+        N: int,
+    ):
+        """Padded-cache path: dynamic_update_slice writes + SDPA with bool mask."""
+        past_k_pad, past_v_pad, valid_len = past_kv
+        _, _, MAX, Dh = past_k_pad.shape
+        cache_dtype = past_k_pad.dtype  # honour whatever dtype the cache was allocated in
+
+        # 1. Append new K/V at offset valid_len (must match cache dtype).
+        k_pad = jax.lax.dynamic_update_slice_in_dim(
+            past_k_pad, new_k.astype(cache_dtype), valid_len, axis=2
+        )
+        v_pad = jax.lax.dynamic_update_slice_in_dim(
+            past_v_pad, new_v.astype(cache_dtype), valid_len, axis=2
+        )
+        new_valid_len = valid_len + N
+
+        # 2. Optional eviction.
+        did_evict = jnp.asarray(False)
+        evict_score_payload = jnp.asarray(0.0, dtype=jnp.float32)
+        if cache_budget is not None:
+            # Branch: if new_valid_len > cache_budget, evict; else passthrough.
+            def _do_evict(operand):
+                kp, vp, vl = operand
+                return _padded_evict(kp, vp, vl, cache_budget, num_anchor_tokens)
+
+            def _no_evict(operand):
+                kp, vp, vl = operand
+                return (kp, vp, vl, jnp.asarray(0.0, dtype=jnp.float32))
+
+            k_pad, v_pad, new_valid_len, evict_score_payload = jax.lax.cond(
+                new_valid_len > cache_budget,
+                _do_evict,
+                _no_evict,
+                operand=(k_pad, v_pad, new_valid_len),
+            )
+            did_evict = new_valid_len <= cache_budget  # after clamp: True iff eviction ran
+            # Note: the cleaner check is "new_valid_len_before > cache_budget".
+            # Recompute that:
+            # Actually we want did_evict = (valid_len + N > cache_budget).
+            # Compute from the original pre-cond values:
+            did_evict = (valid_len + N) > jnp.asarray(cache_budget, dtype=jnp.int32)
+
+        # 3. Attention via jax.nn.dot_product_attention with bool mask.
+        # Cast all inputs to cache_dtype (bf16 when the extractor uses bf16)
+        # so cuDNN flash attention can lower to its kernel.  Replace the
+        # explicit -inf bias with a bool mask (True = valid slot).
+        q_tnhd = jnp.transpose(q.astype(cache_dtype), (0, 2, 1, 3))  # (B, N, H, Dh)
+        k_tnhd = jnp.transpose(k_pad, (0, 2, 1, 3))  # (B, MAX, H, Dh) — already cache_dtype
+        v_tnhd = jnp.transpose(v_pad, (0, 2, 1, 3))
+
+        head_dim_f = float(q.shape[-1])
+        scale = 1.0 / head_dim_f ** 0.5
+
+        # Use key_value_seq_lengths to tell the XLA/cuDNN kernel how many
+        # K/V slots are valid — avoids materialising a (B,H,N,MAX) bias.
+        # Shape: (B,) int32 broadcast-safe for the batch dimension.
+        kv_len = jnp.broadcast_to(new_valid_len.reshape(1), (q.shape[0],)).astype(jnp.int32)
+        out_tnhd = jax.nn.dot_product_attention(
+            q_tnhd,
+            k_tnhd,
+            v_tnhd,
+            scale=scale,
+            is_causal=False,
+            key_value_seq_lengths=kv_len,
+        )
+        out = jnp.transpose(out_tnhd, (0, 2, 1, 3)).astype(q.dtype)
+        out = out.reshape(B, N, self.dim)
+        out = nn.Dense(self.dim, use_bias=self.proj_bias, name="proj")(out)
+
+        new_kv = (k_pad, v_pad, new_valid_len)
+        if cache_budget is not None:
+            # In padded-jit mode we can't use Python-None sentinels across
+            # compile boundaries, so return the score paired with a did_evict
+            # flag; the aggregator decodes with jnp.where.
+            return out, new_kv, (did_evict, evict_score_payload)
+        return out, new_kv

--- a/modules/vggt/jax/attention.py
+++ b/modules/vggt/jax/attention.py
@@ -318,8 +318,10 @@ class Attention(nn.Module):
                 scale=scale, is_causal=False,
                 mask=mask_xla, implementation='xla',
             )
-        out = jnp.transpose(out_tnhd, (0, 2, 1, 3)).astype(q.dtype)
-        out = out.reshape(B, N, self.dim)
+        # out_tnhd is already (B, N, H, Dh) from jax.nn.dot_product_attention;
+        # the legacy path's transpose is for its (B, H, N, Dh) einsum output —
+        # reapplying it here mixes heads across sequence positions.
+        out = out_tnhd.astype(q.dtype).reshape(B, N, self.dim)
         out = nn.Dense(self.dim, use_bias=self.proj_bias, name="proj")(out)
 
         new_kv = (k_pad, v_pad, new_valid_len)

--- a/modules/vggt/jax/attention.py
+++ b/modules/vggt/jax/attention.py
@@ -1,12 +1,18 @@
-"""Attention with optional QK-norm, 2D RoPE, and KV-cache (Step 6a).
+"""Attention with optional QK-norm, 2D RoPE, KV-cache + eviction (Step 6b).
 
 Matches ``streamvggt.layers.attention.Attention``:
 QKV-packed Linear, optional per-head LayerNorm on Q and K, optional 2D RoPE
 on Q and K, manual softmax in fp32, output projection.
 
-The 6a cache path concatenates ``past_kv`` (already RoPE-applied from the
-previous call) with the current frame's new K/V. No eviction — the cache
-grows each frame. Eviction / anchor-token bookkeeping lands in Step 6b.
+Cache semantics:
+* ``past_kv`` = ``(past_k, past_v)`` from the previous call (already
+  RoPE-applied). Concatenated with the current frame's new K/V before
+  attention.
+* If ``cache_budget`` is given and the concatenated cache exceeds it, the
+  first ``num_anchor_tokens`` entries are preserved as anchors and the
+  remaining candidates are pruned down by cosine-similarity-to-mean
+  scoring (least-similar are retained — "diverse" tokens beat "redundant"
+  ones). Dynamic per-block budget allocation lands in Step 6c.
 """
 
 from __future__ import annotations
@@ -24,6 +30,66 @@ from modules.vggt.jax.rope import apply_rope_2d
 # Outer block's norm1 / norm2 may use a different eps (1e-6 for DINOv2) and
 # is configured on the Block, not here.
 _QK_NORM_EPS = 1e-5
+
+# torch.nn.functional.normalize default eps.
+_L2_NORMALIZE_EPS = 1e-12
+
+
+def _evict_kv(
+    k: jnp.ndarray,
+    v: jnp.ndarray,
+    cache_budget: int,
+    num_anchor_tokens: int,
+) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray | None]:
+    """Port of ``streamvggt.layers.attention.Attention.eviction``.
+
+    If ``k.shape[2] <= cache_budget``: no-op, returns ``(k, v, None)``.
+
+    Otherwise: keeps the first ``num_anchor_tokens`` as anchors and prunes
+    the remaining candidates to ``cache_budget - num_anchor_tokens`` by
+    cosine-similarity-to-mean scoring. The tokens with the LOWEST similarity
+    to the candidate mean are retained (they carry the most unique
+    information); high-similarity tokens are redundant and evicted.
+
+    Returns the updated ``(k, v)`` plus a scalar ``avg_scores`` used by the
+    dynamic-budget allocator (Step 6c).
+    """
+    B, H, N, D = k.shape
+    if N <= cache_budget:
+        return k, v, None
+
+    n_anchor = num_anchor_tokens
+    n_keep = cache_budget - n_anchor
+    if n_keep <= 0:
+        raise ValueError(
+            f"cache_budget ({cache_budget}) must exceed num_anchor_tokens "
+            f"({num_anchor_tokens})"
+        )
+
+    anchor_k, cand_k = k[:, :, :n_anchor], k[:, :, n_anchor:]
+    anchor_v, cand_v = v[:, :, :n_anchor], v[:, :, n_anchor:]
+
+    # L2-normalize candidates (matches torch.nn.functional.normalize dim=-1).
+    norm = jnp.linalg.norm(cand_k, axis=-1, keepdims=True)
+    cand_k_norm = cand_k / jnp.maximum(norm, _L2_NORMALIZE_EPS)
+
+    # Score = cos-sim to mean candidate direction.
+    mean_vec = jnp.mean(cand_k_norm, axis=2, keepdims=True)  # (B, H, 1, D)
+    scores = jnp.sum(cand_k_norm * mean_vec, axis=-1)  # (B, H, n_cand)
+    avg_scores = jnp.mean(scores)
+
+    # Keep lowest-similarity (most diverse) candidates. top_k on -scores.
+    _, top_idx = jax.lax.top_k(-scores, n_keep)  # (B, H, n_keep)
+    # PyTorch sorts indices ascending to keep temporal order stable.
+    top_idx = jnp.sort(top_idx, axis=-1)
+
+    gather_idx = jnp.broadcast_to(top_idx[..., None], (B, H, n_keep, D))
+    kept_cand_k = jnp.take_along_axis(cand_k, gather_idx, axis=2)
+    kept_cand_v = jnp.take_along_axis(cand_v, gather_idx, axis=2)
+
+    final_k = jnp.concatenate([anchor_k, kept_cand_k], axis=2)
+    final_v = jnp.concatenate([anchor_v, kept_cand_v], axis=2)
+    return final_k, final_v, avg_scores
 
 
 class Attention(nn.Module):
@@ -57,7 +123,9 @@ class Attention(nn.Module):
         attn_mask: jnp.ndarray | None = None,
         past_kv: tuple[jnp.ndarray, jnp.ndarray] | None = None,
         use_cache: bool = False,
-    ) -> jnp.ndarray | tuple[jnp.ndarray, tuple[jnp.ndarray, jnp.ndarray]]:
+        cache_budget: int | None = None,
+        num_anchor_tokens: int = 0,
+    ):
         """Forward pass.
 
         Args:
@@ -70,10 +138,17 @@ class Attention(nn.Module):
                 (B, H, N, K) where K = past_len + N.
             past_kv: Optional (past_k, past_v), both shape (B, H, past_len, Dh),
                 returned by the previous call. Prepended to the new K/V.
-            use_cache: If True, return (output, (full_k, full_v)).
+            use_cache: If True, return ``(output, (full_k, full_v))`` — or
+                ``(output, (full_k, full_v), avg_scores_or_None)`` if
+                ``cache_budget`` is provided.
+            cache_budget: Optional int. If set and the concatenated cache
+                exceeds this, low-diversity candidates are evicted down to
+                ``cache_budget`` tokens.
+            num_anchor_tokens: Number of leading cache entries that are
+                never evicted (typically the first frame's token count).
 
         Returns:
-            (B, N, dim) attended tokens, optionally plus the updated cache tuple.
+            Tensor, or tuple depending on flags (see ``use_cache``).
         """
         if (rope_tables is None) != (positions is None):
             raise ValueError("rope_tables and positions must be given together.")
@@ -107,6 +182,13 @@ class Attention(nn.Module):
             k = jnp.concatenate([past_k, k], axis=2)
             v = jnp.concatenate([past_v, v], axis=2)
 
+        # Optional eviction: prune the cache back to cache_budget tokens.
+        # ``scores`` is None when no eviction fired; otherwise a scalar
+        # cosine-similarity mean consumed by the dynamic-budget allocator.
+        scores: jnp.ndarray | None = None
+        if use_cache and cache_budget is not None and k.shape[2] > cache_budget:
+            k, v, scores = _evict_kv(k, v, cache_budget, num_anchor_tokens)
+
         # Manual attention with explicit fp32 softmax so bf16 inputs behave
         # like PyTorch's F.scaled_dot_product_attention (which internally
         # computes softmax in fp32).
@@ -123,5 +205,7 @@ class Attention(nn.Module):
         out = jnp.transpose(out, (0, 2, 1, 3)).reshape(B, N, self.dim)
         out = nn.Dense(self.dim, use_bias=self.proj_bias, name="proj")(out)
         if use_cache:
+            if cache_budget is not None:
+                return out, (k, v), scores
             return out, (k, v)
         return out

--- a/modules/vggt/jax/attention.py
+++ b/modules/vggt/jax/attention.py
@@ -1,11 +1,12 @@
-"""Attention with optional QK-norm and RoPE — no-cache forward path.
+"""Attention with optional QK-norm, 2D RoPE, and KV-cache (Step 6a).
 
-Matches ``streamvggt.layers.attention.Attention`` in the no-cache branch:
+Matches ``streamvggt.layers.attention.Attention``:
 QKV-packed Linear, optional per-head LayerNorm on Q and K, optional 2D RoPE
 on Q and K, manual softmax in fp32, output projection.
 
-The KV-cache path (eviction, anchor tokens, dynamic budgets) lands in
-Step 6a+; for now ``use_cache=True`` raises NotImplementedError.
+The 6a cache path concatenates ``past_kv`` (already RoPE-applied from the
+previous call) with the current frame's new K/V. No eviction — the cache
+grows each frame. Eviction / anchor-token bookkeeping lands in Step 6b.
 """
 
 from __future__ import annotations
@@ -54,22 +55,26 @@ class Attention(nn.Module):
         rope_tables: tuple[jnp.ndarray, jnp.ndarray] | None = None,
         positions: jnp.ndarray | None = None,
         attn_mask: jnp.ndarray | None = None,
+        past_kv: tuple[jnp.ndarray, jnp.ndarray] | None = None,
         use_cache: bool = False,
-    ) -> jnp.ndarray:
+    ) -> jnp.ndarray | tuple[jnp.ndarray, tuple[jnp.ndarray, jnp.ndarray]]:
         """Forward pass.
 
         Args:
-            x: (B, N, dim) input tokens.
+            x: (B, N, dim) input tokens (the *new* frame's tokens when caching).
             rope_tables: Optional (cos, sin) pair for 2D RoPE.
             positions: (B, N, 2) integer positions; required iff rope_tables given.
-            attn_mask: Optional additive attention mask broadcastable to (B, H, N, N).
-            use_cache: Must be False here; cache path lands in Step 6a.
+                In cache mode, these are the positions of the new frame only;
+                past_kv already has RoPE applied from prior calls.
+            attn_mask: Optional additive attention mask broadcastable to
+                (B, H, N, K) where K = past_len + N.
+            past_kv: Optional (past_k, past_v), both shape (B, H, past_len, Dh),
+                returned by the previous call. Prepended to the new K/V.
+            use_cache: If True, return (output, (full_k, full_v)).
 
         Returns:
-            (B, N, dim) attended tokens.
+            (B, N, dim) attended tokens, optionally plus the updated cache tuple.
         """
-        if use_cache:
-            raise NotImplementedError("KV-cache path lands in Step 6a of the plan.")
         if (rope_tables is None) != (positions is None):
             raise ValueError("rope_tables and positions must be given together.")
 
@@ -96,6 +101,12 @@ class Attention(nn.Module):
             q = apply_rope_2d(q, positions, cos_table, sin_table)
             k = apply_rope_2d(k, positions, cos_table, sin_table)
 
+        # Prepend cached past K/V (already RoPE-applied) to the new K/V.
+        if past_kv is not None:
+            past_k, past_v = past_kv
+            k = jnp.concatenate([past_k, k], axis=2)
+            v = jnp.concatenate([past_v, v], axis=2)
+
         # Manual attention with explicit fp32 softmax so bf16 inputs behave
         # like PyTorch's F.scaled_dot_product_attention (which internally
         # computes softmax in fp32).
@@ -111,4 +122,6 @@ class Attention(nn.Module):
 
         out = jnp.transpose(out, (0, 2, 1, 3)).reshape(B, N, self.dim)
         out = nn.Dense(self.dim, use_bias=self.proj_bias, name="proj")(out)
+        if use_cache:
+            return out, (k, v)
         return out

--- a/modules/vggt/jax/attention.py
+++ b/modules/vggt/jax/attention.py
@@ -183,11 +183,13 @@ class Attention(nn.Module):
             v = jnp.concatenate([past_v, v], axis=2)
 
         # Optional eviction: prune the cache back to cache_budget tokens.
-        # ``scores`` is None when no eviction fired; otherwise a scalar
+        # ``evict_score`` is None when no eviction fired; otherwise a scalar
         # cosine-similarity mean consumed by the dynamic-budget allocator.
-        scores: jnp.ndarray | None = None
+        # Named distinctly from the attention-score variable below — they are
+        # different quantities and shadowing caused a real bug.
+        evict_score: jnp.ndarray | None = None
         if use_cache and cache_budget is not None and k.shape[2] > cache_budget:
-            k, v, scores = _evict_kv(k, v, cache_budget, num_anchor_tokens)
+            k, v, evict_score = _evict_kv(k, v, cache_budget, num_anchor_tokens)
 
         # Manual attention with explicit fp32 softmax so bf16 inputs behave
         # like PyTorch's F.scaled_dot_product_attention (which internally
@@ -196,16 +198,16 @@ class Attention(nn.Module):
         scale = jnp.asarray(1.0 / jnp.sqrt(head_dim), dtype=self.softmax_dtype)
         q_hi = q.astype(self.softmax_dtype) * scale
         k_hi = k.astype(self.softmax_dtype)
-        scores = jnp.einsum("bhqd,bhkd->bhqk", q_hi, k_hi)
+        attn_scores = jnp.einsum("bhqd,bhkd->bhqk", q_hi, k_hi)
         if attn_mask is not None:
-            scores = scores + attn_mask.astype(self.softmax_dtype)
-        probs = jax.nn.softmax(scores, axis=-1).astype(orig_dtype)
+            attn_scores = attn_scores + attn_mask.astype(self.softmax_dtype)
+        probs = jax.nn.softmax(attn_scores, axis=-1).astype(orig_dtype)
         out = jnp.einsum("bhqk,bhkd->bhqd", probs, v)  # (B, H, N, Dh)
 
         out = jnp.transpose(out, (0, 2, 1, 3)).reshape(B, N, self.dim)
         out = nn.Dense(self.dim, use_bias=self.proj_bias, name="proj")(out)
         if use_cache:
             if cache_budget is not None:
-                return out, (k, v), scores
+                return out, (k, v), evict_score
             return out, (k, v)
         return out

--- a/modules/vggt/jax/attention.py
+++ b/modules/vggt/jax/attention.py
@@ -297,10 +297,11 @@ class Attention(nn.Module):
         head_dim_f = float(q.shape[-1])
         scale = 1.0 / head_dim_f ** 0.5
 
-        # Use key_value_seq_lengths to tell the XLA/cuDNN kernel how many
-        # K/V slots are valid — avoids materialising a (B,H,N,MAX) bias.
-        # Shape: (B,) int32 broadcast-safe for the batch dimension.
-        kv_len = jnp.broadcast_to(new_valid_len.reshape(1), (q.shape[0],)).astype(jnp.int32)
+        # cuDNN flash attention with key_value_seq_lengths: tells cuDNN how
+        # many K/V slots are valid without materialising a (B,H,N,MAX) bias.
+        # Shape: (B,) int32 per-sample valid length.
+        B_dim = q_tnhd.shape[0]
+        kv_len = jnp.broadcast_to(new_valid_len.reshape(1), (B_dim,)).astype(jnp.int32)
         out_tnhd = jax.nn.dot_product_attention(
             q_tnhd,
             k_tnhd,
@@ -308,6 +309,7 @@ class Attention(nn.Module):
             scale=scale,
             is_causal=False,
             key_value_seq_lengths=kv_len,
+            implementation='cudnn',
         )
         out = jnp.transpose(out_tnhd, (0, 2, 1, 3)).astype(q.dtype)
         out = out.reshape(B, N, self.dim)

--- a/modules/vggt/jax/attention.py
+++ b/modules/vggt/jax/attention.py
@@ -302,15 +302,22 @@ class Attention(nn.Module):
         # Shape: (B,) int32 per-sample valid length.
         B_dim = q_tnhd.shape[0]
         kv_len = jnp.broadcast_to(new_valid_len.reshape(1), (B_dim,)).astype(jnp.int32)
-        out_tnhd = jax.nn.dot_product_attention(
-            q_tnhd,
-            k_tnhd,
-            v_tnhd,
-            scale=scale,
-            is_causal=False,
-            key_value_seq_lengths=kv_len,
-            implementation='cudnn',
-        )
+        # cuDNN flash supports only fp16/bf16/fp8. Fall back to XLA for fp32.
+        if q_tnhd.dtype in (jnp.bfloat16, jnp.float16):
+            out_tnhd = jax.nn.dot_product_attention(
+                q_tnhd, k_tnhd, v_tnhd,
+                scale=scale, is_causal=False,
+                key_value_seq_lengths=kv_len,
+                implementation='cudnn',
+            )
+        else:
+            pos = jnp.arange(MAX, dtype=jnp.int32)
+            mask_xla = (pos < new_valid_len).reshape(1, 1, 1, MAX)
+            out_tnhd = jax.nn.dot_product_attention(
+                q_tnhd, k_tnhd, v_tnhd,
+                scale=scale, is_causal=False,
+                mask=mask_xla, implementation='xla',
+            )
         out = jnp.transpose(out_tnhd, (0, 2, 1, 3)).astype(q.dtype)
         out = out.reshape(B, N, self.dim)
         out = nn.Dense(self.dim, use_bias=self.proj_bias, name="proj")(out)

--- a/modules/vggt/jax/backbone.py
+++ b/modules/vggt/jax/backbone.py
@@ -1,0 +1,172 @@
+"""DINOv2 ViT-L/14-reg backbone — the Aggregator's ``patch_embed`` module.
+
+Mirrors ``streamvggt.layers.vision_transformer.vit_large`` with
+``num_register_tokens=4`` and ``init_values=1.0`` (the defaults passed by
+``Aggregator.__build_patch_embed__``).
+
+**Fixed 518x518 input.** For the thesis, the aggregator always sees the
+full 518x518 frame. Since 518/14 = 37 exactly and the checkpoint's
+``pos_embed`` has 1+37*37=1370 slots, the PyTorch ``interpolate_pos_encoding``
+fast-path triggers (``npatch == N and w == h``) and returns ``pos_embed``
+unchanged. We therefore skip the bicubic-AA interpolation math entirely
+and add ``pos_embed`` as-is. Reintroducing interpolation for variable
+input sizes is a follow-up.
+
+**What we expose.** Like the PyTorch reference, the forward returns only
+the patch tokens (the normalized ``x_norm_patchtokens`` slice): cls and
+register tokens are dropped because the aggregator concatenates its own
+camera/register tokens downstream.
+
+Param tree matches ``modules/vggt/jax/weight_transfer.py``:
+    patch_embed/                       # DinoV2Backbone
+      cls_token                         # raw param (1, 1, 1024)
+      mask_token                        # raw param (1, 1024)  -- unused at inference
+      register_tokens                   # raw param (1, 4, 1024)
+      pos_embed                         # raw param (1, 1370, 1024)
+      norm/ {scale, bias}               # final LayerNorm (eps=1e-6)
+      patch_embed/                      # inner PatchEmbed
+        proj/ {kernel, bias}            # Conv2d 14x14 stride 14
+      blocks_0/ ... blocks_23/          # 24 ViT blocks (qk_norm=False, LayerScale init=1.0)
+"""
+
+from __future__ import annotations
+
+import flax.linen as nn
+import jax.numpy as jnp
+
+from modules.vggt.jax.block import Block
+
+
+# --------------------------------------------------------------------------- #
+#  Inner PatchEmbed (Conv2d 14x14 stride 14)
+# --------------------------------------------------------------------------- #
+
+
+class PatchEmbed(nn.Module):
+    """Conv-based patch embedding: (B, H, W, 3) -> (B, H/p, W/p, embed_dim)."""
+
+    embed_dim: int
+    patch_size: int
+
+    @nn.compact
+    def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
+        # x is already NHWC (caller transposed).
+        x = nn.Conv(
+            features=self.embed_dim,
+            kernel_size=(self.patch_size, self.patch_size),
+            strides=(self.patch_size, self.patch_size),
+            padding="VALID",
+            name="proj",
+        )(x)
+        return x
+
+
+# --------------------------------------------------------------------------- #
+#  DINOv2 ViT-L/14-reg backbone
+# --------------------------------------------------------------------------- #
+
+
+class DinoV2Backbone(nn.Module):
+    """DINOv2 ViT-L/14-reg frozen inference, fixed 518x518 input.
+
+    Forward: NCHW image in [0, 1] (after ResNet normalisation done upstream)
+    -> (B, num_patches, embed_dim) patch-token features.
+
+    Attributes match the config baked into ``Aggregator.__build_patch_embed__``
+    for ``patch_embed="dinov2_vitl14_reg"``: depth=24, embed_dim=1024,
+    num_heads=16, mlp_ratio=4, num_register_tokens=4, init_values=1.0.
+    qk_norm stays False (DINOv2 defaults).
+    """
+
+    img_size: int = 518
+    patch_size: int = 14
+    embed_dim: int = 1024
+    depth: int = 24
+    num_heads: int = 16
+    mlp_ratio: float = 4.0
+    num_register_tokens: int = 4
+    init_values: float = 1.0
+    norm_eps: float = 1e-6  # DINOv2 uses eps=1e-6 explicitly for norm1/norm2/norm
+
+    @nn.compact
+    def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
+        # Input: NCHW to match the PyTorch reference's calling convention.
+        # The caller (aggregator) passes ``images.reshape(B*S, C, H, W)``.
+        B, C, H, W = x.shape
+        if H != self.img_size or W != self.img_size:
+            raise NotImplementedError(
+                f"DinoV2Backbone is fixed at {self.img_size}x{self.img_size}; "
+                f"got {H}x{W}. Reintroducing bicubic-AA pos_embed interpolation "
+                "is a follow-up."
+            )
+        if C != 3:
+            raise ValueError(f"expected 3 input channels, got {C}")
+
+        # Declare all top-level params up front so they land in the param tree
+        # even when unused (mask_token is loaded but not used at inference).
+        cls_token = self.param(
+            "cls_token",
+            lambda _k, shape: jnp.zeros(shape, dtype=jnp.float32),
+            (1, 1, self.embed_dim),
+        )
+        _mask_token = self.param(  # noqa: F841 -- loaded from checkpoint, unused here
+            "mask_token",
+            lambda _k, shape: jnp.zeros(shape, dtype=jnp.float32),
+            (1, self.embed_dim),
+        )
+        register_tokens = self.param(
+            "register_tokens",
+            lambda _k, shape: jnp.zeros(shape, dtype=jnp.float32),
+            (1, self.num_register_tokens, self.embed_dim),
+        )
+        num_patches = (self.img_size // self.patch_size) ** 2
+        pos_embed = self.param(
+            "pos_embed",
+            lambda _k, shape: jnp.zeros(shape, dtype=jnp.float32),
+            (1, num_patches + 1, self.embed_dim),
+        )
+
+        # --- PatchEmbed (Conv2d 14x14 stride 14) ---
+        x_nhwc = jnp.transpose(x, (0, 2, 3, 1))  # NCHW -> NHWC
+        x = PatchEmbed(
+            embed_dim=self.embed_dim,
+            patch_size=self.patch_size,
+            name="patch_embed",
+        )(x_nhwc)
+        # (B, 37, 37, 1024) -> (B, 1369, 1024)
+        x = x.reshape(B, -1, self.embed_dim)
+
+        # --- prepend cls_token ---
+        cls = jnp.broadcast_to(cls_token, (B, 1, self.embed_dim)).astype(x.dtype)
+        x = jnp.concatenate([cls, x], axis=1)  # (B, 1+P, 1024)
+
+        # --- add pos_embed ---
+        # Reference fast-path: if npatch == N and square, return pos_embed as-is.
+        # Our fixed 518 input always satisfies this, so plain addition.
+        x = x + pos_embed.astype(x.dtype)
+
+        # --- insert register tokens between cls and patches ---
+        reg = jnp.broadcast_to(
+            register_tokens, (B, self.num_register_tokens, self.embed_dim)
+        ).astype(x.dtype)
+        x = jnp.concatenate([x[:, :1], reg, x[:, 1:]], axis=1)
+        # Now (B, 1 + num_register + num_patches, embed_dim) = (B, 1374, 1024)
+
+        # --- 24 ViT-L blocks (DINOv2 has qk_norm=False, LayerScale init=1.0) ---
+        for i in range(self.depth):
+            x = Block(
+                dim=self.embed_dim,
+                num_heads=self.num_heads,
+                mlp_ratio=self.mlp_ratio,
+                qk_norm=False,
+                init_values=self.init_values,
+                norm_eps=self.norm_eps,
+                name=f"blocks_{i}",
+            )(x)  # no rope for DINOv2
+
+        # --- final LayerNorm (eps=1e-6) ---
+        x = nn.LayerNorm(epsilon=self.norm_eps, name="norm")(x)
+
+        # Return patch tokens only: drop cls (index 0) and register tokens.
+        # This mirrors the reference's `x_norm_patchtokens` slice.
+        return x[:, 1 + self.num_register_tokens:]

--- a/modules/vggt/jax/benchmark_streaming.py
+++ b/modules/vggt/jax/benchmark_streaming.py
@@ -1,0 +1,171 @@
+"""Streaming latency benchmark: JAX vs PyTorch VGGTFeatureExtractor.
+
+Measures per-frame wall time and peak GPU memory for each backend over a
+set of sequence lengths (frames per episode). Each sequence starts with a
+fresh ``reset()`` so the cache builds up organically.
+
+Writes a CSV to ``output/comparison/vggt_streaming_<timestamp>.csv`` with
+columns ``backend, n_frames, mean_latency_ms, median_latency_ms,
+peak_mem_mb``.
+
+v1 runs both backends in their default production settings
+(PyTorch: bf16 autocast; JAX: eager fp32). Future work: add --jit and
+--bf16 flags for JAX and compare against PyTorch compile=True.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import time
+from pathlib import Path
+
+import numpy as np
+
+
+DEFAULT_SEQ_LENS = (10, 50, 100)
+WARMUP_FRAMES = 3
+
+
+def _make_frame(seed: int, size: int = 518) -> np.ndarray:
+    """Synthetic CHW uint8 RGB frame."""
+    rng = np.random.RandomState(seed)
+    return rng.randint(0, 256, size=(3, size, size), dtype=np.uint8)
+
+
+def bench_pytorch(n_frames: int) -> dict:
+    """Benchmark the PyTorch extractor over ``n_frames`` with fresh cache."""
+    import torch
+
+    from modules.vggt.feature_extractor import VGGTFeatureExtractor
+
+    ext = VGGTFeatureExtractor(device="cuda")
+
+    # Warmup.
+    ext.reset()
+    for i in range(WARMUP_FRAMES):
+        ext.extract(_make_frame(i))
+    torch.cuda.synchronize()
+
+    ext.reset()
+    torch.cuda.reset_peak_memory_stats()
+    latencies = []
+    for i in range(n_frames):
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        ext.extract(_make_frame(1000 + i))
+        torch.cuda.synchronize()
+        latencies.append((time.perf_counter() - t0) * 1000.0)
+    peak_mem = torch.cuda.max_memory_allocated() / 1e6
+
+    del ext
+    gc.collect()
+    torch.cuda.empty_cache()
+
+    return {
+        "backend": "pytorch",
+        "n_frames": n_frames,
+        "mean_latency_ms": float(np.mean(latencies)),
+        "median_latency_ms": float(np.median(latencies)),
+        "peak_mem_mb": peak_mem,
+    }
+
+
+def bench_jax(n_frames: int) -> dict:
+    """Benchmark the JAX extractor (eager fp32) over ``n_frames``."""
+    import jax
+
+    jax.config.update("jax_default_matmul_precision", "highest")
+    from modules.vggt.jax import JAXVGGTFeatureExtractor
+
+    ext = JAXVGGTFeatureExtractor(device="cuda")
+
+    ext.reset()
+    for i in range(WARMUP_FRAMES):
+        out = ext.extract(_make_frame(i))
+        # block_until_ready on a sentinel
+        _ = np.asarray(out["world_points"])
+
+    ext.reset()
+    latencies = []
+    for i in range(n_frames):
+        t0 = time.perf_counter()
+        out = ext.extract(_make_frame(1000 + i))
+        _ = np.asarray(out["world_points"])  # ensure sync
+        latencies.append((time.perf_counter() - t0) * 1000.0)
+
+    # JAX doesn't expose a simple peak-memory counter here; fall back to 0.
+    peak_mem = 0.0
+
+    del ext
+    gc.collect()
+
+    return {
+        "backend": "jax",
+        "n_frames": n_frames,
+        "mean_latency_ms": float(np.mean(latencies)),
+        "median_latency_ms": float(np.median(latencies)),
+        "peak_mem_mb": peak_mem,
+    }
+
+
+def run(seq_lens: tuple[int, ...], backends: tuple[str, ...], out_dir: Path) -> Path:
+    rows = []
+    for n in seq_lens:
+        for backend in backends:
+            print(f"[{backend}] n_frames={n} ...", flush=True)
+            if backend == "pytorch":
+                row = bench_pytorch(n)
+            elif backend == "jax":
+                row = bench_jax(n)
+            else:
+                raise ValueError(f"unknown backend {backend}")
+            print(
+                f"  mean={row['mean_latency_ms']:.1f}ms "
+                f"median={row['median_latency_ms']:.1f}ms "
+                f"peak_mem={row['peak_mem_mb']:.0f}MB"
+            )
+            rows.append(row)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stamp = time.strftime("%Y%m%d_%H%M%S")
+    out_path = out_dir / f"vggt_streaming_{stamp}.csv"
+    with out_path.open("w") as f:
+        f.write("backend,n_frames,mean_latency_ms,median_latency_ms,peak_mem_mb\n")
+        for r in rows:
+            f.write(
+                f"{r['backend']},{r['n_frames']},"
+                f"{r['mean_latency_ms']:.3f},{r['median_latency_ms']:.3f},"
+                f"{r['peak_mem_mb']:.1f}\n"
+            )
+    print(f"\nWrote {out_path}")
+    return out_path
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--seq-lens",
+        type=int,
+        nargs="+",
+        default=list(DEFAULT_SEQ_LENS),
+        help="Frames per episode to measure.",
+    )
+    p.add_argument(
+        "--backends",
+        type=str,
+        nargs="+",
+        default=["pytorch", "jax"],
+        choices=["pytorch", "jax"],
+    )
+    p.add_argument(
+        "--out-dir",
+        type=Path,
+        default=Path("output/comparison"),
+    )
+    args = p.parse_args()
+    run(tuple(args.seq_lens), tuple(args.backends), args.out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/vggt/jax/block.py
+++ b/modules/vggt/jax/block.py
@@ -100,17 +100,30 @@ class Block(nn.Module):
         rope_tables: tuple[jnp.ndarray, jnp.ndarray] | None = None,
         positions: jnp.ndarray | None = None,
         attn_mask: jnp.ndarray | None = None,
-    ) -> jnp.ndarray:
+        past_kv: tuple[jnp.ndarray, jnp.ndarray] | None = None,
+        use_cache: bool = False,
+    ) -> jnp.ndarray | tuple[jnp.ndarray, tuple[jnp.ndarray, jnp.ndarray]]:
         # Attention residual
         h = nn.LayerNorm(epsilon=self.norm_eps, name="norm1")(x)
-        h = Attention(
+        attn_out = Attention(
             dim=self.dim,
             num_heads=self.num_heads,
             qk_norm=self.qk_norm,
             qkv_bias=self.qkv_bias,
             proj_bias=self.proj_bias,
             name="attn",
-        )(h, rope_tables=rope_tables, positions=positions, attn_mask=attn_mask)
+        )(
+            h,
+            rope_tables=rope_tables,
+            positions=positions,
+            attn_mask=attn_mask,
+            past_kv=past_kv,
+            use_cache=use_cache,
+        )
+        if use_cache:
+            h, new_kv = attn_out
+        else:
+            h = attn_out
         if self.init_values:
             h = LayerScale(self.dim, init_values=self.init_values, name="ls1")(h)
         x = x + h
@@ -127,4 +140,6 @@ class Block(nn.Module):
             h = LayerScale(self.dim, init_values=self.init_values, name="ls2")(h)
         x = x + h
 
+        if use_cache:
+            return x, new_kv
         return x

--- a/modules/vggt/jax/block.py
+++ b/modules/vggt/jax/block.py
@@ -1,0 +1,130 @@
+"""Transformer block + its small helpers (LayerScale, MLP).
+
+Matches ``streamvggt.layers.block.Block`` structure:
+    norm1 -> attn -> ls1 -> residual
+    norm2 -> mlp  -> ls2 -> residual
+
+LayerScale (``ls1``, ``ls2``) multiplies the residual branch by a per-dim
+learnable ``gamma`` initialised to ``init_values``. When ``init_values`` is
+None or 0, the reference replaces LayerScale with Identity (no params);
+callers express that by passing ``init_values=None``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import flax.linen as nn
+import jax
+import jax.numpy as jnp
+
+from modules.vggt.jax.attention import Attention
+
+
+# --------------------------------------------------------------------------- #
+#  LayerScale
+# --------------------------------------------------------------------------- #
+
+
+class LayerScale(nn.Module):
+    """Element-wise scaling with a learnable gamma initialised to init_values."""
+
+    dim: int
+    init_values: float = 1e-5
+
+    @nn.compact
+    def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
+        gamma = self.param(
+            "gamma",
+            lambda _key, shape: jnp.full(shape, self.init_values, dtype=jnp.float32),
+            (self.dim,),
+        )
+        return x * gamma.astype(x.dtype)
+
+
+# --------------------------------------------------------------------------- #
+#  MLP (two Linears + GELU)
+# --------------------------------------------------------------------------- #
+
+
+class Mlp(nn.Module):
+    """Standard ViT MLP: fc1 -> GELU -> fc2. No dropout (inference-only)."""
+
+    hidden_features: int
+    out_features: int
+    use_bias: bool = True
+
+    @nn.compact
+    def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
+        x = nn.Dense(self.hidden_features, use_bias=self.use_bias, name="fc1")(x)
+        # PyTorch nn.GELU() default is the exact (non-approximate) GELU.
+        x = jax.nn.gelu(x, approximate=False)
+        x = nn.Dense(self.out_features, use_bias=self.use_bias, name="fc2")(x)
+        return x
+
+
+# --------------------------------------------------------------------------- #
+#  Block
+# --------------------------------------------------------------------------- #
+
+
+class Block(nn.Module):
+    """Transformer block (pre-norm) with optional LayerScale and RoPE.
+
+    Attributes:
+        dim: Feature dimension.
+        num_heads: Attention heads.
+        mlp_ratio: Hidden-feature multiplier for the MLP.
+        qk_norm: Forward-only flag for Attention.
+        init_values: LayerScale init. None/0 disables LayerScale (Identity).
+        norm_eps: LayerNorm epsilon for norm1 / norm2. DINOv2 uses 1e-6;
+            aggregator and camera-trunk blocks use 1e-5.
+        qkv_bias / proj_bias / ffn_bias: Bias flags passed through.
+    """
+
+    dim: int
+    num_heads: int
+    mlp_ratio: float = 4.0
+    qk_norm: bool = False
+    init_values: float | None = 0.01
+    norm_eps: float = 1e-5
+    qkv_bias: bool = True
+    proj_bias: bool = True
+    ffn_bias: bool = True
+
+    @nn.compact
+    def __call__(
+        self,
+        x: jnp.ndarray,
+        *,
+        rope_tables: tuple[jnp.ndarray, jnp.ndarray] | None = None,
+        positions: jnp.ndarray | None = None,
+        attn_mask: jnp.ndarray | None = None,
+    ) -> jnp.ndarray:
+        # Attention residual
+        h = nn.LayerNorm(epsilon=self.norm_eps, name="norm1")(x)
+        h = Attention(
+            dim=self.dim,
+            num_heads=self.num_heads,
+            qk_norm=self.qk_norm,
+            qkv_bias=self.qkv_bias,
+            proj_bias=self.proj_bias,
+            name="attn",
+        )(h, rope_tables=rope_tables, positions=positions, attn_mask=attn_mask)
+        if self.init_values:
+            h = LayerScale(self.dim, init_values=self.init_values, name="ls1")(h)
+        x = x + h
+
+        # MLP residual
+        h = nn.LayerNorm(epsilon=self.norm_eps, name="norm2")(x)
+        h = Mlp(
+            hidden_features=int(self.dim * self.mlp_ratio),
+            out_features=self.dim,
+            use_bias=self.ffn_bias,
+            name="mlp",
+        )(h)
+        if self.init_values:
+            h = LayerScale(self.dim, init_values=self.init_values, name="ls2")(h)
+        x = x + h
+
+        return x

--- a/modules/vggt/jax/block.py
+++ b/modules/vggt/jax/block.py
@@ -102,7 +102,9 @@ class Block(nn.Module):
         attn_mask: jnp.ndarray | None = None,
         past_kv: tuple[jnp.ndarray, jnp.ndarray] | None = None,
         use_cache: bool = False,
-    ) -> jnp.ndarray | tuple[jnp.ndarray, tuple[jnp.ndarray, jnp.ndarray]]:
+        cache_budget: int | None = None,
+        num_anchor_tokens: int = 0,
+    ):
         # Attention residual
         h = nn.LayerNorm(epsilon=self.norm_eps, name="norm1")(x)
         attn_out = Attention(
@@ -119,9 +121,15 @@ class Block(nn.Module):
             attn_mask=attn_mask,
             past_kv=past_kv,
             use_cache=use_cache,
+            cache_budget=cache_budget,
+            num_anchor_tokens=num_anchor_tokens,
         )
+        scores = None
         if use_cache:
-            h, new_kv = attn_out
+            if cache_budget is not None:
+                h, new_kv, scores = attn_out
+            else:
+                h, new_kv = attn_out
         else:
             h = attn_out
         if self.init_values:
@@ -141,5 +149,7 @@ class Block(nn.Module):
         x = x + h
 
         if use_cache:
+            if cache_budget is not None:
+                return x, new_kv, scores
             return x, new_kv
         return x

--- a/modules/vggt/jax/feature_extractor.py
+++ b/modules/vggt/jax/feature_extractor.py
@@ -121,11 +121,14 @@ class JAXVGGTFeatureExtractor:
         # ``current_budgets_static`` (argnum 7) are Python-static.
         # Positional signature: (params, images, past_kvs, past_frame_idx,
         # total_budget, last_scores, use_cache, current_budgets_static).
+        # is_first_frame (argnum 3) is a bool — only two distinct static values
+        # → two compiles total. Previously used frame_idx (int), which caused
+        # a recompile every frame.
         def _agg_fn(
             params,
             images,
             past_kvs,
-            past_frame_idx,
+            is_first_frame,
             total_budget,
             last_scores,
             use_cache,
@@ -136,13 +139,13 @@ class JAXVGGTFeatureExtractor:
                 images,
                 use_cache=use_cache,
                 past_kvs=past_kvs,
-                past_frame_idx=past_frame_idx,
+                past_frame_idx=0 if is_first_frame else 1,
                 total_budget=total_budget,
                 last_scores=last_scores,
                 current_budgets_static=current_budgets_static,
             )
 
-        # static_argnums: past_frame_idx (3), total_budget (4), use_cache (6),
+        # static_argnums: is_first_frame (3), total_budget (4), use_cache (6),
         # current_budgets_static (7).
         self._aggregator_apply = jax.jit(
             _agg_fn, static_argnums=(3, 4, 6, 7)
@@ -195,16 +198,16 @@ class JAXVGGTFeatureExtractor:
         last0 = jnp.zeros((self._agg_depth,), dtype=jnp.float32)
         bud0 = self._compute_static_budgets(np.zeros(self._agg_depth, dtype=np.float32))
         out0 = self._aggregator_apply(
-            self._agg_params, dummy, past0, 0, self._total_budget,
+            self._agg_params, dummy, past0, True, self._total_budget,
             last0, True, bud0,
         )
         out0[0][-1].block_until_ready()
 
-        # Frame 1: reuse returned cache to compile the "past_frame_idx != 0" graph.
+        # Frame 1: reuse returned cache to compile the "is_first_frame=False" graph.
         _, _, past1, last1 = out0
         # Keep same budget (same last_scores pre-eviction) so shapes match.
         out1 = self._aggregator_apply(
-            self._agg_params, dummy, past1, 1, self._total_budget,
+            self._agg_params, dummy, past1, False, self._total_budget,
             last1, True, bud0,
         )
         out1[0][-1].block_until_ready()
@@ -298,7 +301,7 @@ class JAXVGGTFeatureExtractor:
                 self._agg_params,
                 images,
                 self._past_kvs_padded,
-                self._frame_idx,
+                self._frame_idx == 0,  # is_first_frame — bool, only 2 compiles total
                 self._total_budget,
                 self._last_scores,
                 True,  # use_cache

--- a/modules/vggt/jax/feature_extractor.py
+++ b/modules/vggt/jax/feature_extractor.py
@@ -6,31 +6,37 @@ so callers can swap backends by changing one import:
     extractor = JAXVGGTFeatureExtractor(device="cuda")
     extractor.reset()                       # at every episode boundary
     out = extractor.extract(rgb)            # rgb: (3, 518, 518) uint8
-    # out = {"world_points": (37, 37, 3) float32,
-    #        "camera_pose":  (9,)        float32}
 
 Weights are loaded from the same HuggingFace checkpoint as the PyTorch
 extractor, transposed into a Flax PyTree. The aggregator + camera-head
 caches are carried as instance state across ``extract`` calls and cleared
 by ``reset``.
-
-v1 runs fp32 end-to-end; bf16 autocast and ``jax.jit`` come in Step 8 with
-the benchmark harness.
 """
 
 from __future__ import annotations
 
+import os
 import time
 from typing import Any
 
-import jax
-import jax.numpy as jnp
-import numpy as np
+# JAX compilation cache: re-use compiled graphs across runs / processes.
+# Must be set before JAX touches the GPU.
+os.environ.setdefault("JAX_COMPILATION_CACHE_DIR", "/tmp/vggt_jax_cache")
 
-from modules.vggt.jax.aggregator import Aggregator
-from modules.vggt.jax.heads.camera_head import CameraHead
-from modules.vggt.jax.heads.dpt_head import DPTHead
-from modules.vggt.jax.weight_transfer import load_checkpoint, load_pytorch_weights
+import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+import numpy as np  # noqa: E402
+
+from modules.vggt.jax.aggregator import (  # noqa: E402
+    Aggregator,
+    _calculate_dynamic_budgets,
+)
+from modules.vggt.jax.heads.camera_head import CameraHead  # noqa: E402
+from modules.vggt.jax.heads.dpt_head import DPTHead  # noqa: E402
+from modules.vggt.jax.weight_transfer import (  # noqa: E402
+    load_checkpoint,
+    load_pytorch_weights,
+)
 
 # Image and patch grid are fixed at 518 / 14 = 37 patches per side.
 _IMG_SIZE = 518
@@ -41,11 +47,7 @@ _DEFAULT_TOTAL_BUDGET = 1_200_000
 
 
 def _adaptive_avg_pool_518_to_37(pts_nhwc: jnp.ndarray) -> jnp.ndarray:
-    """Average-pool (N, 518, 518, C) to (N, 37, 37, C).
-
-    ``F.adaptive_avg_pool2d(518→37)`` with integer ratio 14 is exactly
-    non-overlapping 14x14 box pooling. Implemented as reshape + mean.
-    """
+    """Average-pool (N, 518, 518, C) to (N, 37, 37, C)."""
     N, H, W, C = pts_nhwc.shape
     if (H, W) != (_IMG_SIZE, _IMG_SIZE):
         raise ValueError(f"expected (518, 518), got ({H}, {W})")
@@ -58,9 +60,10 @@ def _adaptive_avg_pool_518_to_37(pts_nhwc: jnp.ndarray) -> jnp.ndarray:
 class JAXVGGTFeatureExtractor:
     """Drop-in JAX backend for ``VGGTFeatureExtractor``.
 
-    Loads the InfiniteVGGT checkpoint once and runs streaming inference
-    under eager JAX. The KV-cache (aggregator + camera-head) is carried as
-    instance state; call :meth:`reset` at every episode boundary.
+    The KV-cache is carried as instance state; call :meth:`reset` at every
+    episode boundary. Internally the aggregator cache is stored in padded
+    form (3-tuples of ``(k, v, valid_len)``) for JIT stability; the
+    ``_past_kvs`` property exposes a compact 2-tuple view for tests.
     """
 
     def __init__(
@@ -68,18 +71,8 @@ class JAXVGGTFeatureExtractor:
         device: str = "cuda",
         compile: bool = False,
         total_budget: int = _DEFAULT_TOTAL_BUDGET,
+        dtype: Any = jnp.bfloat16,
     ):
-        """Load frozen StreamVGGT weights and prepare Flax modules.
-
-        Args:
-            device: Either ``"cuda"``/``"gpu"`` (JAX picks the first CUDA
-                device) or ``"cpu"``. Present for PyTorch-API compatibility.
-            compile: Accepted for API symmetry with the PyTorch extractor
-                but ignored in v1. ``jax.jit`` is enabled by Step 8.
-            total_budget: Global KV-cache budget fed to the aggregator's
-                dynamic allocator. Matches the 1.2M default used by
-                ``streamvggt.models.streamvggt.StreamVGGT``.
-        """
         if device in ("cuda", "gpu"):
             self._device = jax.devices("gpu")[0]
         elif device == "cpu":
@@ -88,6 +81,7 @@ class JAXVGGTFeatureExtractor:
             raise ValueError(f"unknown device {device!r}")
         self._compile = compile  # reserved
         self._total_budget = total_budget
+        self._dtype = dtype
 
         # Load weights: HF checkpoint -> numpy state_dict -> Flax PyTree.
         sd = load_checkpoint()
@@ -97,7 +91,6 @@ class JAXVGGTFeatureExtractor:
         self._cam_params = {"params": tree["camera_head"]}
         self._pt_params = {"params": tree["point_head"]}
 
-        # Bound module instances; Flax modules are cheap to construct.
         self._aggregator = Aggregator()
         self._camera_head = CameraHead()
         self._point_head = DPTHead()
@@ -105,7 +98,164 @@ class JAXVGGTFeatureExtractor:
         self._agg_depth = self._aggregator.depth
         self._cam_depth = self._camera_head.trunk_depth
 
+        # Padded cache dimensions.
+        # Token count per global-block frame: P = 5 + (518/14)^2 = 1374.
+        self._P = 5 + (_IMG_SIZE // _PATCH_SIZE) ** 2
+        # MAX = uniform share of total_budget across depth blocks + one frame
+        # headroom. After eviction the cache has <= uniform valid tokens, and
+        # we append at most P tokens before the next eviction fires, so
+        # uniform + P is the tightest safe upper bound (was uniform * 2).
+        uniform = max(total_budget // self._agg_depth, self._P)
+        self._MAX = uniform + self._P  # headroom for one fresh frame before eviction
+        # Heads / head-dim from aggregator defaults.
+        self._num_heads = self._aggregator.num_heads
+        self._head_dim = self._aggregator.embed_dim // self._num_heads
+
+        # Point head JIT (unchanged from previous version).
+        def _point_head_fn(params, out_list, images, psi):
+            return self._point_head.apply(params, out_list, images, psi)
+
+        self._point_head_apply = jax.jit(_point_head_fn, static_argnums=(3,))
+
+        # JIT-wrap the aggregator apply. ``past_frame_idx`` (argnum 3) and
+        # ``current_budgets_static`` (argnum 7) are Python-static.
+        # Positional signature: (params, images, past_kvs, past_frame_idx,
+        # total_budget, last_scores, use_cache, current_budgets_static).
+        def _agg_fn(
+            params,
+            images,
+            past_kvs,
+            past_frame_idx,
+            total_budget,
+            last_scores,
+            use_cache,
+            current_budgets_static,
+        ):
+            return self._aggregator.apply(
+                params,
+                images,
+                use_cache=use_cache,
+                past_kvs=past_kvs,
+                past_frame_idx=past_frame_idx,
+                total_budget=total_budget,
+                last_scores=last_scores,
+                current_budgets_static=current_budgets_static,
+            )
+
+        # static_argnums: past_frame_idx (3), total_budget (4), use_cache (6),
+        # current_budgets_static (7).
+        self._aggregator_apply = jax.jit(
+            _agg_fn, static_argnums=(3, 4, 6, 7)
+        )
+
         self.reset()
+
+        # AOT warmup: compile for frame 0 (past_kvs=None → padded init with
+        # valid_len=0) and frame 1 (past_kvs=3-tuples with valid_len>0).
+        self._warmup()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _new_padded_cache_entry(self) -> tuple:
+        """Allocate a zero-padded (k, v, valid_len=0) entry."""
+        B = 1
+        k_pad = jnp.zeros(
+            (B, self._num_heads, self._MAX, self._head_dim),
+            dtype=self._dtype,
+        )
+        v_pad = jnp.zeros(
+            (B, self._num_heads, self._MAX, self._head_dim),
+            dtype=self._dtype,
+        )
+        valid_len = jnp.asarray(0, dtype=jnp.int32)
+        return (k_pad, v_pad, valid_len)
+
+    def _compute_static_budgets(self, last_scores_np: np.ndarray) -> tuple[int, ...]:
+        """Compute dynamic per-block budgets as a tuple of Python ints."""
+        bud = np.asarray(
+            _calculate_dynamic_budgets(
+                jnp.asarray(last_scores_np, dtype=jnp.float32),
+                self._total_budget,
+            )
+        )
+        # Cap by MAX so top_k k values stay <= MAX - P.
+        bud = np.minimum(bud, self._MAX)
+        return tuple(int(x) for x in bud.tolist())
+
+    def _warmup(self) -> None:
+        """Pre-compile both cache states so the first real call is fast."""
+        dummy = jnp.zeros(
+            (1, 1, 3, _IMG_SIZE, _IMG_SIZE), dtype=self._dtype
+        )
+
+        # Frame 0: padded cache with valid_len=0 on every block.
+        past0 = [self._new_padded_cache_entry() for _ in range(self._agg_depth)]
+        last0 = jnp.zeros((self._agg_depth,), dtype=jnp.float32)
+        bud0 = self._compute_static_budgets(np.zeros(self._agg_depth, dtype=np.float32))
+        out0 = self._aggregator_apply(
+            self._agg_params, dummy, past0, 0, self._total_budget,
+            last0, True, bud0,
+        )
+        out0[0][-1].block_until_ready()
+
+        # Frame 1: reuse returned cache to compile the "past_frame_idx != 0" graph.
+        _, _, past1, last1 = out0
+        # Keep same budget (same last_scores pre-eviction) so shapes match.
+        out1 = self._aggregator_apply(
+            self._agg_params, dummy, past1, 1, self._total_budget,
+            last1, True, bud0,
+        )
+        out1[0][-1].block_until_ready()
+
+    # ------------------------------------------------------------------
+    # Public cache view (_past_kvs property).
+    # ------------------------------------------------------------------
+
+    @property
+    def _past_kvs(self):
+        """Compact 2-tuple view of the padded cache, for test observation.
+
+        Returns None if no frames have been processed. Otherwise a list of
+        ``(k, v)`` tuples, each shape ``(B, H, valid_len, Dh)``.
+        """
+        if self._past_kvs_padded is None:
+            return None
+        out = []
+        for entry in self._past_kvs_padded:
+            k_pad, v_pad, valid_len = entry
+            vl = int(np.asarray(valid_len))
+            out.append((k_pad[:, :, :vl], v_pad[:, :, :vl]))
+        return out
+
+    @_past_kvs.setter
+    def _past_kvs(self, value):
+        """Setter supporting the ``self._past_kvs = None`` reset pattern.
+
+        Writing anything non-None falls through to storing as padded state.
+        In practice this is only used by ``reset()``.
+        """
+        if value is None:
+            self._past_kvs_padded = None
+        else:
+            # Caller providing either 2-tuples or 3-tuples; re-pad as needed.
+            self._past_kvs_padded = [self._to_padded(e) for e in value]
+
+    def _to_padded(self, entry) -> tuple:
+        """Convert a compact 2-tuple (or None) into padded 3-tuple form."""
+        if entry is None:
+            return self._new_padded_cache_entry()
+        if isinstance(entry, tuple) and len(entry) == 3:
+            return entry
+        k, v = entry
+        B, H, L, Dh = k.shape
+        k_pad = jnp.zeros((B, H, self._MAX, Dh), dtype=k.dtype)
+        v_pad = jnp.zeros((B, H, self._MAX, Dh), dtype=v.dtype)
+        k_pad = jax.lax.dynamic_update_slice_in_dim(k_pad, k, 0, axis=2)
+        v_pad = jax.lax.dynamic_update_slice_in_dim(v_pad, v, 0, axis=2)
+        valid_len = jnp.asarray(L, dtype=jnp.int32)
+        return (k_pad, v_pad, valid_len)
 
     # ------------------------------------------------------------------
     # Public API
@@ -113,7 +263,7 @@ class JAXVGGTFeatureExtractor:
 
     def reset(self) -> None:
         """Clear KV-cache and frame counter. Call at episode boundaries."""
-        self._past_kvs: list[Any] | None = None
+        self._past_kvs_padded: list[Any] | None = None
         self._last_scores: jnp.ndarray | None = None
         self._past_kvs_camera: list[Any] | None = None
         self._frame_idx: int = 0
@@ -123,57 +273,56 @@ class JAXVGGTFeatureExtractor:
         rgb: np.ndarray,
         phase_times: dict[str, list[float]] | None = None,
     ) -> dict[str, np.ndarray]:
-        """Single-frame streaming inference.
-
-        Args:
-            rgb: ``(3, 518, 518)`` uint8 CHW (e.g. from Habitat).
-            phase_times: Optional profiling hook. Records wall-clock ms under
-                ``"vggt_forward"`` (input prep + model forward) and
-                ``"vggt_wrapper"`` (pool + device-transfer).
-
-        Returns:
-            ``{"world_points": (37, 37, 3) float32,
-               "camera_pose": (9,)        float32}``
-        """
+        """Single-frame streaming inference."""
         profiling = phase_times is not None
         fwd_t0 = time.perf_counter() if profiling else 0.0
 
-        # Input prep: uint8 CHW -> float32 [0, 1] -> (1, 1, 3, 518, 518)
-        img = jnp.asarray(rgb, dtype=jnp.float32) / 255.0
-        images = img[None, None]  # add batch + sequence dims
+        img = (jnp.asarray(rgb, dtype=jnp.float32) / 255.0).astype(self._dtype)
+        images = img[None, None]
         images = jax.device_put(images, self._device)
 
-        # Aggregator (streaming cache + dynamic budget eviction).
-        out_list, patch_start_idx, self._past_kvs, self._last_scores = (
-            self._aggregator.apply(
+        # Initialize padded cache on first frame.
+        if self._past_kvs_padded is None:
+            self._past_kvs_padded = [
+                self._new_padded_cache_entry() for _ in range(self._agg_depth)
+            ]
+        if self._last_scores is None:
+            self._last_scores = jnp.zeros((self._agg_depth,), dtype=jnp.float32)
+
+        # Compute budgets outside jit as a static tuple of Python ints.
+        ls_np = np.asarray(self._last_scores)
+        budgets_static = self._compute_static_budgets(ls_np)
+
+        out_list, patch_start_idx, self._past_kvs_padded, self._last_scores = (
+            self._aggregator_apply(
                 self._agg_params,
                 images,
-                use_cache=True,
-                past_kvs=self._past_kvs,
-                past_frame_idx=self._frame_idx,
-                total_budget=self._total_budget,
-                last_scores=self._last_scores,
+                self._past_kvs_padded,
+                self._frame_idx,
+                self._total_budget,
+                self._last_scores,
+                True,  # use_cache
+                budgets_static,
             )
         )
 
-        # Camera head (iterative refiner with its own cache).
         pose_list, self._past_kvs_camera = self._camera_head.apply(
             self._cam_params,
             out_list,
             use_cache=True,
             past_kvs_camera=self._past_kvs_camera,
         )
-        pose_enc = pose_list[-1]  # last refinement iteration
-        camera_pose = pose_enc[:, 0, :]  # (B, 9)
+        pose_enc = pose_list[-1]
+        camera_pose = pose_enc[:, 0, :]
 
-        # Point head (DPT, no cache).
-        pts3d, _ = self._point_head.apply(
+        # patch_start_idx is always 1 + num_register_tokens = 5; cast to Python
+        # int so it can be used as a static JIT arg (JIT returns JAX scalars).
+        pts3d, _ = self._point_head_apply(
             self._pt_params,
             out_list,
             images,
-            patch_start_idx,
+            int(np.asarray(patch_start_idx)),
         )
-        # pts3d is (B, S=1, H, W, 3); drop sequence dim.
         pts3d = pts3d[:, 0]
 
         if profiling:
@@ -181,16 +330,13 @@ class JAXVGGTFeatureExtractor:
             camera_pose.block_until_ready()
             wrap_t0 = time.perf_counter()
 
-        # Pool 518x518 -> 37x37 via non-overlapping 14x14 mean.
-        world_points = _adaptive_avg_pool_518_to_37(pts3d)  # (1, 37, 37, 3)
+        world_points = _adaptive_avg_pool_518_to_37(pts3d)
 
         world_points_np = np.asarray(world_points[0], dtype=np.float32)
         camera_pose_np = np.asarray(camera_pose[0], dtype=np.float32)
 
         if profiling:
             wrap_t1 = time.perf_counter()
-            # Approximate the PyTorch hook's CUDA-event split; both phases
-            # include the blocking wait via block_until_ready/asarray.
             phase_times["vggt_forward"].append((wrap_t0 - fwd_t0) * 1000.0)
             phase_times["vggt_wrapper"].append((wrap_t1 - wrap_t0) * 1000.0)
 

--- a/modules/vggt/jax/feature_extractor.py
+++ b/modules/vggt/jax/feature_extractor.py
@@ -1,0 +1,202 @@
+"""JAX StreamVGGT feature extractor for streaming 3D point extraction.
+
+Mirrors the public API of ``modules.vggt.feature_extractor.VGGTFeatureExtractor``
+so callers can swap backends by changing one import:
+
+    extractor = JAXVGGTFeatureExtractor(device="cuda")
+    extractor.reset()                       # at every episode boundary
+    out = extractor.extract(rgb)            # rgb: (3, 518, 518) uint8
+    # out = {"world_points": (37, 37, 3) float32,
+    #        "camera_pose":  (9,)        float32}
+
+Weights are loaded from the same HuggingFace checkpoint as the PyTorch
+extractor, transposed into a Flax PyTree. The aggregator + camera-head
+caches are carried as instance state across ``extract`` calls and cleared
+by ``reset``.
+
+v1 runs fp32 end-to-end; bf16 autocast and ``jax.jit`` come in Step 8 with
+the benchmark harness.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from modules.vggt.jax.aggregator import Aggregator
+from modules.vggt.jax.heads.camera_head import CameraHead
+from modules.vggt.jax.heads.dpt_head import DPTHead
+from modules.vggt.jax.weight_transfer import load_checkpoint, load_pytorch_weights
+
+# Image and patch grid are fixed at 518 / 14 = 37 patches per side.
+_IMG_SIZE = 518
+_PATCH_GRID = 37
+_PATCH_SIZE = 14
+# Reference default (streamvggt.models.streamvggt.StreamVGGT.__init__).
+_DEFAULT_TOTAL_BUDGET = 1_200_000
+
+
+def _adaptive_avg_pool_518_to_37(pts_nhwc: jnp.ndarray) -> jnp.ndarray:
+    """Average-pool (N, 518, 518, C) to (N, 37, 37, C).
+
+    ``F.adaptive_avg_pool2d(518→37)`` with integer ratio 14 is exactly
+    non-overlapping 14x14 box pooling. Implemented as reshape + mean.
+    """
+    N, H, W, C = pts_nhwc.shape
+    if (H, W) != (_IMG_SIZE, _IMG_SIZE):
+        raise ValueError(f"expected (518, 518), got ({H}, {W})")
+    out = pts_nhwc.reshape(
+        N, _PATCH_GRID, _PATCH_SIZE, _PATCH_GRID, _PATCH_SIZE, C
+    ).mean(axis=(2, 4))
+    return out  # (N, 37, 37, C)
+
+
+class JAXVGGTFeatureExtractor:
+    """Drop-in JAX backend for ``VGGTFeatureExtractor``.
+
+    Loads the InfiniteVGGT checkpoint once and runs streaming inference
+    under eager JAX. The KV-cache (aggregator + camera-head) is carried as
+    instance state; call :meth:`reset` at every episode boundary.
+    """
+
+    def __init__(
+        self,
+        device: str = "cuda",
+        compile: bool = False,
+        total_budget: int = _DEFAULT_TOTAL_BUDGET,
+    ):
+        """Load frozen StreamVGGT weights and prepare Flax modules.
+
+        Args:
+            device: Either ``"cuda"``/``"gpu"`` (JAX picks the first CUDA
+                device) or ``"cpu"``. Present for PyTorch-API compatibility.
+            compile: Accepted for API symmetry with the PyTorch extractor
+                but ignored in v1. ``jax.jit`` is enabled by Step 8.
+            total_budget: Global KV-cache budget fed to the aggregator's
+                dynamic allocator. Matches the 1.2M default used by
+                ``streamvggt.models.streamvggt.StreamVGGT``.
+        """
+        if device in ("cuda", "gpu"):
+            self._device = jax.devices("gpu")[0]
+        elif device == "cpu":
+            self._device = jax.devices("cpu")[0]
+        else:
+            raise ValueError(f"unknown device {device!r}")
+        self._compile = compile  # reserved
+        self._total_budget = total_budget
+
+        # Load weights: HF checkpoint -> numpy state_dict -> Flax PyTree.
+        sd = load_checkpoint()
+        tree, _ = load_pytorch_weights(sd, include_v1_only=True)
+        tree = jax.tree.map(lambda x: jax.device_put(jnp.asarray(x), self._device), tree)
+        self._agg_params = {"params": tree["aggregator"]}
+        self._cam_params = {"params": tree["camera_head"]}
+        self._pt_params = {"params": tree["point_head"]}
+
+        # Bound module instances; Flax modules are cheap to construct.
+        self._aggregator = Aggregator()
+        self._camera_head = CameraHead()
+        self._point_head = DPTHead()
+
+        self._agg_depth = self._aggregator.depth
+        self._cam_depth = self._camera_head.trunk_depth
+
+        self.reset()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def reset(self) -> None:
+        """Clear KV-cache and frame counter. Call at episode boundaries."""
+        self._past_kvs: list[Any] | None = None
+        self._last_scores: jnp.ndarray | None = None
+        self._past_kvs_camera: list[Any] | None = None
+        self._frame_idx: int = 0
+
+    def extract(
+        self,
+        rgb: np.ndarray,
+        phase_times: dict[str, list[float]] | None = None,
+    ) -> dict[str, np.ndarray]:
+        """Single-frame streaming inference.
+
+        Args:
+            rgb: ``(3, 518, 518)`` uint8 CHW (e.g. from Habitat).
+            phase_times: Optional profiling hook. Records wall-clock ms under
+                ``"vggt_forward"`` (input prep + model forward) and
+                ``"vggt_wrapper"`` (pool + device-transfer).
+
+        Returns:
+            ``{"world_points": (37, 37, 3) float32,
+               "camera_pose": (9,)        float32}``
+        """
+        profiling = phase_times is not None
+        fwd_t0 = time.perf_counter() if profiling else 0.0
+
+        # Input prep: uint8 CHW -> float32 [0, 1] -> (1, 1, 3, 518, 518)
+        img = jnp.asarray(rgb, dtype=jnp.float32) / 255.0
+        images = img[None, None]  # add batch + sequence dims
+        images = jax.device_put(images, self._device)
+
+        # Aggregator (streaming cache + dynamic budget eviction).
+        out_list, patch_start_idx, self._past_kvs, self._last_scores = (
+            self._aggregator.apply(
+                self._agg_params,
+                images,
+                use_cache=True,
+                past_kvs=self._past_kvs,
+                past_frame_idx=self._frame_idx,
+                total_budget=self._total_budget,
+                last_scores=self._last_scores,
+            )
+        )
+
+        # Camera head (iterative refiner with its own cache).
+        pose_list, self._past_kvs_camera = self._camera_head.apply(
+            self._cam_params,
+            out_list,
+            use_cache=True,
+            past_kvs_camera=self._past_kvs_camera,
+        )
+        pose_enc = pose_list[-1]  # last refinement iteration
+        camera_pose = pose_enc[:, 0, :]  # (B, 9)
+
+        # Point head (DPT, no cache).
+        pts3d, _ = self._point_head.apply(
+            self._pt_params,
+            out_list,
+            images,
+            patch_start_idx,
+        )
+        # pts3d is (B, S=1, H, W, 3); drop sequence dim.
+        pts3d = pts3d[:, 0]
+
+        if profiling:
+            pts3d.block_until_ready()
+            camera_pose.block_until_ready()
+            wrap_t0 = time.perf_counter()
+
+        # Pool 518x518 -> 37x37 via non-overlapping 14x14 mean.
+        world_points = _adaptive_avg_pool_518_to_37(pts3d)  # (1, 37, 37, 3)
+
+        world_points_np = np.asarray(world_points[0], dtype=np.float32)
+        camera_pose_np = np.asarray(camera_pose[0], dtype=np.float32)
+
+        if profiling:
+            wrap_t1 = time.perf_counter()
+            # Approximate the PyTorch hook's CUDA-event split; both phases
+            # include the blocking wait via block_until_ready/asarray.
+            phase_times["vggt_forward"].append((wrap_t0 - fwd_t0) * 1000.0)
+            phase_times["vggt_wrapper"].append((wrap_t1 - wrap_t0) * 1000.0)
+
+        self._frame_idx += 1
+
+        return {
+            "world_points": world_points_np,
+            "camera_pose": camera_pose_np,
+        }

--- a/modules/vggt/jax/heads/__init__.py
+++ b/modules/vggt/jax/heads/__init__.py
@@ -1,0 +1,1 @@
+"""Prediction heads: camera_head (Step 4), dpt_head / point_head (Step 5)."""

--- a/modules/vggt/jax/heads/camera_head.py
+++ b/modules/vggt/jax/heads/camera_head.py
@@ -1,0 +1,164 @@
+"""CameraHead — AdaLN-modulated iterative refiner for pose prediction.
+
+Mirrors ``streamvggt.heads.camera_head.CameraHead`` for the **no-cache** path
+(``use_cache=False`` in the reference). The cache branch lands in Step 6a+.
+
+Each iteration:
+    1. module_input = embed_pose(empty_pose_tokens | prev_pred_pose_enc)
+    2. shift, scale, gate = split(SiLU; Linear)(module_input)
+    3. pose_mod = gate * ((1 + scale) * adaln_norm(pose_tokens) + shift) + pose_tokens
+    4. pose_mod = trunk[k](pose_mod, causal_mask) for k in 0..trunk_depth-1
+    5. delta = pose_branch(trunk_norm(pose_mod))
+    6. pred_pose_enc = pred_pose_enc + delta   (or delta on the first iter)
+    7. append activate_pose(pred_pose_enc)
+
+Uses explicit ``setup()`` rather than ``@nn.compact`` because the same
+submodules (embed_pose, poseLN_modulation_1, trunk, pose_branch, trunk_norm)
+are invoked once per iteration — Flax's compact mode forbids re-using a
+name within a single ``__call__``.
+"""
+
+from __future__ import annotations
+
+import flax.linen as nn
+import jax
+import jax.numpy as jnp
+
+from modules.vggt.jax.block import Block, Mlp
+
+
+# Default activations for absT_quaR_FoV (CameraHead.__init__).
+_TRANS_ACT = "linear"
+_QUAT_ACT = "linear"
+_FL_ACT = "relu"
+
+
+def _inverse_log_transform(y: jnp.ndarray) -> jnp.ndarray:
+    return jnp.sign(y) * jnp.expm1(jnp.abs(y))
+
+
+def _base_pose_act(x: jnp.ndarray, act_type: str) -> jnp.ndarray:
+    if act_type == "linear":
+        return x
+    if act_type == "inv_log":
+        return _inverse_log_transform(x)
+    if act_type == "exp":
+        return jnp.exp(x)
+    if act_type == "relu":
+        return jax.nn.relu(x)
+    raise ValueError(f"Unknown act_type: {act_type}")
+
+
+def _activate_pose(
+    pred_pose_enc: jnp.ndarray,
+    trans_act: str = _TRANS_ACT,
+    quat_act: str = _QUAT_ACT,
+    fl_act: str = _FL_ACT,
+) -> jnp.ndarray:
+    T = _base_pose_act(pred_pose_enc[..., :3], trans_act)
+    quat = _base_pose_act(pred_pose_enc[..., 3:7], quat_act)
+    fl = _base_pose_act(pred_pose_enc[..., 7:], fl_act)
+    return jnp.concatenate([T, quat, fl], axis=-1)
+
+
+def _modulate(x: jnp.ndarray, shift: jnp.ndarray, scale: jnp.ndarray) -> jnp.ndarray:
+    return x * (1 + scale) + shift
+
+
+def _adaln_norm(x: jnp.ndarray, eps: float = 1e-6) -> jnp.ndarray:
+    """LayerNorm over last axis WITHOUT affine (elementwise_affine=False)."""
+    mean = jnp.mean(x, axis=-1, keepdims=True)
+    var = jnp.var(x, axis=-1, keepdims=True)
+    return (x - mean) * jax.lax.rsqrt(var + eps)
+
+
+class CameraHead(nn.Module):
+    """Iterative camera-pose refiner over aggregator tokens (no cache)."""
+
+    dim_in: int = 2048
+    trunk_depth: int = 4
+    target_dim: int = 9
+    num_heads: int = 16
+    mlp_ratio: float = 4.0
+    init_values: float = 0.01
+    norm_eps: float = 1e-5
+    num_iterations: int = 4
+
+    def setup(self):
+        self.empty_pose_tokens = self.param(
+            "empty_pose_tokens",
+            lambda _k, shape: jnp.zeros(shape, dtype=jnp.float32),
+            (1, 1, self.target_dim),
+        )
+        self.token_norm = nn.LayerNorm(epsilon=self.norm_eps, name="token_norm")
+        self.embed_pose = nn.Dense(self.dim_in, use_bias=True, name="embed_pose")
+        self.poseLN_modulation_1 = nn.Dense(
+            3 * self.dim_in, use_bias=True, name="poseLN_modulation_1"
+        )
+        self.trunk_blocks = [
+            Block(
+                dim=self.dim_in,
+                num_heads=self.num_heads,
+                mlp_ratio=self.mlp_ratio,
+                qk_norm=False,
+                init_values=self.init_values,
+                norm_eps=self.norm_eps,
+                name=f"trunk_{k}",
+            )
+            for k in range(self.trunk_depth)
+        ]
+        self.trunk_norm = nn.LayerNorm(epsilon=self.norm_eps, name="trunk_norm")
+        self.pose_branch = Mlp(
+            hidden_features=self.dim_in // 2,
+            out_features=self.target_dim,
+            use_bias=True,
+            name="pose_branch",
+        )
+
+    def __call__(
+        self,
+        aggregated_tokens_list: list[jnp.ndarray],
+    ) -> list[jnp.ndarray]:
+        tokens = aggregated_tokens_list[-1]
+        B, S, P, C = tokens.shape
+        if C != self.dim_in:
+            raise ValueError(f"aggregator token dim {C} != dim_in {self.dim_in}")
+
+        pose_tokens = self.token_norm(tokens[:, :, 0])  # (B, S, C)
+
+        # Causal mask over S pose-token frames.
+        s_range = jnp.arange(S)
+        future = s_range[:, None] < s_range[None, :]
+        attn_mask = future.astype(jnp.float32) * jnp.finfo(jnp.float32).min
+
+        pred_pose_enc: jnp.ndarray | None = None
+        pred_pose_enc_list: list[jnp.ndarray] = []
+
+        for _ in range(self.num_iterations):
+            if pred_pose_enc is None:
+                pose_input = jnp.broadcast_to(
+                    self.empty_pose_tokens.astype(pose_tokens.dtype),
+                    (B, S, self.target_dim),
+                )
+            else:
+                pose_input = jax.lax.stop_gradient(pred_pose_enc)
+
+            module_input = self.embed_pose(pose_input)
+            mod = self.poseLN_modulation_1(jax.nn.silu(module_input))
+            shift_msa, scale_msa, gate_msa = jnp.split(mod, 3, axis=-1)
+
+            pose_tokens_mod = (
+                gate_msa * _modulate(_adaln_norm(pose_tokens), shift_msa, scale_msa)
+                + pose_tokens
+            )
+
+            for k in range(self.trunk_depth):
+                pose_tokens_mod = self.trunk_blocks[k](
+                    pose_tokens_mod, attn_mask=attn_mask
+                )
+
+            delta = self.pose_branch(self.trunk_norm(pose_tokens_mod))
+            pred_pose_enc = delta if pred_pose_enc is None else pred_pose_enc + delta
+            pred_pose_enc_list.append(_activate_pose(pred_pose_enc))
+
+        return pred_pose_enc_list

--- a/modules/vggt/jax/heads/camera_head.py
+++ b/modules/vggt/jax/heads/camera_head.py
@@ -118,18 +118,51 @@ class CameraHead(nn.Module):
     def __call__(
         self,
         aggregated_tokens_list: list[jnp.ndarray],
-    ) -> list[jnp.ndarray]:
+        *,
+        use_cache: bool = False,
+        past_kvs_camera: list | None = None,
+    ):
+        """Forward pass.
+
+        Args:
+            aggregated_tokens_list: Output of the aggregator — list of
+                (B, S, P, C) tensors. Only the last element is used.
+            use_cache: Streaming mode (S must be 1). Each trunk block's cache
+                grows by ``num_iterations`` entries per frame.
+            past_kvs_camera: List of length ``trunk_depth`` with per-block
+                (k, v) tuples or None. Provided on every frame after the first.
+
+        Returns:
+            Without cache: ``pred_pose_enc_list`` (length = num_iterations).
+            With cache:    ``(pred_pose_enc_list, new_past_kvs_camera)``.
+        """
         tokens = aggregated_tokens_list[-1]
         B, S, P, C = tokens.shape
         if C != self.dim_in:
             raise ValueError(f"aggregator token dim {C} != dim_in {self.dim_in}")
+        if use_cache and S != 1:
+            raise ValueError(f"camera-head use_cache expects S=1, got S={S}")
 
         pose_tokens = self.token_norm(tokens[:, :, 0])  # (B, S, C)
 
-        # Causal mask over S pose-token frames.
-        s_range = jnp.arange(S)
-        future = s_range[:, None] < s_range[None, :]
-        attn_mask = future.astype(jnp.float32) * jnp.finfo(jnp.float32).min
+        # Causal mask over S pose-token frames (no-cache only — under cache,
+        # the rectangular Q vs [past_k | new_k] attention is naturally causal).
+        if use_cache:
+            attn_mask = None
+        else:
+            s_range = jnp.arange(S)
+            future = s_range[:, None] < s_range[None, :]
+            attn_mask = future.astype(jnp.float32) * jnp.finfo(jnp.float32).min
+
+        if use_cache:
+            if past_kvs_camera is None:
+                past_kvs_camera = [None] * self.trunk_depth
+            if len(past_kvs_camera) != self.trunk_depth:
+                raise ValueError(
+                    f"past_kvs_camera length {len(past_kvs_camera)} "
+                    f"!= trunk_depth {self.trunk_depth}"
+                )
+            new_past_kvs_camera: list = list(past_kvs_camera)
 
         pred_pose_enc: jnp.ndarray | None = None
         pred_pose_enc_list: list[jnp.ndarray] = []
@@ -153,12 +186,23 @@ class CameraHead(nn.Module):
             )
 
             for k in range(self.trunk_depth):
-                pose_tokens_mod = self.trunk_blocks[k](
-                    pose_tokens_mod, attn_mask=attn_mask
-                )
+                if use_cache:
+                    pose_tokens_mod, new_kv = self.trunk_blocks[k](
+                        pose_tokens_mod,
+                        attn_mask=None,
+                        past_kv=new_past_kvs_camera[k],
+                        use_cache=True,
+                    )
+                    new_past_kvs_camera[k] = new_kv
+                else:
+                    pose_tokens_mod = self.trunk_blocks[k](
+                        pose_tokens_mod, attn_mask=attn_mask
+                    )
 
             delta = self.pose_branch(self.trunk_norm(pose_tokens_mod))
             pred_pose_enc = delta if pred_pose_enc is None else pred_pose_enc + delta
             pred_pose_enc_list.append(_activate_pose(pred_pose_enc))
 
+        if use_cache:
+            return pred_pose_enc_list, new_past_kvs_camera
         return pred_pose_enc_list

--- a/modules/vggt/jax/heads/dpt_head.py
+++ b/modules/vggt/jax/heads/dpt_head.py
@@ -1,0 +1,505 @@
+"""DPTHead — port of ``streamvggt.heads.dpt_head.DPTHead`` for the point head.
+
+Used as the **point head** in StreamVGGT (``output_dim=4``,
+``activation="inv_log"``, ``conf_activation="expp1"``). The depth head — a
+second DPTHead instance with ``output_dim=2, activation="exp"`` — is out of
+scope for v1 and not wired here.
+
+Pipeline, per frame chunk:
+    1. ``norm(x)`` on tokens, permute to (B*S, C, H_patch, W_patch).
+    2. ``projects[i]`` (1x1 Conv) -> ``+ pos_embed`` -> ``resize_layers[i]``
+       for each of 4 intermediate layer indices [4, 11, 17, 23].
+    3. ``scratch_forward``: fuse via layer{1..4}_rn Conv3x3 (no bias) and 4
+       ``FeatureFusionBlock`` stages (refinenet4/3/2/1) with 2x bilinear
+       upsampling (align_corners=True), then ``output_conv1``.
+    4. Bilinear resize to image resolution (518x518 for the thesis).
+    5. ``output_conv2`` (Conv3x3 -> ReLU -> Conv1x1) -> 4-channel map.
+    6. ``activate_head`` splits into pts3d (inv_log on xyz) + conf (expp1).
+"""
+
+from __future__ import annotations
+
+import flax.linen as nn
+import jax
+import jax.numpy as jnp
+
+
+_DEFAULT_INTERMEDIATE_LAYER_IDX: tuple[int, ...] = (4, 11, 17, 23)
+_OUT_CHANNELS: tuple[int, int, int, int] = (256, 512, 1024, 1024)
+_FEATURES = 256
+_POS_EMBED_RATIO = 0.1
+_POS_EMBED_OMEGA_0 = 100.0
+
+
+# --------------------------------------------------------------------------- #
+#  Sinusoidal positional embedding (non-learnable; heads/utils.py port)
+# --------------------------------------------------------------------------- #
+
+
+def _make_sincos_pos_embed(
+    embed_dim: int, pos: jnp.ndarray, omega_0: float = _POS_EMBED_OMEGA_0
+) -> jnp.ndarray:
+    """Port of ``heads.utils.make_sincos_pos_embed`` — (M,) pos -> (M, embed_dim)."""
+    if embed_dim % 2 != 0:
+        raise ValueError(f"embed_dim must be even, got {embed_dim}")
+    # The reference computes omega in float64; we keep fp32 since the final
+    # scaling by ratio=0.1 and subsequent convs dominate any precision loss.
+    omega = jnp.arange(embed_dim // 2, dtype=jnp.float32)
+    omega = omega / (embed_dim / 2.0)
+    omega = 1.0 / (omega_0 ** omega)
+    pos = pos.reshape(-1)
+    out = jnp.einsum("m,d->md", pos, omega)
+    return jnp.concatenate([jnp.sin(out), jnp.cos(out)], axis=-1)
+
+
+def _position_grid_to_embed(
+    pos_grid: jnp.ndarray, embed_dim: int, omega_0: float = _POS_EMBED_OMEGA_0
+) -> jnp.ndarray:
+    """Port of ``heads.utils.position_grid_to_embed`` — (H, W, 2) -> (H, W, embed_dim)."""
+    H, W, grid_dim = pos_grid.shape
+    assert grid_dim == 2
+    pos_flat = pos_grid.reshape(-1, grid_dim)
+    emb_x = _make_sincos_pos_embed(embed_dim // 2, pos_flat[:, 0], omega_0)
+    emb_y = _make_sincos_pos_embed(embed_dim // 2, pos_flat[:, 1], omega_0)
+    emb = jnp.concatenate([emb_x, emb_y], axis=-1)
+    return emb.reshape(H, W, embed_dim)
+
+
+def _create_uv_grid(
+    width: int, height: int, aspect_ratio: float
+) -> jnp.ndarray:
+    """Port of ``heads.utils.create_uv_grid``.
+
+    Reference uses ``torch.meshgrid(x_coords, y_coords, indexing='xy')`` which
+    yields shape ``(height, width, 2)`` tensors (xy indexing swaps to row-y
+    col-x). Matches that.
+    """
+    diag = (aspect_ratio ** 2 + 1.0) ** 0.5
+    span_x = aspect_ratio / diag
+    span_y = 1.0 / diag
+    left_x = -span_x * (width - 1) / width
+    right_x = span_x * (width - 1) / width
+    top_y = -span_y * (height - 1) / height
+    bot_y = span_y * (height - 1) / height
+    x_coords = jnp.linspace(left_x, right_x, width, dtype=jnp.float32)
+    y_coords = jnp.linspace(top_y, bot_y, height, dtype=jnp.float32)
+    # torch meshgrid indexing='xy' returns (H, W) shaped outputs.
+    yy, xx = jnp.meshgrid(y_coords, x_coords, indexing="ij")
+    # But we want shape (H, W, 2) with [uu, vv] stacked. Using indexing='xy':
+    xx, yy = jnp.meshgrid(x_coords, y_coords, indexing="xy")
+    return jnp.stack([xx, yy], axis=-1)  # (H, W, 2)
+
+
+def _apply_pos_embed(
+    x: jnp.ndarray, W: int, H: int, ratio: float = _POS_EMBED_RATIO
+) -> jnp.ndarray:
+    """x: (N, C, H_feat, W_feat). Adds ratio * sinusoidal 2D pos embed (fixed)."""
+    patch_w = x.shape[-1]
+    patch_h = x.shape[-2]
+    pos = _create_uv_grid(patch_w, patch_h, aspect_ratio=W / H)
+    emb = _position_grid_to_embed(pos, x.shape[1])  # (H_feat, W_feat, C)
+    emb = jnp.transpose(emb, (2, 0, 1))[None]  # (1, C, H_feat, W_feat)
+    emb = (emb * ratio).astype(x.dtype)
+    return x + emb
+
+
+# --------------------------------------------------------------------------- #
+#  Bilinear resize with align_corners=True (jax.image.resize defaults differ).
+# --------------------------------------------------------------------------- #
+
+
+def _bilinear_align_corners(x: jnp.ndarray, out_h: int, out_w: int) -> jnp.ndarray:
+    """Bilinear upsample NCHW with PyTorch's align_corners=True convention.
+
+    jax.image.resize implements the align_corners=False (pixel-centered)
+    sampling — not compatible with the DPT reference which explicitly uses
+    align_corners=True. We implement it directly via fancy indexing.
+    """
+    N, C, H, W = x.shape
+    if H == out_h and W == out_w:
+        return x
+
+    scale_h = (H - 1) / max(out_h - 1, 1) if out_h > 1 else 0.0
+    scale_w = (W - 1) / max(out_w - 1, 1) if out_w > 1 else 0.0
+    y_src = jnp.arange(out_h, dtype=jnp.float32) * scale_h
+    x_src = jnp.arange(out_w, dtype=jnp.float32) * scale_w
+
+    y0 = jnp.floor(y_src).astype(jnp.int32)
+    y1 = jnp.minimum(y0 + 1, H - 1)
+    x0 = jnp.floor(x_src).astype(jnp.int32)
+    x1 = jnp.minimum(x0 + 1, W - 1)
+    yf = (y_src - y0.astype(jnp.float32))[:, None]  # (out_h, 1)
+    xf = (x_src - x0.astype(jnp.float32))[None, :]  # (1, out_w)
+
+    y0_b = y0[:, None]
+    y1_b = y1[:, None]
+    x0_b = x0[None, :]
+    x1_b = x1[None, :]
+    tl = x[:, :, y0_b, x0_b]
+    tr = x[:, :, y0_b, x1_b]
+    bl = x[:, :, y1_b, x0_b]
+    br = x[:, :, y1_b, x1_b]
+    top = tl * (1 - xf) + tr * xf
+    bot = bl * (1 - xf) + br * xf
+    return top * (1 - yf) + bot * yf
+
+
+# --------------------------------------------------------------------------- #
+#  activate_head: inv_log on pts3d, expp1 on conf (head_act.py:52-103).
+# --------------------------------------------------------------------------- #
+
+
+def _inv_log_transform(y: jnp.ndarray) -> jnp.ndarray:
+    return jnp.sign(y) * jnp.expm1(jnp.abs(y))
+
+
+def _activate_head_inv_log_expp1(
+    out: jnp.ndarray,
+) -> tuple[jnp.ndarray, jnp.ndarray]:
+    """out: (N, 4, H, W). Returns (pts3d (N, H, W, 3), conf (N, H, W))."""
+    fmap = jnp.transpose(out, (0, 2, 3, 1))  # (N, H, W, 4)
+    xyz = fmap[..., :-1]
+    conf = fmap[..., -1]
+    pts3d = _inv_log_transform(xyz)
+    conf_out = 1.0 + jnp.exp(conf)
+    return pts3d, conf_out
+
+
+# --------------------------------------------------------------------------- #
+#  Residual conv unit
+# --------------------------------------------------------------------------- #
+
+
+class _ResidualConvUnit(nn.Module):
+    """ReLU -> Conv3x3 -> ReLU -> Conv3x3 -> skip add.
+
+    Uses explicit ``setup`` to pre-declare conv1 / conv2 as attributes. An
+    earlier ``@nn.compact`` version exhibited a Flax-version-specific bug
+    where two sibling ``_ResidualConvUnit`` instances inside the same parent
+    compact scope computed different outputs than when applied standalone
+    (~5x max-abs error in the second instance). Explicit setup avoids it.
+    """
+
+    features: int
+
+    def setup(self):
+        self.conv1 = nn.Conv(
+            self.features,
+            kernel_size=(3, 3),
+            strides=(1, 1),
+            padding="SAME",
+            use_bias=True,
+            name="conv1",
+        )
+        self.conv2 = nn.Conv(
+            self.features,
+            kernel_size=(3, 3),
+            strides=(1, 1),
+            padding="SAME",
+            use_bias=True,
+            name="conv2",
+        )
+
+    def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
+        # Flax convs are NHWC; DPT keeps NCHW. Convert, conv, convert back.
+        h = jax.nn.relu(x)
+        h = jnp.transpose(h, (0, 2, 3, 1))
+        h = self.conv1(h)
+        h = jnp.transpose(h, (0, 3, 1, 2))
+        h = jax.nn.relu(h)
+        h = jnp.transpose(h, (0, 2, 3, 1))
+        h = self.conv2(h)
+        h = jnp.transpose(h, (0, 3, 1, 2))
+        return x + h
+
+
+# --------------------------------------------------------------------------- #
+#  Feature fusion block
+# --------------------------------------------------------------------------- #
+
+
+class _FeatureFusionBlock(nn.Module):
+    """FFB: optional resConfUnit1(skip) + resConfUnit2(running) + 2x up + 1x1 out."""
+
+    features: int
+    has_residual: bool
+
+    def setup(self):
+        if self.has_residual:
+            self.resConfUnit1 = _ResidualConvUnit(self.features, name="resConfUnit1")
+        self.resConfUnit2 = _ResidualConvUnit(self.features, name="resConfUnit2")
+        self.out_conv = nn.Conv(
+            self.features,
+            kernel_size=(1, 1),
+            strides=(1, 1),
+            padding="VALID",
+            use_bias=True,
+            name="out_conv",
+        )
+
+    def __call__(
+        self,
+        running: jnp.ndarray,
+        skip: jnp.ndarray | None = None,
+        size: tuple[int, int] | None = None,
+    ) -> jnp.ndarray:
+        if self.has_residual:
+            assert skip is not None
+            res = self.resConfUnit1(skip)
+            running = running + res
+        running = self.resConfUnit2(running)
+
+        if size is None:
+            out_h = running.shape[2] * 2
+            out_w = running.shape[3] * 2
+        else:
+            out_h, out_w = size
+        running = _bilinear_align_corners(running, out_h, out_w)
+
+        running = jnp.transpose(running, (0, 2, 3, 1))
+        running = self.out_conv(running)
+        running = jnp.transpose(running, (0, 3, 1, 2))
+        return running
+
+
+# --------------------------------------------------------------------------- #
+#  Scratch (rn layers + refinenets + output_conv1)
+# --------------------------------------------------------------------------- #
+
+
+class _Scratch(nn.Module):
+    features: int = _FEATURES
+    in_channels: tuple[int, int, int, int] = _OUT_CHANNELS
+
+    def setup(self):
+        # layer{i}_rn: Conv3x3 stride=1 padding=1, bias=False
+        self.layer1_rn = nn.Conv(
+            self.features, kernel_size=(3, 3), strides=(1, 1),
+            padding="SAME", use_bias=False, name="layer1_rn",
+        )
+        self.layer2_rn = nn.Conv(
+            self.features, kernel_size=(3, 3), strides=(1, 1),
+            padding="SAME", use_bias=False, name="layer2_rn",
+        )
+        self.layer3_rn = nn.Conv(
+            self.features, kernel_size=(3, 3), strides=(1, 1),
+            padding="SAME", use_bias=False, name="layer3_rn",
+        )
+        self.layer4_rn = nn.Conv(
+            self.features, kernel_size=(3, 3), strides=(1, 1),
+            padding="SAME", use_bias=False, name="layer4_rn",
+        )
+        # refinenet4 has has_residual=False (only the running branch, no skip).
+        self.refinenet4 = _FeatureFusionBlock(
+            self.features, has_residual=False, name="refinenet4"
+        )
+        self.refinenet3 = _FeatureFusionBlock(
+            self.features, has_residual=True, name="refinenet3"
+        )
+        self.refinenet2 = _FeatureFusionBlock(
+            self.features, has_residual=True, name="refinenet2"
+        )
+        self.refinenet1 = _FeatureFusionBlock(
+            self.features, has_residual=True, name="refinenet1"
+        )
+        # output_conv1: Conv3x3 features -> features//2  (256 -> 128)
+        self.output_conv1 = nn.Conv(
+            self.features // 2, kernel_size=(3, 3), strides=(1, 1),
+            padding="SAME", use_bias=True, name="output_conv1",
+        )
+        # output_conv2 is a Sequential(Conv3x3 128->32, ReLU, Conv1x1 32->out_dim=4).
+        # We store as two separate submodules named output_conv2_0 / output_conv2_2.
+        self.output_conv2_0 = nn.Conv(
+            32, kernel_size=(3, 3), strides=(1, 1),
+            padding="SAME", use_bias=True, name="output_conv2_0",
+        )
+        self.output_conv2_2 = nn.Conv(
+            4, kernel_size=(1, 1), strides=(1, 1),
+            padding="VALID", use_bias=True, name="output_conv2_2",
+        )
+
+    def _nchw_conv(self, conv: nn.Conv, x: jnp.ndarray) -> jnp.ndarray:
+        """Helper: NCHW -> NHWC for Flax Conv -> NCHW back."""
+        x = jnp.transpose(x, (0, 2, 3, 1))
+        x = conv(x)
+        return jnp.transpose(x, (0, 3, 1, 2))
+
+    def fuse(
+        self, features: list[jnp.ndarray]
+    ) -> jnp.ndarray:
+        layer_1, layer_2, layer_3, layer_4 = features
+
+        l1 = self._nchw_conv(self.layer1_rn, layer_1)
+        l2 = self._nchw_conv(self.layer2_rn, layer_2)
+        l3 = self._nchw_conv(self.layer3_rn, layer_3)
+        l4 = self._nchw_conv(self.layer4_rn, layer_4)
+
+        out = self.refinenet4(l4, size=(l3.shape[2], l3.shape[3]))
+        out = self.refinenet3(out, l3, size=(l2.shape[2], l2.shape[3]))
+        out = self.refinenet2(out, l2, size=(l1.shape[2], l1.shape[3]))
+        out = self.refinenet1(out, l1)
+        out = self._nchw_conv(self.output_conv1, out)
+        return out
+
+    def head(self, x: jnp.ndarray) -> jnp.ndarray:
+        """Apply output_conv2 (Conv3x3 -> ReLU -> Conv1x1)."""
+        x = self._nchw_conv(self.output_conv2_0, x)
+        x = jax.nn.relu(x)
+        x = self._nchw_conv(self.output_conv2_2, x)
+        return x
+
+
+# --------------------------------------------------------------------------- #
+#  DPTHead
+# --------------------------------------------------------------------------- #
+
+
+class DPTHead(nn.Module):
+    """DPT decoder head producing (pts3d, conf) from aggregator tokens.
+
+    Configured for the point head: ``output_dim=4``, ``activation="inv_log"``,
+    ``conf_activation="expp1"``, ``pos_embed=True`` (matches the trained
+    checkpoint — adds a fixed sinusoidal embedding at each of the 4 resized
+    features and again after the final upsample).
+    """
+
+    patch_size: int = 14
+    features: int = _FEATURES
+    out_channels: tuple[int, int, int, int] = _OUT_CHANNELS
+    intermediate_layer_idx: tuple[int, ...] = _DEFAULT_INTERMEDIATE_LAYER_IDX
+    dim_in: int = 2048
+    pos_embed: bool = True
+
+    def setup(self):
+        self.norm = nn.LayerNorm(epsilon=1e-5, name="norm")
+
+        # projects: 1x1 Conv per scale
+        self.projects_0 = nn.Conv(
+            self.out_channels[0], kernel_size=(1, 1), strides=(1, 1),
+            padding="VALID", use_bias=True, name="projects_0",
+        )
+        self.projects_1 = nn.Conv(
+            self.out_channels[1], kernel_size=(1, 1), strides=(1, 1),
+            padding="VALID", use_bias=True, name="projects_1",
+        )
+        self.projects_2 = nn.Conv(
+            self.out_channels[2], kernel_size=(1, 1), strides=(1, 1),
+            padding="VALID", use_bias=True, name="projects_2",
+        )
+        self.projects_3 = nn.Conv(
+            self.out_channels[3], kernel_size=(1, 1), strides=(1, 1),
+            padding="VALID", use_bias=True, name="projects_3",
+        )
+
+        # resize_layers: ConvTranspose (idx 0,1), Identity (idx 2 -> skip), Conv 3x3 stride 2 (idx 3)
+        self.resize_layers_0 = nn.ConvTranspose(
+            self.out_channels[0], kernel_size=(4, 4), strides=(4, 4),
+            padding="VALID", use_bias=True, name="resize_layers_0",
+        )
+        self.resize_layers_1 = nn.ConvTranspose(
+            self.out_channels[1], kernel_size=(2, 2), strides=(2, 2),
+            padding="VALID", use_bias=True, name="resize_layers_1",
+        )
+        # resize_layers_2 is Identity — no submodule
+        self.resize_layers_3 = nn.Conv(
+            self.out_channels[3], kernel_size=(3, 3), strides=(2, 2),
+            padding=((1, 1), (1, 1)), use_bias=True, name="resize_layers_3",
+        )
+
+        self.scratch = _Scratch(
+            features=self.features, in_channels=self.out_channels, name="scratch"
+        )
+
+    def _project_and_resize(
+        self, idx: int, feat: jnp.ndarray
+    ) -> jnp.ndarray:
+        """Apply projects[idx] then resize_layers[idx] to an NCHW feature map."""
+        x = jnp.transpose(feat, (0, 2, 3, 1))
+        if idx == 0:
+            x = self.projects_0(x)
+            x = self.resize_layers_0(x)
+        elif idx == 1:
+            x = self.projects_1(x)
+            x = self.resize_layers_1(x)
+        elif idx == 2:
+            x = self.projects_2(x)
+            # identity resize
+        elif idx == 3:
+            x = self.projects_3(x)
+            x = self.resize_layers_3(x)
+        else:
+            raise ValueError(idx)
+        return jnp.transpose(x, (0, 3, 1, 2))
+
+    def __call__(
+        self,
+        aggregated_tokens_list: list[jnp.ndarray],
+        images: jnp.ndarray,
+        patch_start_idx: int,
+    ) -> tuple[jnp.ndarray, jnp.ndarray]:
+        """Forward pass.
+
+        Args:
+            aggregated_tokens_list: length ``depth`` list of (B, S, P, dim_in).
+            images: (B, S, 3, H, W) — used only for target H, W, batch shape.
+            patch_start_idx: Starting index of patch tokens (5 for the aggregator).
+
+        Returns:
+            (pts3d, conf) with shapes (B, S, H, W, 3) and (B, S, H, W).
+        """
+        B, S, _, H, W = images.shape
+        patch_h = H // self.patch_size
+        patch_w = W // self.patch_size
+
+        features: list[jnp.ndarray] = []
+        for dpt_idx, layer_idx in enumerate(self.intermediate_layer_idx):
+            x = aggregated_tokens_list[layer_idx][:, :, patch_start_idx:]  # (B, S, P_patch, dim_in)
+            x = x.reshape(B * S, patch_h * patch_w, x.shape[-1])
+            x = self.norm(x)
+            # -> (B*S, dim_in, patch_h, patch_w)
+            x = jnp.transpose(x, (0, 2, 1)).reshape(
+                B * S, x.shape[-1], patch_h, patch_w
+            )
+            # projects -> (optional) pos_embed -> resize_layers
+            x = jnp.transpose(x, (0, 2, 3, 1))
+            if dpt_idx == 0:
+                x = self.projects_0(x)
+            elif dpt_idx == 1:
+                x = self.projects_1(x)
+            elif dpt_idx == 2:
+                x = self.projects_2(x)
+            elif dpt_idx == 3:
+                x = self.projects_3(x)
+            x = jnp.transpose(x, (0, 3, 1, 2))  # back to NCHW
+
+            if self.pos_embed:
+                x = _apply_pos_embed(x, W, H)
+
+            # resize_layers
+            if dpt_idx == 0:
+                x = jnp.transpose(x, (0, 2, 3, 1))
+                x = self.resize_layers_0(x)
+                x = jnp.transpose(x, (0, 3, 1, 2))
+            elif dpt_idx == 1:
+                x = jnp.transpose(x, (0, 2, 3, 1))
+                x = self.resize_layers_1(x)
+                x = jnp.transpose(x, (0, 3, 1, 2))
+            elif dpt_idx == 2:
+                pass  # identity
+            elif dpt_idx == 3:
+                x = jnp.transpose(x, (0, 2, 3, 1))
+                x = self.resize_layers_3(x)
+                x = jnp.transpose(x, (0, 3, 1, 2))
+            features.append(x)
+
+        fused = self.scratch.fuse(features)
+        # Upsample to image resolution.
+        fused = _bilinear_align_corners(fused, H, W)
+        if self.pos_embed:
+            fused = _apply_pos_embed(fused, W, H)
+        out = self.scratch.head(fused)  # (B*S, 4, H, W)
+
+        pts3d, conf = _activate_head_inv_log_expp1(out)
+        pts3d = pts3d.reshape(B, S, H, W, 3)
+        conf = conf.reshape(B, S, H, W)
+        return pts3d, conf

--- a/modules/vggt/jax/heads/dpt_head.py
+++ b/modules/vggt/jax/heads/dpt_head.py
@@ -171,13 +171,16 @@ def _activate_head_inv_log_expp1(
 
 
 class _ResidualConvUnit(nn.Module):
-    """ReLU -> Conv3x3 -> ReLU -> Conv3x3 -> skip add.
+    """ReLU -> Conv3x3 -> ReLU -> Conv3x3 -> **skip-add-with-relu'd-x**.
 
-    Uses explicit ``setup`` to pre-declare conv1 / conv2 as attributes. An
-    earlier ``@nn.compact`` version exhibited a Flax-version-specific bug
-    where two sibling ``_ResidualConvUnit`` instances inside the same parent
-    compact scope computed different outputs than when applied standalone
-    (~5x max-abs error in the second instance). Explicit setup avoids it.
+    The reference (``streamvggt.heads.dpt_head.ResidualConvUnit``) does:
+        out = self.activation(x)   # nn.ReLU(inplace=True) -- MUTATES x in place
+        out = self.conv1(out); out = self.activation(out); out = self.conv2(out)
+        return self.skip_add.add(out, x)   # x is now the relu'd version
+
+    The in-place ReLU is a silent side effect: the residual branch literally
+    adds ``out + relu(x)``, not ``out + x``. We reproduce that semantics
+    explicitly with ``relu(x) + h``. Missing this was the Step-5 parity bug.
     """
 
     features: int
@@ -201,16 +204,16 @@ class _ResidualConvUnit(nn.Module):
         )
 
     def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
-        # Flax convs are NHWC; DPT keeps NCHW. Convert, conv, convert back.
-        h = jax.nn.relu(x)
-        h = jnp.transpose(h, (0, 2, 3, 1))
+        # NCHW throughout; Flax convs are NHWC so we transpose in / out.
+        x_relu = jax.nn.relu(x)  # also the "x" that skip-add uses (in-place side effect)
+        h = jnp.transpose(x_relu, (0, 2, 3, 1))
         h = self.conv1(h)
         h = jnp.transpose(h, (0, 3, 1, 2))
         h = jax.nn.relu(h)
         h = jnp.transpose(h, (0, 2, 3, 1))
         h = self.conv2(h)
         h = jnp.transpose(h, (0, 3, 1, 2))
-        return x + h
+        return x_relu + h
 
 
 # --------------------------------------------------------------------------- #
@@ -275,19 +278,19 @@ class _Scratch(nn.Module):
         # layer{i}_rn: Conv3x3 stride=1 padding=1, bias=False
         self.layer1_rn = nn.Conv(
             self.features, kernel_size=(3, 3), strides=(1, 1),
-            padding="SAME", use_bias=False, name="layer1_rn",
+            padding="SAME", use_bias=False,
         )
         self.layer2_rn = nn.Conv(
             self.features, kernel_size=(3, 3), strides=(1, 1),
-            padding="SAME", use_bias=False, name="layer2_rn",
+            padding="SAME", use_bias=False,
         )
         self.layer3_rn = nn.Conv(
             self.features, kernel_size=(3, 3), strides=(1, 1),
-            padding="SAME", use_bias=False, name="layer3_rn",
+            padding="SAME", use_bias=False,
         )
         self.layer4_rn = nn.Conv(
             self.features, kernel_size=(3, 3), strides=(1, 1),
-            padding="SAME", use_bias=False, name="layer4_rn",
+            padding="SAME", use_bias=False,
         )
         # refinenet4 has has_residual=False (only the running branch, no skip).
         self.refinenet4 = _FeatureFusionBlock(
@@ -305,17 +308,17 @@ class _Scratch(nn.Module):
         # output_conv1: Conv3x3 features -> features//2  (256 -> 128)
         self.output_conv1 = nn.Conv(
             self.features // 2, kernel_size=(3, 3), strides=(1, 1),
-            padding="SAME", use_bias=True, name="output_conv1",
+            padding="SAME", use_bias=True,
         )
         # output_conv2 is a Sequential(Conv3x3 128->32, ReLU, Conv1x1 32->out_dim=4).
         # We store as two separate submodules named output_conv2_0 / output_conv2_2.
         self.output_conv2_0 = nn.Conv(
             32, kernel_size=(3, 3), strides=(1, 1),
-            padding="SAME", use_bias=True, name="output_conv2_0",
+            padding="SAME", use_bias=True,
         )
         self.output_conv2_2 = nn.Conv(
             4, kernel_size=(1, 1), strides=(1, 1),
-            padding="VALID", use_bias=True, name="output_conv2_2",
+            padding="VALID", use_bias=True,
         )
 
     def _nchw_conv(self, conv: nn.Conv, x: jnp.ndarray) -> jnp.ndarray:
@@ -376,34 +379,34 @@ class DPTHead(nn.Module):
         # projects: 1x1 Conv per scale
         self.projects_0 = nn.Conv(
             self.out_channels[0], kernel_size=(1, 1), strides=(1, 1),
-            padding="VALID", use_bias=True, name="projects_0",
+            padding="VALID", use_bias=True,
         )
         self.projects_1 = nn.Conv(
             self.out_channels[1], kernel_size=(1, 1), strides=(1, 1),
-            padding="VALID", use_bias=True, name="projects_1",
+            padding="VALID", use_bias=True,
         )
         self.projects_2 = nn.Conv(
             self.out_channels[2], kernel_size=(1, 1), strides=(1, 1),
-            padding="VALID", use_bias=True, name="projects_2",
+            padding="VALID", use_bias=True,
         )
         self.projects_3 = nn.Conv(
             self.out_channels[3], kernel_size=(1, 1), strides=(1, 1),
-            padding="VALID", use_bias=True, name="projects_3",
+            padding="VALID", use_bias=True,
         )
 
         # resize_layers: ConvTranspose (idx 0,1), Identity (idx 2 -> skip), Conv 3x3 stride 2 (idx 3)
         self.resize_layers_0 = nn.ConvTranspose(
             self.out_channels[0], kernel_size=(4, 4), strides=(4, 4),
-            padding="VALID", use_bias=True, name="resize_layers_0",
+            padding="VALID", use_bias=True,
         )
         self.resize_layers_1 = nn.ConvTranspose(
             self.out_channels[1], kernel_size=(2, 2), strides=(2, 2),
-            padding="VALID", use_bias=True, name="resize_layers_1",
+            padding="VALID", use_bias=True,
         )
         # resize_layers_2 is Identity — no submodule
         self.resize_layers_3 = nn.Conv(
             self.out_channels[3], kernel_size=(3, 3), strides=(2, 2),
-            padding=((1, 1), (1, 1)), use_bias=True, name="resize_layers_3",
+            padding=((1, 1), (1, 1)), use_bias=True,
         )
 
         self.scratch = _Scratch(

--- a/modules/vggt/jax/profile_streaming.py
+++ b/modules/vggt/jax/profile_streaming.py
@@ -1,0 +1,195 @@
+"""Per-phase latency breakdown for the JAX VGGT extractor.
+
+Reproduces the body of ``JAXVGGTFeatureExtractor.extract`` with explicit
+``block_until_ready()`` between each major component so wall time can be
+attributed to the input prep, aggregator, camera head, point head, and the
+pool+numpy transfer separately. Use this when ``benchmark_streaming.py``
+shows you a per-frame number and you need to know which component to
+optimize next.
+
+Run::
+
+    uv run python -m modules.vggt.jax.profile_streaming --n-frames 10
+    uv run python -m modules.vggt.jax.profile_streaming --n-frames 5 --trace /tmp/vggt_trace
+
+The optional ``--trace DIR`` flag writes a Perfetto-compatible JAX profile
+trace for one frame; open ``DIR/plugins/profile/...`` in
+``chrome://tracing`` or in TensorBoard's profile tab for a kernel-level
+view.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import time
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from modules.vggt.jax.feature_extractor import (
+    JAXVGGTFeatureExtractor,
+    _adaptive_avg_pool_518_to_37,
+)
+
+
+WARMUP_FRAMES = 3
+PHASES = ("input_prep", "aggregator", "camera_head", "point_head", "pool_transfer")
+
+
+def _make_frame(seed: int, size: int = 518) -> np.ndarray:
+    """Synthetic CHW uint8 RGB frame, deterministic by seed."""
+    rng = np.random.RandomState(seed)
+    return rng.randint(0, 256, size=(3, size, size), dtype=np.uint8)
+
+
+def _profile_one_frame(ext: JAXVGGTFeatureExtractor, rgb: np.ndarray) -> dict[str, float]:
+    """Run one streaming frame, returning per-phase wall time in ms.
+
+    Mirrors ``JAXVGGTFeatureExtractor.extract`` but inserts
+    ``block_until_ready()`` between phases so each timer captures only its
+    own segment. Mutates the extractor's cache state exactly as ``extract``
+    would (so this is suitable for streaming sequences, not just isolated
+    frames).
+    """
+    t = {}
+
+    # 1. Input prep: numpy uint8 -> JAX bf16 on device.
+    t0 = time.perf_counter()
+    img = (jnp.asarray(rgb, dtype=jnp.float32) / 255.0).astype(ext._dtype)
+    images = img[None, None]
+    images = jax.device_put(images, ext._device)
+    images.block_until_ready()
+    t["input_prep"] = (time.perf_counter() - t0) * 1000.0
+
+    # 2. Aggregator forward (24 alternating frame/global blocks + cache update).
+    # Routes through the extractor's jitted wrapper so we measure the real
+    # streaming-path cost, not a fresh apply without compilation cache.
+    t0 = time.perf_counter()
+    if ext._past_kvs_padded is None:
+        ext._past_kvs_padded = [
+            ext._new_padded_cache_entry() for _ in range(ext._agg_depth)
+        ]
+    if ext._last_scores is None:
+        ext._last_scores = jnp.zeros((ext._agg_depth,), dtype=jnp.float32)
+    ls_np = np.asarray(ext._last_scores)
+    budgets_static = ext._compute_static_budgets(ls_np)
+    out_list, patch_start_idx, ext._past_kvs_padded, ext._last_scores = (
+        ext._aggregator_apply(
+            ext._agg_params,
+            images,
+            ext._past_kvs_padded,
+            ext._frame_idx == 0,  # is_first_frame bool — 2 compiles total
+            ext._total_budget,
+            ext._last_scores,
+            True,
+            budgets_static,
+        )
+    )
+    out_list[-1].block_until_ready()
+    if ext._past_kvs_padded is not None:
+        ext._past_kvs_padded[-1][0].block_until_ready()
+    t["aggregator"] = (time.perf_counter() - t0) * 1000.0
+
+    # 3. Camera head (iterative refiner + its own cache).
+    t0 = time.perf_counter()
+    pose_list, ext._past_kvs_camera = ext._camera_head.apply(
+        ext._cam_params,
+        out_list,
+        use_cache=True,
+        past_kvs_camera=ext._past_kvs_camera,
+    )
+    pose_enc = pose_list[-1]
+    camera_pose = pose_enc[:, 0, :]
+    camera_pose.block_until_ready()
+    t["camera_head"] = (time.perf_counter() - t0) * 1000.0
+
+    # 4. Point head (DPT, jit-compiled, fixed shapes).
+    t0 = time.perf_counter()
+    pts3d, _ = ext._point_head_apply(ext._pt_params, out_list, images, int(np.asarray(patch_start_idx)))
+    pts3d = pts3d[:, 0]
+    pts3d.block_until_ready()
+    t["point_head"] = (time.perf_counter() - t0) * 1000.0
+
+    # 5. Pool 518->37 + JAX -> numpy host transfer.
+    t0 = time.perf_counter()
+    world_points = _adaptive_avg_pool_518_to_37(pts3d)
+    world_points_np = np.asarray(world_points[0], dtype=np.float32)
+    camera_pose_np = np.asarray(camera_pose[0], dtype=np.float32)
+    t["pool_transfer"] = (time.perf_counter() - t0) * 1000.0
+
+    ext._frame_idx += 1
+
+    # Touch outputs so the consumer can verify shapes if needed.
+    assert world_points_np.shape == (37, 37, 3)
+    assert camera_pose_np.shape == (9,)
+
+    return t
+
+
+def run(n_frames: int, dtype_name: str, trace_dir: Path | None) -> None:
+    dtype = {"bf16": jnp.bfloat16, "fp32": jnp.float32}[dtype_name]
+    print(f"Building extractor (dtype={dtype_name}) ...", flush=True)
+    ext = JAXVGGTFeatureExtractor(device="cuda", dtype=dtype)
+
+    # Warmup.
+    print(f"Warmup ({WARMUP_FRAMES} frames) ...", flush=True)
+    ext.reset()
+    for i in range(WARMUP_FRAMES):
+        _profile_one_frame(ext, _make_frame(i))
+
+    # Optional trace capture (one extra frame, after warmup is hot).
+    if trace_dir is not None:
+        trace_dir.mkdir(parents=True, exist_ok=True)
+        print(f"Capturing JAX profile trace -> {trace_dir} ...", flush=True)
+        with jax.profiler.trace(str(trace_dir)):
+            _profile_one_frame(ext, _make_frame(999))
+
+    # Measurement: fresh cache, then n_frames timed frames.
+    ext.reset()
+    rows: list[dict[str, float]] = []
+    for i in range(n_frames):
+        rows.append(_profile_one_frame(ext, _make_frame(1000 + i)))
+        print(f"  frame {i+1}/{n_frames}: total={sum(rows[-1].values()):.1f}ms", flush=True)
+
+    # Aggregate.
+    print("\nPer-phase wall time (ms), n={} frames, dtype={}".format(n_frames, dtype_name))
+    print("-" * 78)
+    print(f"{'phase':<18} {'mean':>10} {'median':>10} {'std':>10} {'min':>10} {'max':>10} {'%':>6}")
+    print("-" * 78)
+    totals = np.array([sum(r.values()) for r in rows])
+    for phase in PHASES:
+        vals = np.array([r[phase] for r in rows])
+        share = 100.0 * vals.mean() / totals.mean()
+        print(
+            f"{phase:<18} {vals.mean():>10.2f} {np.median(vals):>10.2f} "
+            f"{vals.std():>10.2f} {vals.min():>10.2f} {vals.max():>10.2f} {share:>5.1f}%"
+        )
+    print("-" * 78)
+    print(
+        f"{'TOTAL':<18} {totals.mean():>10.2f} {np.median(totals):>10.2f} "
+        f"{totals.std():>10.2f} {totals.min():>10.2f} {totals.max():>10.2f} {100.0:>5.1f}%"
+    )
+
+    del ext
+    gc.collect()
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--n-frames", type=int, default=10, help="Frames to time after warmup.")
+    p.add_argument("--dtype", choices=["bf16", "fp32"], default="bf16")
+    p.add_argument(
+        "--trace",
+        type=Path,
+        default=None,
+        help="Optional directory for jax.profiler.trace() output (one extra frame).",
+    )
+    args = p.parse_args()
+    run(args.n_frames, args.dtype, args.trace)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/vggt/jax/rope.py
+++ b/modules/vggt/jax/rope.py
@@ -1,0 +1,98 @@
+"""2D Rotary Position Embedding — pure functional JAX port.
+
+Mirrors ``streamvggt.layers.rope.RotaryPositionEmbedding2D`` exactly:
+split feature dim in half; vertical half rotated by y-positions, horizontal
+half by x-positions. Each half is further split into pairs via
+``rotate_features(x) = concat(-x[..., d/2:], x[..., :d/2])``.
+
+Design choice: this module is *stateless*. The cos/sin tables are computed
+by the caller once (usually at aggregator construction, since the patch
+grid is fixed at 37x37 for the thesis) and passed in. This keeps attention
+jit-friendly without a stateful frequency cache.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+
+def compute_1d_rope_tables(
+    dim: int,
+    max_pos: int,
+    frequency: float = 100.0,
+    dtype=jnp.float32,
+) -> tuple[jnp.ndarray, jnp.ndarray]:
+    """Return (cos, sin) tables of shape (max_pos, dim).
+
+    Matches PyTorch reference:
+        exponents = [0, 2, ..., dim-2] / dim
+        inv_freq  = 1 / frequency ** exponents                # (dim/2,)
+        angles    = outer(positions, inv_freq)                # (max_pos, dim/2)
+        angles    = concat(angles, angles, axis=-1)           # (max_pos, dim)
+        cos, sin  = cos(angles), sin(angles)
+    """
+    if dim % 2 != 0:
+        raise ValueError(f"dim must be even, got {dim}")
+    exponents = jnp.arange(0, dim, 2, dtype=jnp.float32) / dim
+    inv_freq = 1.0 / (frequency ** exponents)
+    positions = jnp.arange(max_pos, dtype=jnp.float32)
+    angles = jnp.einsum("i,j->ij", positions, inv_freq)  # (max_pos, dim/2)
+    angles = jnp.concatenate([angles, angles], axis=-1)  # (max_pos, dim)
+    return jnp.cos(angles).astype(dtype), jnp.sin(angles).astype(dtype)
+
+
+def _rotate_features(x: jnp.ndarray) -> jnp.ndarray:
+    """Split last dim in halves, return concat(-x2, x1)."""
+    x1, x2 = jnp.split(x, 2, axis=-1)
+    return jnp.concatenate([-x2, x1], axis=-1)
+
+
+def _apply_1d_rope(
+    tokens: jnp.ndarray,
+    positions: jnp.ndarray,
+    cos_table: jnp.ndarray,
+    sin_table: jnp.ndarray,
+) -> jnp.ndarray:
+    """Apply 1D RoPE.
+
+    Args:
+        tokens:    (B, H, N, D) features to rotate.
+        positions: (B, N) integer position indices.
+        cos_table: (max_pos, D).
+        sin_table: (max_pos, D).
+
+    Returns:
+        (B, H, N, D) rotated features.
+    """
+    # Index tables by positions; broadcast over heads.
+    cos = cos_table[positions][:, None, :, :]  # (B, 1, N, D)
+    sin = sin_table[positions][:, None, :, :]  # (B, 1, N, D)
+    return (tokens * cos) + (_rotate_features(tokens) * sin)
+
+
+def apply_rope_2d(
+    tokens: jnp.ndarray,
+    positions: jnp.ndarray,
+    cos_table: jnp.ndarray,
+    sin_table: jnp.ndarray,
+) -> jnp.ndarray:
+    """Apply 2D RoPE.
+
+    Args:
+        tokens:    (B, H, N, D) where D is even. Split into two (D/2) halves;
+                   the first (vertical) rotated by y-positions, the second
+                   (horizontal) by x-positions.
+        positions: (B, N, 2) integer (y, x) positions.
+        cos_table: (max_pos, D/2).
+        sin_table: (max_pos, D/2).
+
+    Returns:
+        (B, H, N, D) rotated features.
+    """
+    if tokens.shape[-1] % 2 != 0:
+        raise ValueError(f"feature dim must be even, got {tokens.shape[-1]}")
+    vertical, horizontal = jnp.split(tokens, 2, axis=-1)
+    vertical = _apply_1d_rope(vertical, positions[..., 0], cos_table, sin_table)
+    horizontal = _apply_1d_rope(horizontal, positions[..., 1], cos_table, sin_table)
+    return jnp.concatenate([vertical, horizontal], axis=-1)

--- a/modules/vggt/jax/weight_transfer.py
+++ b/modules/vggt/jax/weight_transfer.py
@@ -1,0 +1,525 @@
+"""PyTorch StreamVGGT state_dict -> JAX/Flax PyTree.
+
+Produces a nested dict whose leaves are numpy arrays in Flax layout:
+  - Conv2d         (O, I, H, W)    -> kernel (H, W, I, O)
+  - ConvTranspose2d(I, O, H, W)    -> kernel (H, W, I, O)
+  - Linear         (O, I)          -> kernel (I, O)
+  - LayerNorm weight               -> scale  (unchanged)
+  - Bias / param tensors           -> unchanged
+
+The returned tree is consumed directly by ``flax_module.apply({"params": tree}, ...)``.
+Step 1 only produces and validates this tree; the Flax modules that consume
+it land in step 2+.
+
+v1 scope excludes ``depth_head.*`` and ``track_head.*`` -- the plan ports
+only aggregator, camera_head, and point_head.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+# --------------------------------------------------------------------------- #
+#  Scope
+# --------------------------------------------------------------------------- #
+
+V1_EXCLUDE_PREFIXES: tuple[str, ...] = ("depth_head.", "track_head.")
+"""State_dict prefixes that are ignored in v1 (per plan non-goals)."""
+
+
+# --------------------------------------------------------------------------- #
+#  Transposition helpers
+# --------------------------------------------------------------------------- #
+
+# ConvTranspose2d weight layout in PyTorch is (in, out, H, W) whereas Conv2d is
+# (out, in, H, W). Flax uses (H, W, in, out) for both. We therefore need to
+# know which 4-D weight tensors are ConvTranspose2d -- we list them explicitly
+# since the tensor shape alone does not disambiguate.
+_CONV_TRANSPOSE_SUFFIXES: frozenset[str] = frozenset(
+    {
+        # DPT decoder upsampling layers (point_head / depth_head)
+        "resize_layers.0.weight",
+        "resize_layers.1.weight",
+        # resize_layers.2 is Identity (no params); resize_layers.3 is Conv2d.
+    }
+)
+
+
+def _conv2d_to_flax(t: np.ndarray) -> np.ndarray:
+    """(O, I, H, W) -> (H, W, I, O)."""
+    assert t.ndim == 4, t.shape
+    return np.transpose(t, (2, 3, 1, 0))
+
+
+def _conv_transpose2d_to_flax(t: np.ndarray) -> np.ndarray:
+    """(I, O, H, W) -> (H, W, I, O)."""
+    assert t.ndim == 4, t.shape
+    return np.transpose(t, (2, 3, 0, 1))
+
+
+def _linear_to_flax(t: np.ndarray) -> np.ndarray:
+    """(O, I) -> (I, O)."""
+    assert t.ndim == 2, t.shape
+    return np.transpose(t, (1, 0))
+
+
+# --------------------------------------------------------------------------- #
+#  Key -> path / leaf-name rewriting
+# --------------------------------------------------------------------------- #
+
+# Each rule is (regex, path_template, leaf_name_map, transpose).
+#   - path_template: dotted output path; use \1, \2 for captured groups and
+#     ``_N`` markers are replaced by capture groups in order.
+#   - leaf_name_map: dict mapping the last component of the PyTorch key
+#     ("weight", "bias", "gamma", or a literal param name) to the output leaf
+#     name ("kernel", "scale", "bias", "gamma", or the literal).
+#   - transpose: one of None, "conv", "conv_transpose", "linear".
+#
+# The rules are ordered; the first match wins. Patterns are anchored with ^/$.
+
+_Rule = tuple[re.Pattern[str], str, dict[str, str], str | None]
+
+
+def _rule(
+    pattern: str,
+    path_template: str,
+    leaf_map: dict[str, str],
+    transpose: str | None = None,
+) -> _Rule:
+    return re.compile("^" + pattern + "$"), path_template, leaf_map, transpose
+
+
+# Leaf maps
+_NORM_MAP = {"weight": "scale", "bias": "bias"}
+_CONV_MAP = {"weight": "kernel", "bias": "bias"}
+_LINEAR_MAP = {"weight": "kernel", "bias": "bias"}
+_LS_MAP = {"gamma": "gamma"}
+
+# --------------------------------------------------------------------------- #
+#  Rule builders for the repeated block families
+# --------------------------------------------------------------------------- #
+
+def _make_attention_rules(prefix: str, out_prefix: str, has_qk_norm: bool) -> list[_Rule]:
+    """Rules for a transformer-block attention submodule."""
+    rules = [
+        _rule(
+            rf"{prefix}\.(\d+)\.attn\.qkv\.(weight|bias)",
+            rf"{out_prefix}_\1.attn.qkv",
+            _LINEAR_MAP,
+            "linear",
+        ),
+        _rule(
+            rf"{prefix}\.(\d+)\.attn\.proj\.(weight|bias)",
+            rf"{out_prefix}_\1.attn.proj",
+            _LINEAR_MAP,
+            "linear",
+        ),
+    ]
+    if has_qk_norm:
+        rules.extend(
+            [
+                _rule(
+                    rf"{prefix}\.(\d+)\.attn\.(q_norm|k_norm)\.(weight|bias)",
+                    rf"{out_prefix}_\1.attn.\2",
+                    _NORM_MAP,
+                    None,
+                ),
+            ]
+        )
+    return rules
+
+
+def _make_block_rules(prefix: str, out_prefix: str, has_qk_norm: bool) -> list[_Rule]:
+    """Rules for a full transformer Block (norm1 + attn + ls1 + norm2 + mlp + ls2)."""
+    return [
+        _rule(
+            rf"{prefix}\.(\d+)\.norm1\.(weight|bias)",
+            rf"{out_prefix}_\1.norm1",
+            _NORM_MAP,
+            None,
+        ),
+        _rule(
+            rf"{prefix}\.(\d+)\.norm2\.(weight|bias)",
+            rf"{out_prefix}_\1.norm2",
+            _NORM_MAP,
+            None,
+        ),
+        _rule(
+            rf"{prefix}\.(\d+)\.ls1\.(gamma)",
+            rf"{out_prefix}_\1.ls1",
+            _LS_MAP,
+            None,
+        ),
+        _rule(
+            rf"{prefix}\.(\d+)\.ls2\.(gamma)",
+            rf"{out_prefix}_\1.ls2",
+            _LS_MAP,
+            None,
+        ),
+        _rule(
+            rf"{prefix}\.(\d+)\.mlp\.(fc1|fc2)\.(weight|bias)",
+            rf"{out_prefix}_\1.mlp.\2",
+            _LINEAR_MAP,
+            "linear",
+        ),
+        *_make_attention_rules(
+            prefix=rf"{prefix}",
+            out_prefix=f"{out_prefix}",
+            has_qk_norm=has_qk_norm,
+        ),
+    ]
+
+
+# The functions below are forward-referenced in RULES; we build them as
+# plain lists using the helpers above. Defined at module scope after RULES
+# via a closure trick is awkward, so we defer by making them module-level
+# builders that RULES looks up. Instead, we just define them before use --
+# but RULES is computed at import, so we need to define these first.
+
+def _dinov2_block_rules(prefix: str, out_prefix: str, block_name: str) -> list[_Rule]:
+    # DINOv2 blocks in the reference have no QK norm (qk_norm defaults to False
+    # for vit_large) -- no k_norm / q_norm keys appear in the checkpoint under
+    # `aggregator.patch_embed.blocks.*`.
+    return _make_block_rules(
+        prefix=prefix,
+        out_prefix=f"{out_prefix}.{block_name}",
+        has_qk_norm=False,
+    )
+
+
+def _aggregator_block_rules(variant: str) -> list[_Rule]:
+    # Aggregator frame_blocks / global_blocks use qk_norm=True.
+    assert variant in ("frame", "global")
+    return _make_block_rules(
+        prefix=rf"aggregator\.{variant}_blocks",
+        out_prefix=f"aggregator.{variant}_blocks",
+        has_qk_norm=True,
+    )
+
+
+def _camera_trunk_rules() -> list[_Rule]:
+    # Camera head trunk blocks: no qk_norm, no rope, dim=2048, num_heads=16.
+    return _make_block_rules(
+        prefix=r"camera_head\.trunk",
+        out_prefix="camera_head.trunk",
+        has_qk_norm=False,
+    )
+
+
+# Forward-referenced builders are used in RULES; rebuild RULES now that they
+# exist (Python order of definition means we need to redo the construction).
+RULES = [
+    _rule(r"aggregator\.(camera_token|register_token)", r"aggregator", {}, None),
+    _rule(
+        r"aggregator\.patch_embed\.(cls_token|mask_token|register_tokens|pos_embed)",
+        r"aggregator.patch_embed",
+        {},
+        None,
+    ),
+    _rule(
+        r"aggregator\.patch_embed\.norm\.(weight|bias)",
+        r"aggregator.patch_embed.norm",
+        _NORM_MAP,
+        None,
+    ),
+    _rule(
+        r"aggregator\.patch_embed\.patch_embed\.proj\.(weight|bias)",
+        r"aggregator.patch_embed.patch_embed.proj",
+        _CONV_MAP,
+        "conv",
+    ),
+    *_dinov2_block_rules(
+        prefix=r"aggregator\.patch_embed\.blocks",
+        out_prefix="aggregator.patch_embed",
+        block_name="blocks",
+    ),
+    *_aggregator_block_rules(variant="frame"),
+    *_aggregator_block_rules(variant="global"),
+    _rule(r"camera_head\.empty_pose_tokens", r"camera_head", {}, None),
+    _rule(r"camera_head\.embed_pose\.(weight|bias)", r"camera_head.embed_pose", _LINEAR_MAP, "linear"),
+    _rule(r"camera_head\.token_norm\.(weight|bias)", r"camera_head.token_norm", _NORM_MAP, None),
+    _rule(r"camera_head\.trunk_norm\.(weight|bias)", r"camera_head.trunk_norm", _NORM_MAP, None),
+    _rule(r"camera_head\.adaln_norm\.(weight|bias)", r"camera_head.adaln_norm", _NORM_MAP, None),
+    _rule(
+        r"camera_head\.poseLN_modulation\.1\.(weight|bias)",
+        r"camera_head.poseLN_modulation_1",
+        _LINEAR_MAP,
+        "linear",
+    ),
+    _rule(
+        r"camera_head\.pose_branch\.(fc1|fc2)\.(weight|bias)",
+        r"camera_head.pose_branch.\1",
+        _LINEAR_MAP,
+        "linear",
+    ),
+    *_camera_trunk_rules(),
+    _rule(r"point_head\.norm\.(weight|bias)", r"point_head.norm", _NORM_MAP, None),
+    _rule(
+        r"point_head\.projects\.(\d+)\.(weight|bias)",
+        r"point_head.projects_\1",
+        _CONV_MAP,
+        "conv",
+    ),
+    _rule(
+        r"point_head\.resize_layers\.(0|1)\.(weight|bias)",
+        r"point_head.resize_layers_\1",
+        _CONV_MAP,
+        "conv_transpose",
+    ),
+    _rule(
+        r"point_head\.resize_layers\.(3)\.(weight|bias)",
+        r"point_head.resize_layers_\1",
+        _CONV_MAP,
+        "conv",
+    ),
+    _rule(
+        r"point_head\.scratch\.(layer[1-4]_rn)\.(weight|bias)",
+        r"point_head.scratch.\1",
+        _CONV_MAP,
+        "conv",
+    ),
+    _rule(
+        r"point_head\.scratch\.(refinenet[1-4])\.out_conv\.(weight|bias)",
+        r"point_head.scratch.\1.out_conv",
+        _CONV_MAP,
+        "conv",
+    ),
+    _rule(
+        r"point_head\.scratch\.(refinenet[1-4])\.(resConfUnit[12])\.(conv[12])\.(weight|bias)",
+        r"point_head.scratch.\1.\2.\3",
+        _CONV_MAP,
+        "conv",
+    ),
+    _rule(
+        r"point_head\.scratch\.output_conv1\.(weight|bias)",
+        r"point_head.scratch.output_conv1",
+        _CONV_MAP,
+        "conv",
+    ),
+    _rule(
+        r"point_head\.scratch\.output_conv2\.(0|2)\.(weight|bias)",
+        r"point_head.scratch.output_conv2_\1",
+        _CONV_MAP,
+        "conv",
+    ),
+]
+
+
+# --------------------------------------------------------------------------- #
+#  Translation
+# --------------------------------------------------------------------------- #
+
+_PARAM_LEAF_NAMES = ("camera_token", "register_token", "cls_token", "mask_token",
+                     "register_tokens", "pos_embed", "empty_pose_tokens")
+
+
+def _split_key_suffix(key: str) -> tuple[str, str]:
+    """Split into (prefix, last_component). Last component is e.g. "weight", "bias",
+    "gamma", or a top-level parameter name like "cls_token"."""
+    idx = key.rfind(".")
+    return (key[:idx], key[idx + 1 :]) if idx >= 0 else ("", key)
+
+
+def _apply_transpose(t: np.ndarray, kind: str | None, leaf_name: str) -> np.ndarray:
+    """Dispatch transposition. Biases / scales / gammas / raw params pass through."""
+    if kind is None or leaf_name in ("bias", "scale", "gamma"):
+        return t
+    if leaf_name == "kernel":
+        if kind == "conv":
+            return _conv2d_to_flax(t) if t.ndim == 4 else _linear_to_flax(t)
+        if kind == "conv_transpose":
+            return _conv_transpose2d_to_flax(t)
+        if kind == "linear":
+            return _linear_to_flax(t)
+    return t
+
+
+def _match_rule(key: str) -> tuple[_Rule, re.Match[str]] | None:
+    for rule in RULES:
+        pat, _, _, _ = rule
+        m = pat.match(key)
+        if m is not None:
+            return rule, m
+    return None
+
+
+def _resolve_leaf_name(key: str, leaf_map: dict[str, str]) -> str:
+    """Determine the JAX leaf name from the PyTorch key's last component."""
+    _, last = _split_key_suffix(key)
+    if last in _PARAM_LEAF_NAMES:
+        return last
+    if last in leaf_map:
+        return leaf_map[last]
+    # Fallback: raw parameter name preserved (e.g. camera_token without suffix)
+    return last
+
+
+def _insert(tree: dict[str, Any], path: str, leaf: str, value: np.ndarray) -> None:
+    """Insert ``value`` at ``tree[path][leaf]``, creating intermediate dicts."""
+    node = tree
+    if path:
+        for part in path.split("."):
+            node = node.setdefault(part, {})
+    if leaf in node:
+        raise KeyError(f"Duplicate destination: {path}/{leaf}")
+    node[leaf] = value
+
+
+def load_pytorch_weights(
+    state_dict: dict[str, np.ndarray],
+    *,
+    include_v1_only: bool = True,
+) -> tuple[dict[str, Any], dict[str, list[str]]]:
+    """Convert a PyTorch StreamVGGT ``state_dict`` to a JAX PyTree.
+
+    Args:
+        state_dict: mapping from PyTorch parameter names to numpy arrays.
+        include_v1_only: if True (default), skip depth_head and track_head.
+
+    Returns:
+        (params_tree, report) where ``report`` has keys:
+          - ``"mapped"``:    list of state_dict keys that were mapped.
+          - ``"skipped"``:   list of state_dict keys skipped by v1 scope.
+          - ``"unmapped"``:  list of state_dict keys that no rule matched
+                             (this MUST be empty for Level-1 to pass).
+
+    Raises:
+        No exceptions on rule miss -- the caller checks ``report["unmapped"]``.
+    """
+    tree: dict[str, Any] = {}
+    report: dict[str, list[str]] = {"mapped": [], "skipped": [], "unmapped": []}
+
+    for key, tensor in state_dict.items():
+        if include_v1_only and key.startswith(V1_EXCLUDE_PREFIXES):
+            report["skipped"].append(key)
+            continue
+
+        matched = _match_rule(key)
+        if matched is None:
+            report["unmapped"].append(key)
+            continue
+
+        (_pat, path_template, leaf_map, transpose_kind), m = matched
+        # Expand backreferences in the path template.
+        try:
+            out_path = m.expand(path_template)
+        except re.error as e:
+            raise RuntimeError(f"Bad path_template for key {key!r}: {e}") from e
+
+        leaf_name = _resolve_leaf_name(key, leaf_map)
+        value = _apply_transpose(np.asarray(tensor), transpose_kind, leaf_name)
+        _insert(tree, out_path, leaf_name, value)
+        report["mapped"].append(key)
+
+    return tree, report
+
+
+# --------------------------------------------------------------------------- #
+#  Coverage / round-trip checks (Level-1 exit criterion)
+# --------------------------------------------------------------------------- #
+
+def verify_coverage(
+    state_dict: dict[str, np.ndarray],
+    report: dict[str, list[str]],
+) -> None:
+    """Assert every v1-scope state_dict key was mapped exactly once.
+
+    Raises AssertionError if any key is unmapped.
+    """
+    unmapped = report.get("unmapped", [])
+    assert not unmapped, f"{len(unmapped)} unmapped keys; first 10: {unmapped[:10]}"
+
+    in_scope = [k for k in state_dict if not k.startswith(V1_EXCLUDE_PREFIXES)]
+    mapped = set(report.get("mapped", []))
+    missing = [k for k in in_scope if k not in mapped]
+    assert not missing, f"{len(missing)} in-scope keys not mapped; first 10: {missing[:10]}"
+
+
+def verify_per_leaf_roundtrip(
+    state_dict: dict[str, np.ndarray],
+    tree: dict[str, Any],
+) -> None:
+    """Assert every JAX leaf equals the transposed source tensor exactly (atol=0).
+
+    Iterates state_dict rather than the tree so we also catch duplicate mappings.
+    """
+    for key, tensor in state_dict.items():
+        if key.startswith(V1_EXCLUDE_PREFIXES):
+            continue
+        matched = _match_rule(key)
+        assert matched is not None, f"Unmapped: {key}"
+        (_pat, path_template, leaf_map, transpose_kind), m = matched
+        out_path = m.expand(path_template)
+        leaf_name = _resolve_leaf_name(key, leaf_map)
+        expected = _apply_transpose(np.asarray(tensor), transpose_kind, leaf_name)
+
+        node = tree
+        if out_path:
+            for part in out_path.split("."):
+                node = node[part]
+        got = node[leaf_name]
+        if got.shape != expected.shape:
+            raise AssertionError(
+                f"Shape mismatch at {out_path}/{leaf_name}: got {got.shape}, expected {expected.shape} (from {key})"
+            )
+        if not np.array_equal(got, expected):
+            raise AssertionError(f"Value mismatch at {out_path}/{leaf_name} (from {key})")
+
+
+def count_leaves(tree: dict[str, Any]) -> int:
+    n = 0
+    stack = [tree]
+    while stack:
+        node = stack.pop()
+        for v in node.values():
+            if isinstance(v, dict):
+                stack.append(v)
+            else:
+                n += 1
+    return n
+
+
+def sum_numel(tree: dict[str, Any]) -> int:
+    s = 0
+    stack = [tree]
+    while stack:
+        node = stack.pop()
+        for v in node.values():
+            if isinstance(v, dict):
+                stack.append(v)
+            else:
+                s += int(np.asarray(v).size)
+    return s
+
+
+# --------------------------------------------------------------------------- #
+#  Checkpoint loading (HuggingFace)
+# --------------------------------------------------------------------------- #
+
+_DEFAULT_REPO = "lch01/StreamVGGT"
+
+
+def load_checkpoint(repo: str = _DEFAULT_REPO) -> dict[str, np.ndarray]:
+    """Download (or hit HF cache) and return StreamVGGT weights as numpy arrays.
+
+    Keeps the dependency on the PyTorch StreamVGGT class for one-time loading
+    (the checkpoint is pickled as a torch state_dict via PyTorchModelHubMixin),
+    then detaches into numpy so downstream code never needs torch again.
+    """
+    import sys
+
+    ivggt_src = Path(__file__).resolve().parents[3] / "external" / "InfiniteVGGT" / "src"
+    if str(ivggt_src) not in sys.path:
+        sys.path.insert(0, str(ivggt_src))
+
+    import torch  # noqa: E402 -- deferred until used
+    from streamvggt.models.streamvggt import StreamVGGT  # noqa: E402
+
+    with torch.device("cpu"):
+        model = StreamVGGT.from_pretrained(repo)
+    sd = model.state_dict()
+    return {k: v.detach().cpu().numpy() for k, v in sd.items()}

--- a/modules/vggt/jax/weight_transfer.py
+++ b/modules/vggt/jax/weight_transfer.py
@@ -56,9 +56,23 @@ def _conv2d_to_flax(t: np.ndarray) -> np.ndarray:
 
 
 def _conv_transpose2d_to_flax(t: np.ndarray) -> np.ndarray:
-    """(I, O, H, W) -> (H, W, I, O)."""
+    """(I, O, H, W) -> (H, W, I, O) with spatial axes reversed.
+
+    Flax ``nn.ConvTranspose`` (default ``transpose_kernel=False``) expects
+    kernel shape ``(*spatial, in_features, features)`` — same layout as
+    ``nn.Conv``. However the numerics of JAX's ``lax.conv_transpose`` treat
+    the kernel as the FORWARD-conv kernel whose transpose it computes, so
+    the kernel must be spatially flipped (H and W reversed) relative to
+    PyTorch's ``ConvTranspose2d`` convention.
+
+    Verified empirically: for a minimal 5x5 -> 20x20 conv_transpose with
+    stride=4, ``np.flip(np.transpose(pt_w, (2, 3, 0, 1)), axis=(0, 1))``
+    produces bit-exact parity with PyTorch while the un-flipped form gives
+    ~10-15 max-abs error.
+    """
     assert t.ndim == 4, t.shape
-    return np.transpose(t, (2, 3, 0, 1))
+    jax_layout = np.transpose(t, (2, 3, 0, 1))   # (I, O, H, W) -> (H, W, I, O)
+    return np.flip(jax_layout, axis=(0, 1)).copy()
 
 
 def _linear_to_flax(t: np.ndarray) -> np.ndarray:

--- a/modules/vggt/tests/test_jax_integration.py
+++ b/modules/vggt/tests/test_jax_integration.py
@@ -110,9 +110,13 @@ class TestJAXvsPyTorchExtractor:
 
     @pytest.fixture(scope="class")
     def jax_ext(self):
+        import jax.numpy as jnp
+
         from modules.vggt.jax import JAXVGGTFeatureExtractor
 
-        return JAXVGGTFeatureExtractor(device="cuda")
+        # Force fp32 to line up with the fp32-pinned PyTorch fixture below;
+        # default bf16 would exceed ROLLOUT_ATOL against fp32 PyTorch.
+        return JAXVGGTFeatureExtractor(device="cuda", dtype=jnp.float32)
 
     @pytest.fixture(scope="class")
     def pt_ext(self):

--- a/modules/vggt/tests/test_jax_integration.py
+++ b/modules/vggt/tests/test_jax_integration.py
@@ -1,0 +1,161 @@
+"""Level-4 integration tests for ``JAXVGGTFeatureExtractor`` (Step 7).
+
+Mirrors the contract tests in ``test_feature_extractor.py`` (shapes, NaN-
+free streaming, reset reproducibility) plus a cross-backend drop-in
+parity test: a 5-step rollout with the same RGB inputs should match the
+PyTorch extractor to within the production tolerance.
+"""
+
+from __future__ import annotations
+
+import os
+
+import jax
+
+# Match test_jax_parity: force highest matmul precision so parity isn't
+# blown by TF32 drift. Both backends then have a fair fp32 comparison.
+jax.config.update("jax_default_matmul_precision", "highest")
+
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+
+HAS_CUDA_JAX = bool(jax.devices("gpu"))
+try:
+    import torch
+
+    HAS_CUDA_PT = torch.cuda.is_available()
+except ImportError:
+    HAS_CUDA_PT = False
+
+gpu_jax = pytest.mark.skipif(not HAS_CUDA_JAX, reason="requires CUDA GPU for JAX")
+both = pytest.mark.skipif(
+    not (HAS_CUDA_JAX and HAS_CUDA_PT), reason="requires both JAX and PyTorch CUDA"
+)
+
+
+def _make_frame(seed: int = 0) -> np.ndarray:
+    """Synthetic 518x518 RGB frame (CHW, uint8)."""
+    rng = np.random.RandomState(seed)
+    return rng.randint(0, 256, size=(3, 518, 518), dtype=np.uint8)
+
+
+@gpu_jax
+class TestJAXFeatureExtractorContract:
+    """API-contract tests for the JAX extractor — mirrors PyTorch suite."""
+
+    @pytest.fixture(scope="class")
+    def extractor(self):
+        from modules.vggt.jax import JAXVGGTFeatureExtractor
+
+        return JAXVGGTFeatureExtractor(device="cuda")
+
+    def test_single_frame_shapes(self, extractor):
+        extractor.reset()
+        out = extractor.extract(_make_frame(seed=42))
+        assert out["world_points"].shape == (37, 37, 3)
+        assert out["camera_pose"].shape == (9,)
+        assert out["world_points"].dtype == np.float32
+        assert out["camera_pose"].dtype == np.float32
+
+    def test_streaming_multiple_frames(self, extractor):
+        """Five streaming frames produce NaN-free outputs of the right shape."""
+        extractor.reset()
+        for i in range(5):
+            out = extractor.extract(_make_frame(seed=i))
+            assert out["world_points"].shape == (37, 37, 3)
+            assert out["camera_pose"].shape == (9,)
+            assert not np.any(np.isnan(out["world_points"])), f"NaN at frame {i}"
+            assert not np.any(np.isnan(out["camera_pose"])), f"NaN at frame {i}"
+
+    def test_reset_reproduces_first_frame(self, extractor):
+        """reset() must fully clear cache + last_scores + frame counter."""
+        frame0 = _make_frame(seed=99)
+        extractor.reset()
+        out_first = extractor.extract(frame0)
+        for i in range(3):
+            extractor.extract(_make_frame(seed=200 + i))
+        extractor.reset()
+        out_again = extractor.extract(frame0)
+
+        np.testing.assert_allclose(
+            out_first["world_points"],
+            out_again["world_points"],
+            atol=1e-4,
+            err_msg="world_points differ after reset",
+        )
+        np.testing.assert_allclose(
+            out_first["camera_pose"],
+            out_again["camera_pose"],
+            atol=1e-4,
+            err_msg="camera_pose differs after reset",
+        )
+
+    def test_camera_pose_not_all_zero_after_second_frame(self, extractor):
+        extractor.reset()
+        extractor.extract(_make_frame(seed=10))
+        out2 = extractor.extract(_make_frame(seed=11))
+        assert not np.allclose(out2["camera_pose"], 0.0, atol=1e-6)
+
+
+@both
+class TestJAXvsPyTorchExtractor:
+    """Cross-backend drop-in parity — plan Level-4 exit gate."""
+
+    # Level-4 tolerance per the plan: ``atol ≤ 1e-2`` for the rollout.
+    # We relax slightly above the per-frame parity test (1e-3) because
+    # the pool operation + different float accumulation paths add noise.
+    ROLLOUT_ATOL = 1e-2
+    N_FRAMES = 5
+
+    @pytest.fixture(scope="class")
+    def jax_ext(self):
+        from modules.vggt.jax import JAXVGGTFeatureExtractor
+
+        return JAXVGGTFeatureExtractor(device="cuda")
+
+    @pytest.fixture(scope="class")
+    def pt_ext(self):
+        from modules.vggt.feature_extractor import VGGTFeatureExtractor
+
+        ext = VGGTFeatureExtractor(device="cuda")
+        # Force full-precision attention in the aggregator so the backends
+        # line up. Production bf16 parity is part of Step 8's benchmark.
+        ext.model.aggregator = ext.model.aggregator.to(torch.float32)
+        ext.model.camera_head = ext.model.camera_head.to(torch.float32)
+        ext.model.point_head = ext.model.point_head.to(torch.float32)
+        for blk in ext.model.aggregator.patch_embed.blocks:
+            blk.attn.fused_attn = False
+        for blk in ext.model.aggregator.frame_blocks:
+            blk.attn.fused_attn = False
+        for blk in ext.model.aggregator.global_blocks:
+            blk.attn.fused_attn = False
+        for blk in ext.model.camera_head.trunk:
+            blk.attn.fused_attn = False
+        # Disable the bf16 autocast the extractor installs by default.
+        ext._amp_dtype = torch.float32
+        yield ext
+        del ext
+        torch.cuda.empty_cache()
+
+    def test_rollout_parity(self, jax_ext, pt_ext):
+        """5-frame rollout: JAX outputs match PyTorch within Level-4 atol."""
+        frames = [_make_frame(seed=300 + i) for i in range(self.N_FRAMES)]
+
+        jax_ext.reset()
+        pt_ext.reset()
+
+        jax_outs = [jax_ext.extract(f) for f in frames]
+        pt_outs = [pt_ext.extract(f) for f in frames]
+
+        for i, (jx, pt) in enumerate(zip(jax_outs, pt_outs)):
+            wp_err = np.max(np.abs(jx["world_points"] - pt["world_points"]))
+            cp_err = np.max(np.abs(jx["camera_pose"] - pt["camera_pose"]))
+            assert wp_err <= self.ROLLOUT_ATOL, (
+                f"frame {i} world_points err={wp_err:.3e} "
+                f"> {self.ROLLOUT_ATOL:.0e}"
+            )
+            assert cp_err <= self.ROLLOUT_ATOL, (
+                f"frame {i} camera_pose err={cp_err:.3e} "
+                f"> {self.ROLLOUT_ATOL:.0e}"
+            )

--- a/modules/vggt/tests/test_jax_parity.py
+++ b/modules/vggt/tests/test_jax_parity.py
@@ -895,3 +895,151 @@ class TestLevel3CameraHeadCache:
             f"camera-head cache: max_abs={max_abs:.3e} "
             f"> {ATOL_CAMERA_CACHE_FP32:.0e}"
         )
+
+
+# --------------------------------------------------------------------------- #
+#  Level 3 -- eviction parity (Step 6b: static uniform budget)
+# --------------------------------------------------------------------------- #
+
+
+class TestLevel3Eviction:
+    """Step 6b gate: small-budget uniform eviction.
+
+    Runs exactly 4 frames so eviction fires **once** on the last frame:
+      * frames 0, 1, 2: pre-evict cache <= 3*P, no eviction fires.
+      * frame 3: pre-evict cache = 4*P > 3*P, eviction prunes to 3*P.
+
+    Stopping at 4 frames is deliberate: the reference updates its
+    ``self.last_scores`` buffer after eviction, after which subsequent
+    frames compute a NON-uniform per-block budget via softmax. That
+    dynamic-budget path lands in Step 6c. For 6b we verify that the
+    uniform branch (last_scores still zero on frame 3) matches PyTorch
+    exactly.
+
+    The first *P* tokens (frame 0) are anchors — never evicted. The
+    candidate scoring + top_k(-scores) path must match between PyTorch and
+    JAX for the cache contents to agree on which tokens were retained.
+    """
+
+    @pytest.fixture(scope="class")
+    def pt_aggregator(self, state_dict, pytorch_ivggt_module):
+        import torch
+        from streamvggt.models.aggregator import Aggregator as PtAggregator
+
+        pt_agg = PtAggregator(img_size=518, patch_size=14, embed_dim=1024).eval()
+        for blk in pt_agg.patch_embed.blocks:
+            blk.attn.fused_attn = False
+        for blk in pt_agg.frame_blocks:
+            blk.attn.fused_attn = False
+        for blk in pt_agg.global_blocks:
+            blk.attn.fused_attn = False
+
+        prefix = "aggregator."
+        pt_sd = {
+            k[len(prefix):]: torch.from_numpy(np.asarray(v))
+            for k, v in state_dict.items()
+            if k.startswith(prefix)
+        }
+        pt_agg.load_state_dict(pt_sd, strict=False)
+        return pt_agg
+
+    @pytest.fixture(scope="class")
+    def jx_params(self, state_dict):
+        tree, _ = load_pytorch_weights(state_dict, include_v1_only=True)
+        return jax.tree.map(jnp.asarray, {"params": tree["aggregator"]})
+
+    @pytest.fixture(scope="class")
+    def frames_and_budget(self):
+        # 4 frames; eviction fires exactly once, on the last frame.
+        rng = np.random.RandomState(91)
+        frames = rng.uniform(0.0, 1.0, size=(4, 3, 518, 518)).astype(np.float32)
+        P = 5 + (518 // 14) ** 2  # 1374
+        depth = 24
+        per_block = 3 * P
+        total_budget = per_block * depth
+        return frames, total_budget, per_block
+
+    @pytest.fixture(scope="class")
+    def pt_run(self, pt_aggregator, frames_and_budget):
+        import torch
+
+        frames, total_budget, _ = frames_and_budget
+        past = [None] * pt_aggregator.depth
+        outs = []
+        sizes = []
+        with torch.no_grad():
+            for i, frame in enumerate(frames):
+                one = torch.from_numpy(frame[None, None])
+                out_list, _, past = pt_aggregator(
+                    one,
+                    past_key_values=past,
+                    use_cache=True,
+                    past_frame_idx=i,
+                    total_budget=total_budget,
+                )
+                outs.append(out_list[-1].cpu().numpy())
+                sizes.append(past[0][0].shape[2])
+        # Convert past to numpy to release PyTorch tensors.
+        past_np = [(k.cpu().numpy(), v.cpu().numpy()) for (k, v) in past]
+        return outs, sizes, past_np
+
+    @pytest.fixture(scope="class")
+    def jx_run(self, jx_params, frames_and_budget):
+        from modules.vggt.jax.aggregator import Aggregator
+
+        frames, total_budget, _ = frames_and_budget
+        past = None
+        outs = []
+        sizes = []
+        for i, frame in enumerate(frames):
+            one = jnp.asarray(frame[None, None])
+            out_list, _, past = Aggregator().apply(
+                jx_params,
+                one,
+                use_cache=True,
+                past_kvs=past,
+                past_frame_idx=i,
+                total_budget=total_budget,
+            )
+            outs.append(np.asarray(out_list[-1]))
+            sizes.append(past[0][0].shape[2])
+        past_np = [(np.asarray(k), np.asarray(v)) for (k, v) in past]
+        return outs, sizes, past_np
+
+    def test_eviction_fires_at_same_frame(self, pt_run, jx_run):
+        """Both implementations should evict starting at frame 3."""
+        _, pt_sizes, _ = pt_run
+        _, jx_sizes, _ = jx_run
+        assert pt_sizes == jx_sizes, (
+            f"cache sizes diverge: PT={pt_sizes} JX={jx_sizes}"
+        )
+        P = 1374
+        expected = [P, 2 * P, 3 * P, 3 * P]
+        assert pt_sizes == expected, f"unexpected sizes: {pt_sizes}"
+
+    def test_retained_kv_matches_pytorch(self, pt_run, jx_run):
+        """After eviction, retained (K, V) must match bit-close — which is
+        equivalent to ``same indices retained`` under the scoring rule."""
+        _, _, pt_past = pt_run
+        _, _, jx_past = jx_run
+
+        for b in [0, 11, 23]:
+            pt_k, pt_v = pt_past[b]
+            jx_k, jx_v = jx_past[b]
+            assert pt_k.shape == jx_k.shape, (b, pt_k.shape, jx_k.shape)
+            max_abs_k = np.max(np.abs(pt_k - jx_k))
+            max_abs_v = np.max(np.abs(pt_v - jx_v))
+            # 3e-3 absorbs accumulated fp32-noise-through-24-blocks rounding.
+            assert max_abs_k <= 3e-3, f"block {b} K mismatch: {max_abs_k:.3e}"
+            assert max_abs_v <= 3e-3, f"block {b} V mismatch: {max_abs_v:.3e}"
+
+    def test_per_frame_output_matches_pytorch(self, pt_run, jx_run):
+        """Final aggregator outputs per frame within the cache tolerance."""
+        pt_outs, _, _ = pt_run
+        jx_outs, _, _ = jx_run
+        for i, (pt, jx) in enumerate(zip(pt_outs, jx_outs)):
+            max_abs = np.max(np.abs(pt - jx))
+            assert max_abs <= ATOL_AGGREGATOR_CACHE_FP32, (
+                f"frame {i} output: max_abs={max_abs:.3e} "
+                f"> {ATOL_AGGREGATOR_CACHE_FP32:.0e}"
+            )

--- a/modules/vggt/tests/test_jax_parity.py
+++ b/modules/vggt/tests/test_jax_parity.py
@@ -488,3 +488,71 @@ class TestLevel2AggregatorNoCache:
             f"aggregator no-cache parity: max_abs={max_abs:.3e} "
             f"> {ATOL_AGGREGATOR_NO_CACHE_FP32:.0e}"
         )
+
+
+# --------------------------------------------------------------------------- #
+#  Level 2 -- camera head parity (Step 4)
+# --------------------------------------------------------------------------- #
+
+
+ATOL_CAMERA_HEAD_FP32 = 1e-3
+
+
+class TestLevel2CameraHead:
+    """Step 4 parity gate: iterative AdaLN camera head on synthetic tokens.
+
+    Random ``aggregated_tokens_list`` suffices because the head is a pure
+    function of its input; we skip the 3-minute aggregator forward here.
+    """
+
+    @pytest.fixture(scope="class")
+    def pt_camera_head(self, state_dict, pytorch_ivggt_module):
+        import torch
+        from streamvggt.heads.camera_head import CameraHead as PtCameraHead
+
+        head = PtCameraHead(dim_in=2048).eval()
+        for blk in head.trunk:
+            blk.attn.fused_attn = False
+        prefix = "camera_head."
+        pt_sd = {
+            k[len(prefix):]: torch.from_numpy(np.asarray(v))
+            for k, v in state_dict.items()
+            if k.startswith(prefix)
+        }
+        missing, unexpected = head.load_state_dict(pt_sd, strict=False)
+        assert not missing, f"missing: {missing}"
+        assert not unexpected, f"unexpected: {unexpected}"
+        return head
+
+    @pytest.fixture(scope="class")
+    def jx_params(self, state_dict):
+        tree, _ = load_pytorch_weights(state_dict, include_v1_only=True)
+        return jax.tree.map(jnp.asarray, {"params": tree["camera_head"]})
+
+    @pytest.fixture(scope="class")
+    def aggregated_tokens(self):
+        # (B=1, S=2, P=1374, dim_in=2048) — realistic scale.
+        rng = np.random.RandomState(17)
+        last = rng.randn(1, 2, 1374, 2048).astype(np.float32) * 0.1
+        # head only uses the last list element; pass a singleton list.
+        return last
+
+    def test_camera_head_last_iter_matches_pytorch(
+        self, pt_camera_head, jx_params, aggregated_tokens
+    ):
+        import torch
+        from modules.vggt.jax.heads.camera_head import CameraHead
+
+        pt_tokens = torch.from_numpy(aggregated_tokens)
+        with torch.no_grad():
+            pt_list = pt_camera_head([pt_tokens])
+        pt_last = pt_list[-1].numpy()  # (B, S, 9)
+
+        jx_list = CameraHead().apply(jx_params, [jnp.asarray(aggregated_tokens)])
+        jx_last = np.asarray(jx_list[-1])
+
+        assert jx_last.shape == pt_last.shape, (jx_last.shape, pt_last.shape)
+        max_abs = np.max(np.abs(jx_last - pt_last))
+        assert max_abs <= ATOL_CAMERA_HEAD_FP32, (
+            f"camera-head parity: max_abs={max_abs:.3e} > {ATOL_CAMERA_HEAD_FP32:.0e}"
+        )

--- a/modules/vggt/tests/test_jax_parity.py
+++ b/modules/vggt/tests/test_jax_parity.py
@@ -304,3 +304,112 @@ class TestLevel2SharedBlockParity:
         assert max_abs <= ATOL_SINGLE_BLOCK_FP32, (
             f"single-block parity: max_abs={max_abs:.3e} > {ATOL_SINGLE_BLOCK_FP32:.0e}"
         )
+
+
+# --------------------------------------------------------------------------- #
+#  Level 2 -- DINOv2 backbone parity (Step 2)
+# --------------------------------------------------------------------------- #
+
+
+ATOL_PATCH_EMBED_FP32 = 1e-5
+ATOL_FULL_BACKBONE_FP32 = 1e-3  # 24 blocks of accumulated fp32 matmul drift
+
+
+class TestLevel2DinoV2Backbone:
+    """Step 2 parity gate: DINOv2 ViT-L/14-reg backbone at 518x518."""
+
+    @pytest.fixture(scope="class")
+    def pt_backbone(self, state_dict, pytorch_ivggt_module):
+        """PyTorch DINOv2 ViT-L loaded with checkpoint weights under the same
+        config the Aggregator builds (num_register_tokens=4, init_values=1.0,
+        interpolate_antialias=True, interpolate_offset=0.0, block_chunks=0)."""
+        import torch
+        from streamvggt.layers.vision_transformer import vit_large
+
+        model = vit_large(
+            patch_size=14,
+            img_size=518,
+            num_register_tokens=4,
+            interpolate_antialias=True,
+            interpolate_offset=0.0,
+            block_chunks=0,
+            init_values=1.0,
+        ).eval()
+        # Force naive attention path for clean parity (matches JAX manual attention).
+        for blk in model.blocks:
+            blk.attn.fused_attn = False
+
+        prefix = "aggregator.patch_embed."
+        pt_sd = {
+            k[len(prefix):]: torch.from_numpy(np.asarray(v))
+            for k, v in state_dict.items()
+            if k.startswith(prefix)
+        }
+        missing, unexpected = model.load_state_dict(pt_sd, strict=False)
+        # mask_token is loaded; prepare_tokens_with_masks skips it when masks is None.
+        assert not missing, f"missing: {missing}"
+        assert not unexpected, f"unexpected: {unexpected}"
+        return model
+
+    @pytest.fixture(scope="class")
+    def jx_params(self, state_dict):
+        """JAX param tree for the DinoV2Backbone sub-module."""
+        tree, _ = load_pytorch_weights(state_dict, include_v1_only=True)
+        return jax.tree.map(jnp.asarray, {"params": tree["aggregator"]["patch_embed"]})
+
+    @pytest.fixture(scope="class")
+    def sample_image(self):
+        """Random normalized NCHW image matching the aggregator's pipeline output."""
+        rng = np.random.RandomState(4242)
+        # Values in roughly the range of a normalized image.
+        return rng.randn(1, 3, 518, 518).astype(np.float32)
+
+    def test_patch_embed_conv_matches_pytorch(
+        self, pt_backbone, jx_params, sample_image
+    ):
+        """Inner 14x14 Conv patch embed only (before cls/pos/register)."""
+        import torch
+
+        with torch.no_grad():
+            # PyTorch reference: `model.patch_embed(images)` returns flattened
+            # (B, num_patches, embed_dim). We match that output shape.
+            pt_out = pt_backbone.patch_embed(torch.from_numpy(sample_image)).numpy()
+
+        from modules.vggt.jax.backbone import PatchEmbed
+
+        pe_params = {"params": jx_params["params"]["patch_embed"]}
+        # NCHW -> NHWC for Flax Conv
+        x_nhwc = jnp.asarray(np.transpose(sample_image, (0, 2, 3, 1)))
+        jx_conv = PatchEmbed(embed_dim=1024, patch_size=14).apply(pe_params, x_nhwc)
+        # Flatten spatial dims to match PyTorch's (B, num_patches, embed_dim)
+        jx_out = np.asarray(jx_conv).reshape(1, -1, 1024)
+
+        assert jx_out.shape == pt_out.shape, (jx_out.shape, pt_out.shape)
+        max_abs = np.max(np.abs(jx_out - pt_out))
+        assert max_abs <= ATOL_PATCH_EMBED_FP32, (
+            f"patch-embed parity: max_abs={max_abs:.3e} > {ATOL_PATCH_EMBED_FP32:.0e}"
+        )
+
+    def test_full_backbone_matches_pytorch(
+        self, pt_backbone, jx_params, sample_image
+    ):
+        """Full DINOv2 backbone (24 blocks + final norm), patch-tokens slice."""
+        import torch
+
+        with torch.no_grad():
+            pt_dict = pt_backbone(torch.from_numpy(sample_image), is_training=True)
+        pt_patch_tokens = pt_dict["x_norm_patchtokens"].numpy()  # (B, num_patches, 1024)
+
+        from modules.vggt.jax.backbone import DinoV2Backbone
+
+        jx_out = DinoV2Backbone().apply(jx_params, jnp.asarray(sample_image))
+        jx_out_np = np.asarray(jx_out)
+
+        assert jx_out_np.shape == pt_patch_tokens.shape, (
+            jx_out_np.shape,
+            pt_patch_tokens.shape,
+        )
+        max_abs = np.max(np.abs(jx_out_np - pt_patch_tokens))
+        assert max_abs <= ATOL_FULL_BACKBONE_FP32, (
+            f"full-backbone parity: max_abs={max_abs:.3e} > {ATOL_FULL_BACKBONE_FP32:.0e}"
+        )

--- a/modules/vggt/tests/test_jax_parity.py
+++ b/modules/vggt/tests/test_jax_parity.py
@@ -132,14 +132,19 @@ class TestTranspositionRules:
     def test_conv_transpose2d_layout(self):
         from modules.vggt.jax.weight_transfer import _conv_transpose2d_to_flax
 
-        pt = np.random.randn(4, 8, 2, 2).astype(np.float32)  # (I, O, H, W)
+        # Use H=W=3 to catch spatial-axis flip (2x2 happens to be symmetric-ish).
+        pt = np.random.randn(4, 8, 3, 3).astype(np.float32)  # (I, O, H, W)
         jx = _conv_transpose2d_to_flax(pt)
-        assert jx.shape == (2, 2, 4, 8)
+        # Flax nn.ConvTranspose uses (H, W, in, out) layout (same as nn.Conv),
+        # but requires spatially-flipped kernel vs PyTorch's ConvTranspose2d.
+        assert jx.shape == (3, 3, 4, 8)
+        H, W = 3, 3
         for i in range(4):
             for o in range(8):
-                for kh in range(2):
-                    for kw in range(2):
-                        assert jx[kh, kw, i, o] == pt[i, o, kh, kw]
+                for kh in range(H):
+                    for kw in range(W):
+                        # Spatial flip: jax[kh, kw] corresponds to pt[:, :, H-1-kh, W-1-kw].
+                        assert jx[kh, kw, i, o] == pt[i, o, H - 1 - kh, W - 1 - kw]
 
     def test_linear_layout(self):
         from modules.vggt.jax.weight_transfer import _linear_to_flax
@@ -555,4 +560,109 @@ class TestLevel2CameraHead:
         max_abs = np.max(np.abs(jx_last - pt_last))
         assert max_abs <= ATOL_CAMERA_HEAD_FP32, (
             f"camera-head parity: max_abs={max_abs:.3e} > {ATOL_CAMERA_HEAD_FP32:.0e}"
+        )
+
+
+# --------------------------------------------------------------------------- #
+#  Level 2 -- DPT point head parity (Step 5)
+# --------------------------------------------------------------------------- #
+
+
+ATOL_POINT_HEAD_FP32 = 1e-3
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Step 5 WIP: DPT decoder output drifts by ~0.8 max-abs vs PyTorch "
+        "reference despite individual components (projects/resize/refinenet/"
+        "bilinear/out_conv) matching at fp32 noise (~1e-6) when tested in "
+        "isolation. Bug manifests only when the full forward chains them "
+        "together; likely in an interaction between the setup()-mode "
+        "ResidualConvUnit and the bilinear-upsample step. Hand-off marker."
+    ),
+    strict=True,
+)
+class TestLevel2PointHead:
+    """Step 5 parity gate: DPT decoder producing pts3d + conf.
+
+    Random aggregated_tokens_list (24 entries, only indices 4/11/17/23 are
+    actually read by the head) and a dummy image tensor are enough here: the
+    head is a pure function of those inputs, so we skip the 3-minute
+    aggregator forward.
+    """
+
+    @pytest.fixture(scope="class")
+    def pt_point_head(self, state_dict, pytorch_ivggt_module):
+        import torch
+        from streamvggt.heads.dpt_head import DPTHead as PtDPTHead
+
+        head = PtDPTHead(
+            dim_in=2048,
+            output_dim=4,
+            activation="inv_log",
+            conf_activation="expp1",
+            pos_embed=True,
+        ).eval()
+        prefix = "point_head."
+        pt_sd = {
+            k[len(prefix):]: torch.from_numpy(np.asarray(v))
+            for k, v in state_dict.items()
+            if k.startswith(prefix)
+        }
+        missing, unexpected = head.load_state_dict(pt_sd, strict=False)
+        assert not missing, f"missing: {missing}"
+        assert not unexpected, f"unexpected: {unexpected}"
+        return head
+
+    @pytest.fixture(scope="class")
+    def jx_params(self, state_dict):
+        tree, _ = load_pytorch_weights(state_dict, include_v1_only=True)
+        return jax.tree.map(jnp.asarray, {"params": tree["point_head"]})
+
+    @pytest.fixture(scope="class")
+    def synthetic_inputs(self):
+        # 24 aggregated levels, only 4/11/17/23 are consumed.
+        rng = np.random.RandomState(101)
+        B, S, P, dim_in = 1, 1, 1374, 2048  # 5 special + 1369 patch
+        agg_list = [
+            rng.randn(B, S, P, dim_in).astype(np.float32) * 0.1
+            for _ in range(24)
+        ]
+        # Images are only used for H, W, B, S in the DPT forward.
+        images = np.zeros((B, S, 3, 518, 518), dtype=np.float32)
+        return agg_list, images
+
+    def test_point_head_matches_pytorch(
+        self, pt_point_head, jx_params, synthetic_inputs
+    ):
+        import torch
+        from modules.vggt.jax.heads.dpt_head import DPTHead
+
+        agg_list, images = synthetic_inputs
+        pt_agg = [torch.from_numpy(x) for x in agg_list]
+        with torch.no_grad():
+            pt_pts3d, pt_conf = pt_point_head(
+                pt_agg, images=torch.from_numpy(images), patch_start_idx=5
+            )
+        pt_pts3d_np = pt_pts3d.numpy()
+        pt_conf_np = pt_conf.numpy()
+
+        jx_pts3d, jx_conf = DPTHead().apply(
+            jx_params,
+            [jnp.asarray(x) for x in agg_list],
+            jnp.asarray(images),
+            5,
+        )
+        jx_pts3d_np = np.asarray(jx_pts3d)
+        jx_conf_np = np.asarray(jx_conf)
+
+        assert jx_pts3d_np.shape == pt_pts3d_np.shape
+        assert jx_conf_np.shape == pt_conf_np.shape
+        max_abs_pts = np.max(np.abs(jx_pts3d_np - pt_pts3d_np))
+        max_abs_conf = np.max(np.abs(jx_conf_np - pt_conf_np))
+        assert max_abs_pts <= ATOL_POINT_HEAD_FP32, (
+            f"point-head pts3d: max_abs={max_abs_pts:.3e} > {ATOL_POINT_HEAD_FP32:.0e}"
+        )
+        assert max_abs_conf <= ATOL_POINT_HEAD_FP32, (
+            f"point-head conf: max_abs={max_abs_conf:.3e} > {ATOL_POINT_HEAD_FP32:.0e}"
         )

--- a/modules/vggt/tests/test_jax_parity.py
+++ b/modules/vggt/tests/test_jax_parity.py
@@ -1,0 +1,306 @@
+"""Parity tests for the JAX StreamVGGT reimplementation.
+
+This file implements Levels 1-3 from the plan:
+
+- **Level 1** (Step 1): weight-transfer correctness.
+- **Level 2** (Steps 1.5-5): per-layer numerical equivalence, fp32 reference.
+  Step 1.5 covers the shared block infrastructure via a single aggregator
+  ``frame_blocks.0`` parity check which exercises Attention+LayerNorm+MLP+
+  LayerScale+RoPE in one shot.
+
+Subsequent levels (streaming, integration) land as later steps come online.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import jax
+
+# JAX on Ampere+ GPUs (H100) defaults to TF32 matmul precision, which caps
+# accumulated fp32 errors around 1e-3 after a few layers. PyTorch on CPU (our
+# parity baseline) runs full fp32. Force highest precision for parity tests so
+# the tolerance ladder reflects algorithmic equivalence, not TF32 vs fp32.
+jax.config.update("jax_default_matmul_precision", "highest")
+
+import jax.numpy as jnp  # noqa: E402
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+from modules.vggt.jax.weight_transfer import (
+    V1_EXCLUDE_PREFIXES,
+    count_leaves,
+    load_checkpoint,
+    load_pytorch_weights,
+    sum_numel,
+    verify_coverage,
+    verify_per_leaf_roundtrip,
+)
+
+
+# Downloading the 1.26B-param HF checkpoint is slow on first run; cache the
+# numpy state_dict to a scratch path so repeated test runs are quick.
+_CACHE_DIR = Path(os.environ.get("VGGT_TEST_CACHE", "/tmp/vggt_test_cache"))
+_CACHE_NPZ = _CACHE_DIR / "streamvggt_state_dict.npz"
+
+
+@pytest.fixture(scope="module")
+def state_dict() -> dict[str, np.ndarray]:
+    """Cached numpy state_dict from the HF StreamVGGT checkpoint."""
+    if _CACHE_NPZ.exists():
+        with np.load(_CACHE_NPZ, allow_pickle=False) as f:
+            return {k: f[k] for k in f.files}
+    sd = load_checkpoint()
+    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    np.savez(_CACHE_NPZ, **sd)
+    return sd
+
+
+# --------------------------------------------------------------------------- #
+#  Level 1
+# --------------------------------------------------------------------------- #
+
+
+class TestLevel1WeightTransfer:
+    """Exit criterion: every in-scope key mapped, per-leaf roundtrip exact."""
+
+    def test_coverage(self, state_dict):
+        _tree, report = load_pytorch_weights(state_dict, include_v1_only=True)
+        verify_coverage(state_dict, report)
+
+    def test_no_v1_keys_unmapped(self, state_dict):
+        _tree, report = load_pytorch_weights(state_dict, include_v1_only=True)
+        assert report["unmapped"] == [], (
+            f"Unmapped keys: {report['unmapped'][:10]}"
+        )
+
+    def test_v1_skips_depth_and_track(self, state_dict):
+        _tree, report = load_pytorch_weights(state_dict, include_v1_only=True)
+        for k in report["skipped"]:
+            assert k.startswith(V1_EXCLUDE_PREFIXES), k
+        # Every out-of-scope key was indeed skipped (not silently mapped)
+        out_of_scope = [k for k in state_dict if k.startswith(V1_EXCLUDE_PREFIXES)]
+        assert set(report["skipped"]) == set(out_of_scope)
+
+    def test_per_leaf_exact_roundtrip(self, state_dict):
+        tree, _ = load_pytorch_weights(state_dict, include_v1_only=True)
+        # Bit-exact: atol=0 enforced inside verify_per_leaf_roundtrip via array_equal.
+        verify_per_leaf_roundtrip(state_dict, tree)
+
+    def test_param_count_matches(self, state_dict):
+        tree, _ = load_pytorch_weights(state_dict, include_v1_only=True)
+        in_scope_sum = sum(
+            int(t.size) for k, t in state_dict.items() if not k.startswith(V1_EXCLUDE_PREFIXES)
+        )
+        assert sum_numel(tree) == in_scope_sum
+
+    def test_leaf_count_matches(self, state_dict):
+        tree, _ = load_pytorch_weights(state_dict, include_v1_only=True)
+        in_scope_n = sum(1 for k in state_dict if not k.startswith(V1_EXCLUDE_PREFIXES))
+        assert count_leaves(tree) == in_scope_n
+
+    def test_v1_expected_tensor_count(self, state_dict):
+        # From the checkpoint inventory: aggregator (1210) + camera_head (69)
+        # + point_head (62) = 1341 tensors in v1 scope. This guards against
+        # silently dropping keys if the checkpoint structure shifts upstream.
+        in_scope_n = sum(1 for k in state_dict if not k.startswith(V1_EXCLUDE_PREFIXES))
+        assert in_scope_n == 1341, f"expected 1341 v1 tensors, got {in_scope_n}"
+
+
+# --------------------------------------------------------------------------- #
+#  Transposition unit tests (no checkpoint needed)
+# --------------------------------------------------------------------------- #
+
+
+class TestTranspositionRules:
+    """Cheap property-style tests for the four transposition families."""
+
+    def test_conv2d_layout(self):
+        from modules.vggt.jax.weight_transfer import _conv2d_to_flax
+
+        pt = np.random.randn(8, 4, 3, 3).astype(np.float32)  # (O, I, H, W)
+        jx = _conv2d_to_flax(pt)
+        assert jx.shape == (3, 3, 4, 8)
+        # element at (kh, kw, i, o) must equal source (o, i, kh, kw)
+        for o in range(8):
+            for i in range(4):
+                for kh in range(3):
+                    for kw in range(3):
+                        assert jx[kh, kw, i, o] == pt[o, i, kh, kw]
+
+    def test_conv_transpose2d_layout(self):
+        from modules.vggt.jax.weight_transfer import _conv_transpose2d_to_flax
+
+        pt = np.random.randn(4, 8, 2, 2).astype(np.float32)  # (I, O, H, W)
+        jx = _conv_transpose2d_to_flax(pt)
+        assert jx.shape == (2, 2, 4, 8)
+        for i in range(4):
+            for o in range(8):
+                for kh in range(2):
+                    for kw in range(2):
+                        assert jx[kh, kw, i, o] == pt[i, o, kh, kw]
+
+    def test_linear_layout(self):
+        from modules.vggt.jax.weight_transfer import _linear_to_flax
+
+        pt = np.random.randn(32, 8).astype(np.float32)  # (O, I)
+        jx = _linear_to_flax(pt)
+        assert jx.shape == (8, 32)
+        np.testing.assert_array_equal(jx, pt.T)
+
+
+# --------------------------------------------------------------------------- #
+#  Level 2 -- single aggregator frame_block parity
+# --------------------------------------------------------------------------- #
+
+
+# ATOL from the repo's established ladder. The per-block budget at fp32 is
+# "single attention block: atol <= 1e-4" per the plan's Success Criteria.
+ATOL_SINGLE_BLOCK_FP32 = 1e-4
+
+
+@pytest.fixture(scope="module")
+def pytorch_ivggt_module():
+    """Import the PyTorch StreamVGGT layer module once (adds external to sys.path)."""
+    import sys
+
+    ext = str(
+        Path(__file__).resolve().parents[3] / "external" / "InfiniteVGGT" / "src"
+    )
+    if ext not in sys.path:
+        sys.path.insert(0, ext)
+    import streamvggt  # noqa: F401
+    return streamvggt
+
+
+class TestLevel2SharedBlockParity:
+    """Single-block parity: covers Attention, LayerNorm, MLP, LayerScale, RoPE.
+
+    We pick ``aggregator.frame_blocks.0`` because it exercises every piece of
+    shared infra (qk_norm=True, RoPE wired, LayerScale present).
+    """
+
+    @pytest.fixture(scope="class")
+    def fixtures(self, state_dict, pytorch_ivggt_module):
+        """Load weights, build matched PyTorch and JAX single-block modules."""
+        import torch
+        from streamvggt.layers.block import Block as PtBlock
+        from streamvggt.layers.rope import RotaryPositionEmbedding2D
+
+        # Aggregator config for vit_large path (see aggregator.py:50-68).
+        dim = 1024
+        num_heads = 16
+        head_dim = dim // num_heads  # 64
+        mlp_ratio = 4.0
+        init_values = 0.01
+        qk_norm = True
+        rope_frequency = 100.0
+
+        # --- PyTorch module ---
+        pt_rope = RotaryPositionEmbedding2D(frequency=rope_frequency)
+        pt_block = PtBlock(
+            dim=dim,
+            num_heads=num_heads,
+            mlp_ratio=mlp_ratio,
+            qkv_bias=True,
+            proj_bias=True,
+            ffn_bias=True,
+            init_values=init_values,
+            qk_norm=qk_norm,
+            rope=pt_rope,
+        ).eval()
+
+        # Load block-0 weights from the full state_dict into pt_block.
+        prefix = "aggregator.frame_blocks.0."
+        pt_sd = {
+            k[len(prefix):]: torch.from_numpy(np.asarray(v))
+            for k, v in state_dict.items()
+            if k.startswith(prefix)
+        }
+        missing, unexpected = pt_block.load_state_dict(pt_sd, strict=False)
+        assert not missing, f"missing keys: {missing}"
+        assert not unexpected, f"unexpected keys: {unexpected}"
+
+        # --- JAX module ---
+        from modules.vggt.jax.block import Block as JxBlock
+        from modules.vggt.jax.rope import compute_1d_rope_tables
+        from modules.vggt.jax.weight_transfer import load_pytorch_weights
+
+        jx_block = JxBlock(
+            dim=dim,
+            num_heads=num_heads,
+            mlp_ratio=mlp_ratio,
+            qk_norm=qk_norm,
+            init_values=init_values,
+            norm_eps=1e-5,
+        )
+
+        full_tree, _ = load_pytorch_weights(state_dict, include_v1_only=True)
+        jx_params = {"params": full_tree["aggregator"]["frame_blocks_0"]}
+        jx_params = jax.tree.map(jnp.asarray, jx_params)
+
+        # --- Inputs common to both ---
+        # B=1, S=1; grid 37x37 -> P = 1 (cam) + 4 (reg) + 1369 (patch) = 1374.
+        rng = np.random.RandomState(1234)
+        x_np = rng.randn(1, 1374, dim).astype(np.float32)
+
+        # Build positions the same way aggregator.forward does (aggregator.py:247-254):
+        # patch positions from cartesian product of [0, 37) x [0, 37), shifted by +1,
+        # special tokens (first patch_start_idx=5) get zeros.
+        ys, xs = np.meshgrid(np.arange(37), np.arange(37), indexing="ij")
+        patch_pos = np.stack([ys.reshape(-1), xs.reshape(-1)], axis=-1)  # (1369, 2)
+        patch_pos = patch_pos + 1  # aggregator shifts by 1
+        special = np.zeros((5, 2), dtype=patch_pos.dtype)
+        positions_np = np.concatenate([special, patch_pos], axis=0)[None]  # (1, 1374, 2)
+
+        return dict(
+            pt_block=pt_block,
+            pt_rope=pt_rope,
+            jx_block=jx_block,
+            jx_params=jx_params,
+            x_np=x_np,
+            positions_np=positions_np,
+            head_dim=head_dim,
+            rope_frequency=rope_frequency,
+        )
+
+    def test_single_frame_block_matches_pytorch(self, fixtures):
+        import torch
+
+        x_np = fixtures["x_np"]
+        positions_np = fixtures["positions_np"]
+        head_dim = fixtures["head_dim"]
+        freq = fixtures["rope_frequency"]
+
+        # --- PyTorch forward ---
+        with torch.no_grad():
+            pt_out = fixtures["pt_block"](
+                torch.from_numpy(x_np),
+                pos=torch.from_numpy(positions_np.astype(np.int64)),
+            ).numpy()
+
+        # --- JAX forward (same RoPE tables the PyTorch version would build) ---
+        from modules.vggt.jax.rope import compute_1d_rope_tables
+
+        max_pos = int(positions_np.max()) + 1  # 38
+        cos_t, sin_t = compute_1d_rope_tables(
+            dim=head_dim // 2,  # 2D RoPE splits per-head dim in half
+            max_pos=max_pos,
+            frequency=freq,
+            dtype=jnp.float32,
+        )
+        jx_out = fixtures["jx_block"].apply(
+            fixtures["jx_params"],
+            jnp.asarray(x_np),
+            rope_tables=(cos_t, sin_t),
+            positions=jnp.asarray(positions_np),
+        )
+        jx_out_np = np.asarray(jx_out)
+
+        # Shape first so mismatches are obvious before value diffs.
+        assert jx_out_np.shape == pt_out.shape, (jx_out_np.shape, pt_out.shape)
+        max_abs = np.max(np.abs(jx_out_np - pt_out))
+        assert max_abs <= ATOL_SINGLE_BLOCK_FP32, (
+            f"single-block parity: max_abs={max_abs:.3e} > {ATOL_SINGLE_BLOCK_FP32:.0e}"
+        )

--- a/modules/vggt/tests/test_jax_parity.py
+++ b/modules/vggt/tests/test_jax_parity.py
@@ -1253,3 +1253,141 @@ class TestLevel3DynamicBudget:
             max_abs_v = np.max(np.abs(pt_v[:, :, :P] - jx_v[:, :, :P]))
             assert max_abs_k <= 3e-3, f"block {b} anchor K: {max_abs_k:.3e}"
             assert max_abs_v <= 3e-3, f"block {b} anchor V: {max_abs_v:.3e}"
+
+
+# --------------------------------------------------------------------------- #
+#  Level 3: padded-vs-legacy KV-cache parity
+# --------------------------------------------------------------------------- #
+
+# The JAXVGGTFeatureExtractor uses a fixed-size padded 3-tuple cache
+# (k_pad, v_pad, valid_len) so the aggregator can be jitted once and reused.
+# The existing Level-3 tests above all use past_kvs=None and therefore only
+# exercise the legacy 2-tuple growing path. These tests lock the padded path
+# to the legacy path's numerics so layout/reshape/mask regressions surface
+# at a small block-level unit instead of only the 4-min integration test.
+ATOL_PADDED_VS_LEGACY_FP32 = 1e-5
+
+
+class TestLevel3PaddedCacheParity:
+    """Padded 3-tuple cache must match legacy 2-tuple cache bit-for-bit.
+
+    Both paths implement the same math — attention over [past tokens | new
+    tokens]. The padded path pre-allocates a fixed buffer and masks invalid
+    slots; the legacy path grows a list by concat. With no eviction, the
+    two must produce identical output and identical stored K/V (at the
+    valid prefix).
+    """
+
+    @pytest.fixture(scope="class")
+    def block_setup(self):
+        from modules.vggt.jax.block import Block
+
+        dim = 64
+        num_heads = 4
+        head_dim = dim // num_heads
+        N = 8
+        block = Block(
+            dim=dim, num_heads=num_heads, mlp_ratio=2.0,
+            qk_norm=False, init_values=None,
+        )
+        rng_key = jax.random.PRNGKey(0)
+        x_init = jnp.zeros((1, N, dim), dtype=jnp.float32)
+        params = block.init(rng_key, x_init, use_cache=False)
+        return dict(block=block, params=params, dim=dim, num_heads=num_heads,
+                    head_dim=head_dim, N=N)
+
+    def _empty_padded(self, B, H, MAX, Dh, dtype=jnp.float32):
+        return (
+            jnp.zeros((B, H, MAX, Dh), dtype=dtype),
+            jnp.zeros((B, H, MAX, Dh), dtype=dtype),
+            jnp.asarray(0, dtype=jnp.int32),
+        )
+
+    def test_single_frame_padded_matches_legacy(self, block_setup):
+        """Frame 0, no prior cache — padded and legacy must give identical output.
+
+        This is the exact case that caught the (0,2,1,3) transpose bug in
+        _padded_cache_forward's output reshape.
+        """
+        block = block_setup["block"]
+        params = block_setup["params"]
+        N, H, Dh = block_setup["N"], block_setup["num_heads"], block_setup["head_dim"]
+        MAX = 64
+        cache_budget = 48
+
+        x = jax.random.normal(jax.random.PRNGKey(42), (1, N, block_setup["dim"]),
+                               dtype=jnp.float32)
+
+        out_legacy, kv_legacy, _ = block.apply(
+            params, x, past_kv=None, use_cache=True,
+            cache_budget=cache_budget, num_anchor_tokens=0,
+        )
+        out_padded, kv_padded, _ = block.apply(
+            params, x, past_kv=self._empty_padded(1, H, MAX, Dh),
+            use_cache=True, cache_budget=cache_budget, num_anchor_tokens=0,
+        )
+
+        max_abs = np.max(np.abs(np.asarray(out_legacy) - np.asarray(out_padded)))
+        assert max_abs <= ATOL_PADDED_VS_LEGACY_FP32, (
+            f"single-frame output drift: {max_abs:.3e} > {ATOL_PADDED_VS_LEGACY_FP32:.0e}"
+        )
+        # Stored K/V must also match at the valid prefix.
+        k_leg, v_leg = kv_legacy
+        k_pad, v_pad, vl = kv_padded
+        vl_int = int(np.asarray(vl))
+        assert vl_int == N, (vl_int, N)
+        np.testing.assert_allclose(np.asarray(k_leg), np.asarray(k_pad[:, :, :N]),
+                                    atol=ATOL_PADDED_VS_LEGACY_FP32)
+        np.testing.assert_allclose(np.asarray(v_leg), np.asarray(v_pad[:, :, :N]),
+                                    atol=ATOL_PADDED_VS_LEGACY_FP32)
+
+    def test_streaming_rollout_padded_matches_legacy(self, block_setup):
+        """5-frame rollout, no eviction — padded must match legacy at every frame.
+
+        Catches incremental-write bugs (off-by-one in valid_len, wrong
+        dynamic_update_slice offset, stale mask) that single-frame misses.
+        """
+        block = block_setup["block"]
+        params = block_setup["params"]
+        N, H, Dh = block_setup["N"], block_setup["num_heads"], block_setup["head_dim"]
+        n_frames = 5
+        # Budget > total tokens so eviction never fires (this test is about
+        # the write + masked-read path, not eviction).
+        cache_budget = n_frames * N + 4
+        MAX = cache_budget + N  # room for one more append before any evict
+
+        rng = jax.random.PRNGKey(7)
+        xs = [jax.random.normal(k, (1, N, block_setup["dim"]), dtype=jnp.float32)
+              for k in jax.random.split(rng, n_frames)]
+
+        legacy_past = None
+        padded_past = self._empty_padded(1, H, MAX, Dh)
+        for i, x in enumerate(xs):
+            out_l, legacy_past, _ = block.apply(
+                params, x, past_kv=legacy_past, use_cache=True,
+                cache_budget=cache_budget, num_anchor_tokens=0,
+            )
+            out_p, padded_past, _ = block.apply(
+                params, x, past_kv=padded_past, use_cache=True,
+                cache_budget=cache_budget, num_anchor_tokens=0,
+            )
+            max_abs = np.max(np.abs(np.asarray(out_l) - np.asarray(out_p)))
+            assert max_abs <= ATOL_PADDED_VS_LEGACY_FP32, (
+                f"frame {i} output drift: {max_abs:.3e} > {ATOL_PADDED_VS_LEGACY_FP32:.0e}"
+            )
+            # Valid prefix of the padded K/V must equal the legacy K/V.
+            k_leg, v_leg = legacy_past
+            k_pad, v_pad, vl = padded_past
+            vl_int = int(np.asarray(vl))
+            expected_vl = (i + 1) * N
+            assert vl_int == expected_vl, (i, vl_int, expected_vl)
+            np.testing.assert_allclose(
+                np.asarray(k_leg), np.asarray(k_pad[:, :, :expected_vl]),
+                atol=ATOL_PADDED_VS_LEGACY_FP32,
+                err_msg=f"frame {i} K prefix mismatch",
+            )
+            np.testing.assert_allclose(
+                np.asarray(v_leg), np.asarray(v_pad[:, :, :expected_vl]),
+                atol=ATOL_PADDED_VS_LEGACY_FP32,
+                err_msg=f"frame {i} V prefix mismatch",
+            )

--- a/modules/vggt/tests/test_jax_parity.py
+++ b/modules/vggt/tests/test_jax_parity.py
@@ -413,3 +413,78 @@ class TestLevel2DinoV2Backbone:
         assert max_abs <= ATOL_FULL_BACKBONE_FP32, (
             f"full-backbone parity: max_abs={max_abs:.3e} > {ATOL_FULL_BACKBONE_FP32:.0e}"
         )
+
+
+# --------------------------------------------------------------------------- #
+#  Level 2 -- aggregator no-cache parity (Step 3)
+# --------------------------------------------------------------------------- #
+
+
+ATOL_AGGREGATOR_NO_CACHE_FP32 = 1e-3
+
+
+class TestLevel2AggregatorNoCache:
+    """Step 3 parity gate: full aggregator forward without KV-cache.
+
+    Uses S=2 so the global attention's causal frame mask is actually exercised
+    (S=1 would leave it a no-op).
+    """
+
+    @pytest.fixture(scope="class")
+    def pt_aggregator(self, state_dict, pytorch_ivggt_module):
+        import torch
+        from streamvggt.models.aggregator import Aggregator as PtAggregator
+
+        pt_agg = PtAggregator(img_size=518, patch_size=14, embed_dim=1024).eval()
+        # Force naive attention in every block (DINOv2 patch_embed + frame + global).
+        for blk in pt_agg.patch_embed.blocks:
+            blk.attn.fused_attn = False
+        for blk in pt_agg.frame_blocks:
+            blk.attn.fused_attn = False
+        for blk in pt_agg.global_blocks:
+            blk.attn.fused_attn = False
+
+        prefix = "aggregator."
+        pt_sd = {
+            k[len(prefix):]: torch.from_numpy(np.asarray(v))
+            for k, v in state_dict.items()
+            if k.startswith(prefix)
+        }
+        missing, unexpected = pt_agg.load_state_dict(pt_sd, strict=False)
+        assert not missing, f"missing: {missing}"
+        assert not unexpected, f"unexpected: {unexpected}"
+        return pt_agg
+
+    @pytest.fixture(scope="class")
+    def jx_params(self, state_dict):
+        tree, _ = load_pytorch_weights(state_dict, include_v1_only=True)
+        return jax.tree.map(jnp.asarray, {"params": tree["aggregator"]})
+
+    @pytest.fixture(scope="class")
+    def sample_frames(self):
+        # B=1, S=2 frames, 518x518, values in [0, 1] like the aggregator expects.
+        rng = np.random.RandomState(7)
+        return rng.uniform(0.0, 1.0, size=(1, 2, 3, 518, 518)).astype(np.float32)
+
+    def test_aggregator_last_level_matches_pytorch(
+        self, pt_aggregator, jx_params, sample_frames
+    ):
+        import torch
+        from modules.vggt.jax.aggregator import Aggregator
+
+        with torch.no_grad():
+            pt_out_list, pt_patch_start = pt_aggregator(torch.from_numpy(sample_frames))
+        pt_last = pt_out_list[-1].numpy()  # (B, S, P, 2*C)
+
+        jx_out_list, jx_patch_start = Aggregator().apply(
+            jx_params, jnp.asarray(sample_frames)
+        )
+        assert jx_patch_start == pt_patch_start == 5
+        jx_last = np.asarray(jx_out_list[-1])
+
+        assert jx_last.shape == pt_last.shape, (jx_last.shape, pt_last.shape)
+        max_abs = np.max(np.abs(jx_last - pt_last))
+        assert max_abs <= ATOL_AGGREGATOR_NO_CACHE_FP32, (
+            f"aggregator no-cache parity: max_abs={max_abs:.3e} "
+            f"> {ATOL_AGGREGATOR_NO_CACHE_FP32:.0e}"
+        )

--- a/modules/vggt/tests/test_jax_parity.py
+++ b/modules/vggt/tests/test_jax_parity.py
@@ -737,11 +737,17 @@ class TestLevel3AggregatorCache:
 
         # Cache: loop frame-by-frame with S=1 each.
         past_kvs = None
+        last_scores = None
         cached_last_per_frame = []
         for i in range(frames.shape[0]):
             one = jnp.asarray(frames[i : i + 1][None])  # (1, 1, 3, H, W)
-            out_list, _, past_kvs = Aggregator().apply(
-                jx_params, one, use_cache=True, past_kvs=past_kvs, past_frame_idx=i
+            out_list, _, past_kvs, last_scores = Aggregator().apply(
+                jx_params,
+                one,
+                use_cache=True,
+                past_kvs=past_kvs,
+                past_frame_idx=i,
+                last_scores=last_scores,
             )
             cached_last_per_frame.append(np.asarray(out_list[-1]))
         cached_last = np.concatenate(cached_last_per_frame, axis=1)  # (1, N, P, 2C)
@@ -790,15 +796,17 @@ class TestLevel3AggregatorCache:
 
         # ---- JAX: loop with use_cache=True ----
         jx_past_kvs = None
+        jx_last_scores = None
         jx_last_per_frame = []
         for i in range(N):
             one = jnp.asarray(frames[i : i + 1][None])
-            out_list, _, jx_past_kvs = Aggregator().apply(
+            out_list, _, jx_past_kvs, jx_last_scores = Aggregator().apply(
                 jx_params,
                 one,
                 use_cache=True,
                 past_kvs=jx_past_kvs,
                 past_frame_idx=i,
+                last_scores=jx_last_scores,
             )
             jx_last_per_frame.append(np.asarray(out_list[-1]))
         jx_last = np.concatenate(jx_last_per_frame, axis=1)
@@ -989,17 +997,19 @@ class TestLevel3Eviction:
 
         frames, total_budget, _ = frames_and_budget
         past = None
+        last_scores = None
         outs = []
         sizes = []
         for i, frame in enumerate(frames):
             one = jnp.asarray(frame[None, None])
-            out_list, _, past = Aggregator().apply(
+            out_list, _, past, last_scores = Aggregator().apply(
                 jx_params,
                 one,
                 use_cache=True,
                 past_kvs=past,
                 past_frame_idx=i,
                 total_budget=total_budget,
+                last_scores=last_scores,
             )
             outs.append(np.asarray(out_list[-1]))
             sizes.append(past[0][0].shape[2])
@@ -1043,3 +1053,203 @@ class TestLevel3Eviction:
                 f"frame {i} output: max_abs={max_abs:.3e} "
                 f"> {ATOL_AGGREGATOR_CACHE_FP32:.0e}"
             )
+
+
+# --------------------------------------------------------------------------- #
+#  Level 3 -- dynamic budget allocation (Step 6c)
+# --------------------------------------------------------------------------- #
+
+
+# Plan target: dynamic-budget computation matches PyTorch at atol ≤ 1e-4
+# (both sides compute in fp32).
+ATOL_DYNAMIC_BUDGET_FP32 = 1e-4
+
+
+class TestLevel3DynamicBudget:
+    """Step 6c gate: softmax-of-diversity dynamic budget allocation.
+
+    The reference updates ``self.last_scores`` whenever any block evicts,
+    so frames 4+ receive a non-uniform budget per block. JAX must reproduce
+    both the budget computation and the resulting outputs bit-close.
+    """
+
+    def test_dynamic_budget_formula_matches_pytorch(self, pytorch_ivggt_module):
+        """Unit test — ``_calculate_dynamic_budgets`` vs PyTorch reference."""
+        import torch
+        from streamvggt.models.aggregator import Aggregator as PtAggregator
+        from modules.vggt.jax.aggregator import _calculate_dynamic_budgets
+
+        pt_agg = PtAggregator(img_size=518, patch_size=14, embed_dim=1024)
+        # Fabricate a non-uniform last_scores to exercise the allocator.
+        rng = np.random.RandomState(17)
+        last = rng.uniform(0.0, 0.9, size=(24,)).astype(np.float32)
+        total_budget = 1_200_000
+
+        pt_agg.last_scores = torch.from_numpy(last)
+        pt_budgets = pt_agg._calculate_dynamic_budgets(total_budget).cpu().numpy()
+
+        jx_budgets = np.asarray(
+            _calculate_dynamic_budgets(jnp.asarray(last), total_budget)
+        )
+
+        assert pt_budgets.shape == jx_budgets.shape == (24,)
+        max_abs = np.max(np.abs(pt_budgets - jx_budgets))
+        # Both sides run fp32 * int truncation; the softmax may disagree
+        # by ~1 unit after round-to-zero. atol 2 absorbs that.
+        assert max_abs <= 2, (
+            f"dynamic-budget diff: max_abs={max_abs}, "
+            f"pt={pt_budgets[:5]} jx={jx_budgets[:5]}"
+        )
+
+    @pytest.fixture(scope="class")
+    def pt_aggregator(self, state_dict, pytorch_ivggt_module):
+        import torch
+        from streamvggt.models.aggregator import Aggregator as PtAggregator
+
+        pt_agg = PtAggregator(img_size=518, patch_size=14, embed_dim=1024).eval()
+        for blk in pt_agg.patch_embed.blocks:
+            blk.attn.fused_attn = False
+        for blk in pt_agg.frame_blocks:
+            blk.attn.fused_attn = False
+        for blk in pt_agg.global_blocks:
+            blk.attn.fused_attn = False
+
+        prefix = "aggregator."
+        pt_sd = {
+            k[len(prefix):]: torch.from_numpy(np.asarray(v))
+            for k, v in state_dict.items()
+            if k.startswith(prefix)
+        }
+        pt_agg.load_state_dict(pt_sd, strict=False)
+        return pt_agg
+
+    @pytest.fixture(scope="class")
+    def jx_params(self, state_dict):
+        tree, _ = load_pytorch_weights(state_dict, include_v1_only=True)
+        return jax.tree.map(jnp.asarray, {"params": tree["aggregator"]})
+
+    @pytest.fixture(scope="class")
+    def frames_and_budget(self):
+        # 6 frames: eviction fires at frame 3 (still uniform), frames 4-5
+        # use the dynamic budget derived from updated last_scores.
+        rng = np.random.RandomState(33)
+        frames = rng.uniform(0.0, 1.0, size=(6, 3, 518, 518)).astype(np.float32)
+        P = 5 + (518 // 14) ** 2
+        per_block = 3 * P
+        total_budget = per_block * 24
+        return frames, total_budget
+
+    @pytest.fixture(scope="class")
+    def pt_run(self, pt_aggregator, frames_and_budget):
+        import torch
+
+        frames, total_budget = frames_and_budget
+        past = [None] * pt_aggregator.depth
+        outs = []
+        budgets_per_frame = []
+        with torch.no_grad():
+            for i, frame in enumerate(frames):
+                # Snapshot the budgets the aggregator will use on this call.
+                budgets_per_frame.append(
+                    pt_aggregator._calculate_dynamic_budgets(total_budget)
+                    .cpu().numpy().copy()
+                )
+                one = torch.from_numpy(frame[None, None])
+                out_list, _, past = pt_aggregator(
+                    one,
+                    past_key_values=past,
+                    use_cache=True,
+                    past_frame_idx=i,
+                    total_budget=total_budget,
+                )
+                outs.append(out_list[-1].cpu().numpy())
+        past_np = [(k.cpu().numpy(), v.cpu().numpy()) for (k, v) in past]
+        final_last_scores = pt_aggregator.last_scores.cpu().numpy().copy()
+        return outs, past_np, budgets_per_frame, final_last_scores
+
+    @pytest.fixture(scope="class")
+    def jx_run(self, jx_params, frames_and_budget):
+        from modules.vggt.jax.aggregator import (
+            Aggregator,
+            _calculate_dynamic_budgets,
+        )
+
+        frames, total_budget = frames_and_budget
+        past = None
+        last_scores = None
+        outs = []
+        budgets_per_frame = []
+        for i, frame in enumerate(frames):
+            ls = (
+                last_scores
+                if last_scores is not None
+                else jnp.zeros((24,), dtype=jnp.float32)
+            )
+            budgets_per_frame.append(
+                np.asarray(_calculate_dynamic_budgets(ls, total_budget))
+            )
+            one = jnp.asarray(frame[None, None])
+            out_list, _, past, last_scores = Aggregator().apply(
+                jx_params,
+                one,
+                use_cache=True,
+                past_kvs=past,
+                past_frame_idx=i,
+                total_budget=total_budget,
+                last_scores=last_scores,
+            )
+            outs.append(np.asarray(out_list[-1]))
+        past_np = [(np.asarray(k), np.asarray(v)) for (k, v) in past]
+        return outs, past_np, budgets_per_frame, np.asarray(last_scores)
+
+    def test_dynamic_budgets_per_frame(self, pt_run, jx_run):
+        """The per-block budget arrays should match frame-by-frame."""
+        _, _, pt_bud, _ = pt_run
+        _, _, jx_bud, _ = jx_run
+        for i in range(len(pt_bud)):
+            diff = np.abs(pt_bud[i] - jx_bud[i]).max()
+            assert diff <= 2, f"frame {i} budget diff={diff}, pt={pt_bud[i]}"
+
+    def test_last_scores_match_pytorch(self, pt_run, jx_run):
+        _, _, _, pt_ls = pt_run
+        _, _, _, jx_ls = jx_run
+        diff = np.abs(pt_ls - jx_ls).max()
+        assert diff <= ATOL_DYNAMIC_BUDGET_FP32, (
+            f"last_scores diff={diff:.3e} pt={pt_ls[:5]} jx={jx_ls[:5]}"
+        )
+
+    def test_per_frame_output_matches_pytorch(self, pt_run, jx_run):
+        pt_outs, _, _, _ = pt_run
+        jx_outs, _, _, _ = jx_run
+        # 6 frames + dynamic budget → more fp32-noise accumulation than the
+        # 4-frame uniform-budget (6b) test. Minor softmax rounding in
+        # _calculate_dynamic_budgets can shift a handful of retained
+        # candidates across blocks; measured drift is ~1.3e-3 at frame 4.
+        atol = 2e-3
+        for i, (pt, jx) in enumerate(zip(pt_outs, jx_outs)):
+            max_abs = np.max(np.abs(pt - jx))
+            assert max_abs <= atol, (
+                f"frame {i} output: max_abs={max_abs:.3e} > {atol:.0e}"
+            )
+
+    def test_anchor_kv_matches_pytorch(self, pt_run, jx_run):
+        """Anchors (first P tokens) are never evicted and should bit-match.
+
+        The candidate portion is deliberately NOT compared here: 6c's
+        dynamic-budget allocation rounds proportions to int, and a 1-unit
+        budget difference between PT and JX can swap a single candidate
+        token at the eviction boundary, producing large per-index K/V
+        divergence even though the overall outputs match. Anchors bypass
+        that path entirely — their contents are fully determined by frame
+        0's forward pass.
+        """
+        _, pt_past, _, _ = pt_run
+        _, jx_past, _, _ = jx_run
+        P = 1374  # 5 specials + 37*37 patches
+        for b in [0, 11, 23]:
+            pt_k, pt_v = pt_past[b]
+            jx_k, jx_v = jx_past[b]
+            max_abs_k = np.max(np.abs(pt_k[:, :, :P] - jx_k[:, :, :P]))
+            max_abs_v = np.max(np.abs(pt_v[:, :, :P] - jx_v[:, :, :P]))
+            assert max_abs_k <= 3e-3, f"block {b} anchor K: {max_abs_k:.3e}"
+            assert max_abs_v <= 3e-3, f"block {b} anchor V: {max_abs_v:.3e}"

--- a/modules/vggt/tests/test_jax_parity.py
+++ b/modules/vggt/tests/test_jax_parity.py
@@ -571,17 +571,6 @@ class TestLevel2CameraHead:
 ATOL_POINT_HEAD_FP32 = 1e-3
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Step 5 WIP: DPT decoder output drifts by ~0.8 max-abs vs PyTorch "
-        "reference despite individual components (projects/resize/refinenet/"
-        "bilinear/out_conv) matching at fp32 noise (~1e-6) when tested in "
-        "isolation. Bug manifests only when the full forward chains them "
-        "together; likely in an interaction between the setup()-mode "
-        "ResidualConvUnit and the bilinear-upsample step. Hand-off marker."
-    ),
-    strict=True,
-)
 class TestLevel2PointHead:
     """Step 5 parity gate: DPT decoder producing pts3d + conf.
 

--- a/modules/vggt/tests/test_jax_parity.py
+++ b/modules/vggt/tests/test_jax_parity.py
@@ -655,3 +655,243 @@ class TestLevel2PointHead:
         assert max_abs_conf <= ATOL_POINT_HEAD_FP32, (
             f"point-head conf: max_abs={max_abs_conf:.3e} > {ATOL_POINT_HEAD_FP32:.0e}"
         )
+
+
+# --------------------------------------------------------------------------- #
+#  Level 3 -- streaming cache parity (Step 6a: eviction disabled)
+# --------------------------------------------------------------------------- #
+
+
+# Cache-mode parity bound. The cache path rearranges the order of arithmetic
+# (each frame's global attention now uses a rectangular Q x [past_K | new_K]
+# matmul instead of the block-diagonal-causal S*P x S*P version) so rounding
+# patterns differ slightly. 1e-3 fp32 matches the aggregator-no-cache bound.
+ATOL_AGGREGATOR_CACHE_FP32 = 1e-3
+ATOL_CAMERA_CACHE_FP32 = 1e-3
+
+# Frames used across Level-3 tests. Keep small so PyTorch fp32 / no-fused
+# attention completes quickly; Step 6c will add 500-frame sequences once
+# eviction is wired up to keep memory bounded.
+_L3_NUM_FRAMES = 3
+
+
+class TestLevel3AggregatorCache:
+    """Step 6a gate: aggregator streaming with eviction disabled.
+
+    Two independent checks:
+
+    1. **JAX self-consistency** — running the cache path frame-by-frame should
+       reproduce the no-cache path applied to all frames at once. This catches
+       bugs in cache threading without involving PyTorch.
+    2. **JAX vs PyTorch cache** — mirrors the production streaming path. Uses
+       ``total_budget`` large enough that the reference's eviction never fires.
+    """
+
+    @pytest.fixture(scope="class")
+    def pt_aggregator(self, state_dict, pytorch_ivggt_module):
+        import torch
+        from streamvggt.models.aggregator import Aggregator as PtAggregator
+
+        pt_agg = PtAggregator(img_size=518, patch_size=14, embed_dim=1024).eval()
+        for blk in pt_agg.patch_embed.blocks:
+            blk.attn.fused_attn = False
+        for blk in pt_agg.frame_blocks:
+            blk.attn.fused_attn = False
+        for blk in pt_agg.global_blocks:
+            blk.attn.fused_attn = False
+
+        prefix = "aggregator."
+        pt_sd = {
+            k[len(prefix):]: torch.from_numpy(np.asarray(v))
+            for k, v in state_dict.items()
+            if k.startswith(prefix)
+        }
+        missing, unexpected = pt_agg.load_state_dict(pt_sd, strict=False)
+        assert not missing, f"missing: {missing}"
+        assert not unexpected, f"unexpected: {unexpected}"
+        return pt_agg
+
+    @pytest.fixture(scope="class")
+    def jx_params(self, state_dict):
+        tree, _ = load_pytorch_weights(state_dict, include_v1_only=True)
+        return jax.tree.map(jnp.asarray, {"params": tree["aggregator"]})
+
+    @pytest.fixture(scope="class")
+    def frames(self):
+        # N frames of (3, 518, 518) each; returned as numpy (N, 3, 518, 518).
+        rng = np.random.RandomState(11)
+        return rng.uniform(
+            0.0, 1.0, size=(_L3_NUM_FRAMES, 3, 518, 518)
+        ).astype(np.float32)
+
+    # --------------------------------------------------------------------- #
+    #  (1) JAX cache vs JAX no-cache
+    # --------------------------------------------------------------------- #
+    def test_jax_cache_matches_jax_nocache(self, jx_params, frames):
+        from modules.vggt.jax.aggregator import Aggregator
+
+        # No-cache: process all frames at once with shape (1, N, 3, 518, 518).
+        all_frames = frames[None]  # (1, N, 3, H, W)
+        nc_out_list, _ = Aggregator().apply(jx_params, jnp.asarray(all_frames))
+        nc_last = np.asarray(nc_out_list[-1])  # (1, N, P, 2C)
+
+        # Cache: loop frame-by-frame with S=1 each.
+        past_kvs = None
+        cached_last_per_frame = []
+        for i in range(frames.shape[0]):
+            one = jnp.asarray(frames[i : i + 1][None])  # (1, 1, 3, H, W)
+            out_list, _, past_kvs = Aggregator().apply(
+                jx_params, one, use_cache=True, past_kvs=past_kvs, past_frame_idx=i
+            )
+            cached_last_per_frame.append(np.asarray(out_list[-1]))
+        cached_last = np.concatenate(cached_last_per_frame, axis=1)  # (1, N, P, 2C)
+
+        assert cached_last.shape == nc_last.shape
+        max_abs = np.max(np.abs(cached_last - nc_last))
+        assert max_abs <= ATOL_AGGREGATOR_CACHE_FP32, (
+            f"JAX cache vs JAX no-cache: max_abs={max_abs:.3e} "
+            f"> {ATOL_AGGREGATOR_CACHE_FP32:.0e}"
+        )
+
+    # --------------------------------------------------------------------- #
+    #  (2) JAX cache vs PyTorch cache
+    # --------------------------------------------------------------------- #
+    def test_jax_cache_matches_pytorch_cache(
+        self, pt_aggregator, jx_params, frames
+    ):
+        import torch
+        from modules.vggt.jax.aggregator import Aggregator
+
+        # total_budget is distributed across the 24 global blocks via softmax
+        # of 1-last_scores. With last_scores initialised to 0, the proportions
+        # are ~uniform, so per-block budget ~= total_budget / depth. We need
+        # per-block budget >= N*P to keep eviction from firing in 6a. Add 2x
+        # slack to absorb softmax rounding.
+        P = 5 + (518 // 14) ** 2  # 5 specials + 1369 patch tokens = 1374
+        N = frames.shape[0]
+        depth = pt_aggregator.depth
+        total_budget = N * P * depth * 2
+
+        # ---- PyTorch: loop with use_cache=True ----
+        pt_past_kvs = [None] * pt_aggregator.depth
+        pt_last_per_frame = []
+        with torch.no_grad():
+            for i in range(N):
+                one = torch.from_numpy(frames[i : i + 1][None])  # (1, 1, 3, H, W)
+                out_list, _, pt_past_kvs = pt_aggregator(
+                    one,
+                    past_key_values=pt_past_kvs,
+                    use_cache=True,
+                    past_frame_idx=i,
+                    total_budget=total_budget,
+                )
+                pt_last_per_frame.append(out_list[-1].cpu().numpy())
+        pt_last = np.concatenate(pt_last_per_frame, axis=1)
+
+        # ---- JAX: loop with use_cache=True ----
+        jx_past_kvs = None
+        jx_last_per_frame = []
+        for i in range(N):
+            one = jnp.asarray(frames[i : i + 1][None])
+            out_list, _, jx_past_kvs = Aggregator().apply(
+                jx_params,
+                one,
+                use_cache=True,
+                past_kvs=jx_past_kvs,
+                past_frame_idx=i,
+            )
+            jx_last_per_frame.append(np.asarray(out_list[-1]))
+        jx_last = np.concatenate(jx_last_per_frame, axis=1)
+
+        assert jx_last.shape == pt_last.shape, (jx_last.shape, pt_last.shape)
+        max_abs = np.max(np.abs(jx_last - pt_last))
+        assert max_abs <= ATOL_AGGREGATOR_CACHE_FP32, (
+            f"JAX cache vs PyTorch cache: max_abs={max_abs:.3e} "
+            f"> {ATOL_AGGREGATOR_CACHE_FP32:.0e}"
+        )
+
+
+class TestLevel3CameraHeadCache:
+    """Step 6a gate: camera head streaming cache.
+
+    Works on the aggregator's output tokens, so we can feed it random tensors
+    (like TestLevel2CameraHead) instead of running the full aggregator.
+    """
+
+    @pytest.fixture(scope="class")
+    def pt_camera_head(self, state_dict, pytorch_ivggt_module):
+        import torch
+        from streamvggt.heads.camera_head import CameraHead as PtCamera
+
+        head = PtCamera(dim_in=2048).eval()
+        for blk in head.trunk:
+            blk.attn.fused_attn = False
+        prefix = "camera_head."
+        pt_sd = {
+            k[len(prefix):]: torch.from_numpy(np.asarray(v))
+            for k, v in state_dict.items()
+            if k.startswith(prefix)
+        }
+        missing, unexpected = head.load_state_dict(pt_sd, strict=False)
+        assert not missing, f"missing: {missing}"
+        assert not unexpected, f"unexpected: {unexpected}"
+        return head
+
+    @pytest.fixture(scope="class")
+    def jx_params(self, state_dict):
+        tree, _ = load_pytorch_weights(state_dict, include_v1_only=True)
+        return jax.tree.map(jnp.asarray, {"params": tree["camera_head"]})
+
+    @pytest.fixture(scope="class")
+    def agg_tokens_per_frame(self):
+        # 24 aggregator levels, N frames each with S=1. Only ``[-1]`` is used.
+        rng = np.random.RandomState(29)
+        B, P, C = 1, 1374, 2048
+        frames = []
+        for _ in range(_L3_NUM_FRAMES):
+            frames.append(
+                [
+                    rng.randn(B, 1, P, C).astype(np.float32) * 0.1
+                    for _ in range(24)
+                ]
+            )
+        return frames
+
+    def test_camera_head_cache_matches_pytorch(
+        self, pt_camera_head, jx_params, agg_tokens_per_frame
+    ):
+        import torch
+        from modules.vggt.jax.heads.camera_head import CameraHead
+
+        # ---- PyTorch cache loop ----
+        pt_cache = [None] * pt_camera_head.trunk_depth
+        pt_poses = []
+        with torch.no_grad():
+            for frame_tokens in agg_tokens_per_frame:
+                pt_input = [torch.from_numpy(x) for x in frame_tokens]
+                pose_list, pt_cache = pt_camera_head(
+                    pt_input, past_key_values_camera=pt_cache, use_cache=True
+                )
+                pt_poses.append(pose_list[-1].cpu().numpy())
+        pt_poses = np.concatenate(pt_poses, axis=1)  # (B, N, 9)
+
+        # ---- JAX cache loop ----
+        jx_cache = None
+        jx_poses = []
+        for frame_tokens in agg_tokens_per_frame:
+            jx_input = [jnp.asarray(x) for x in frame_tokens]
+            pose_list, jx_cache = CameraHead().apply(
+                jx_params,
+                jx_input,
+                use_cache=True,
+                past_kvs_camera=jx_cache,
+            )
+            jx_poses.append(np.asarray(pose_list[-1]))
+        jx_poses = np.concatenate(jx_poses, axis=1)
+
+        assert jx_poses.shape == pt_poses.shape
+        max_abs = np.max(np.abs(jx_poses - pt_poses))
+        assert max_abs <= ATOL_CAMERA_CACHE_FP32, (
+            f"camera-head cache: max_abs={max_abs:.3e} "
+            f"> {ATOL_CAMERA_CACHE_FP32:.0e}"
+        )


### PR DESCRIPTION
## Summary

Full JAX port of VGGT streaming feature extractor (Steps 1-8) plus an in-progress jit+padded-KV-cache pass on the aggregator.

- Steps 1-8 (Flax backbone, aggregator, camera head, DPT point head, KV cache with dynamic per-block eviction, streaming extractor, bench harness) — previously landed per-step on this branch
- Latest commit: jit the aggregator apply with a fixed-size padded KV cache; static-arg key distinguishes only first-frame vs subsequent-frame so we compile twice, not once per frame
- Added \`modules/vggt/jax/profile_streaming.py\` for per-phase latency breakdown

## Measured (profile_streaming, H100)

- aggregator: **2897ms → 57ms (51x)**
- total extract: **4040ms → 1255ms (3.2x)**
- camera_head still eager — now ~95% of remaining time; next target

## Known issue — integration test regression

\`tests/test_jax_integration.py::TestJAXvsPyTorchExtractor::test_rollout_parity\` currently **fails**: \`world_points\` drift ≈ 0.36 vs 1e-2 tolerance.

- Fast parity (8/8) and Level-3 cache parity (12/12) still pass — but those use \`past_kvs=None\` and only exercise the legacy 2-tuple growing-cache path
- The 3-tuple padded cache path used by \`JAXVGGTFeatureExtractor.extract\` is not covered by parity and is the suspected source
- Drift is identical at bf16 and fp32 → cache-state bug, not precision
- Main suspects: \`jax.lax.cond\` eviction plumbing in \`attention.py:_padded_cache_forward\`, or \`_padded_evict\` zero-fill semantics

Integration fixture pinned to fp32 to make the diagnosis precision-independent.

## Test plan

- [ ] Add padded-path parity coverage at Level-3 (current gap)
- [ ] Fix padded eviction bug → integration test green
- [ ] Apply same jit pattern to camera_head (should close most of the remaining 1.2s)
- [ ] Rerun \`bench_fast\` for the final PT-vs-JAX speedup number

Draft until padded-path fix lands and integration test goes green.