### PR TITLE
feat(agent-loop): tmux+srun dispatcher for ready-for-agent issues

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,25 @@
+# Master-Thesis-3D-VLA — Domain Glossary
+
+This file is the canonical glossary for the project. Terms are added here
+as they're resolved during design discussions (see `.agents/skills/grill-with-docs`).
+Architectural decisions live in `docs/adr/`.
+
+## Agent-loop dispatcher
+
+| Term                | Meaning |
+| ------------------- | ------- |
+| **agent loop**      | The tmux+srun+`claude -p` dispatcher in `scripts/agent_loop.sh`. Serial — one issue at a time, no parallelism, no worktree. Wraps an `srun --gres=gpu:1` shell in a tmux session on the login node so the loop survives SSH disconnects. See `docs/agents/agent-loop.md`. |
+| **ready-for-agent** | The *only* label `agent_loop.sh` treats as a green light. An issue is eligible iff it has `ready-for-agent` and lacks `blocked` / `in-progress` / `needs-info`. See ADR 0001. |
+| **AFK** / **HITL**  | Orthogonal *execution-mode* labels. Document expected human involvement. Do **not** gate the picker. (See `docs/agents/triage-labels.md`.) |
+| **PRD branch**      | `agent/prd-<N>` — single branch where every child commit of PRD #N accumulates across loop iterations. One PR per PRD lands when the last child closes. |
+| **orphan issue**    | A `ready-for-agent` issue whose body has no `## Parent #N` reference. Handled on its own `agent/issue-<M>` branch with an immediate PR. |
+| **PRD ↔ child link**| The `## Parent\n#N` body reference written by `.agents/skills/to-issues`. The dispatcher uses `gh issue list --search 'in:body "Parent #N"'` to enumerate siblings. |
+| **halt**            | Hard-stop the loop on first failure. The failing issue keeps `in-progress` and gets a stderr-tail comment; the tmux pane prints `LOOP HALTED: see #<N>` and exits 1. |
+| **drain**           | Loop exits cleanly with code 0 when the picker returns no eligible issues. |
+| **implement pass**  | First `claude -p --model claude-opus-4-7 --dangerously-skip-permissions` call per issue. Reads issue body, writes code, runs tests, commits. |
+| **review pass**     | Second `claude -p` call per issue. Runs `pr-review-toolkit:review-pr` on the diff vs `main`, commits any blocker fixes, writes `APPROVED` or `BLOCKED: …` to `.agent_loop/review-verdict`. |
+
+## Project domain
+
+*(populated as terms come up in future grilling sessions — start with the
+thesis-specific vocabulary as it's introduced)*

--- a/docs/adr/0001-canonical-ready-for-agent-label.md
+++ b/docs/adr/0001-canonical-ready-for-agent-label.md
@@ -1,0 +1,57 @@
+# ADR 0001: Use `ready-for-agent` (not `AFK`+`ready`) as the agent-loop picker label
+
+**Status**: Accepted  •  **Date**: 2026-05-04
+
+## Context
+
+The repo has two overlapping vocabularies for "this issue is ready for an
+autonomous agent":
+
+1. **`AFK` + `ready`** — used in practice (e.g. issue #116) and matched by
+   the prior `scripts/run_ralph.sh` dispatcher.
+2. **`ready-for-agent`** — the canonical mattpocock triage label documented
+   in `docs/agents/triage-labels.md`.
+
+When introducing `scripts/agent_loop.sh`, we had to pick one as the
+single source of truth for which issues the loop will pop.
+
+## Decision
+
+`agent_loop.sh` recognises **only `ready-for-agent`**. The `AFK` label is
+demoted to its documented role: an orthogonal *execution-mode* tag (autonomous
+vs human-in-the-loop), not a picker signal.
+
+A one-time migration relabels existing `AFK`+`ready` issues to
+`ready-for-agent`. Project-specific guidance for `to-issues` (apply
+`ready-for-agent` directly to AFK slices, skipping `needs-triage`) lives
+in `docs/agents/agent-loop.md` under "Feeding the loop", not in
+`docs/agents/issue-tracker.md` — the latter is reserved for canonical
+mattpocock conventions.
+
+## Consequences
+
+**Positive**
+
+- The picker query is one label, not a conjunction — fewer ways to
+  mis-tag and silently skip an issue.
+- Documentation and reality agree. `docs/agents/triage-labels.md` already
+  said `AFK`/`HITL` are orthogonal to triage state; we now enforce that.
+- A single tracker query (`gh issue list --label ready-for-agent`) tells
+  any operator exactly what the loop will pick up next.
+
+**Negative**
+
+- Existing issues with `AFK`+`ready` need a one-time relabel.
+- Any external automation or muscle memory referring to `AFK`+`ready` as
+  the trigger pair is now wrong.
+- The choice is hard to reverse cheaply: re-introducing `AFK`+`ready` later
+  would require migrating both labels back across all open issues.
+
+## Alternatives considered
+
+- **Accept either** (`AFK`+`ready` *or* `ready-for-agent`). Forgiving during
+  transition, but the picker becomes the source of truth and the docs drift
+  again. Rejected for the same reason it appealed: implicit dual vocabulary.
+- **Keep `AFK`+`ready`, retire `ready-for-agent` from the docs.** Simpler
+  for #116, but loses alignment with the upstream mattpocock skill set we
+  installed and would put `AFK` back in the triage axis it doesn't belong on.

--- a/docs/agents/agent-loop.md
+++ b/docs/agents/agent-loop.md
@@ -1,0 +1,91 @@
+# Agent loop (`scripts/agent_loop.sh`)
+
+A tmux+srun dispatcher that picks `ready-for-agent` issues from this repo,
+implements them with Claude Opus 4.7, reviews the diff, pushes commits, and
+opens a PR — all surviving SSH disconnect.
+
+> **Status**: stub. The first verification step in `.claude/plans/my-team-want-a-purrfect-curry.md`
+> is an issue that asks the loop itself to fill out this doc end-to-end. If
+> you're reading this and it's still a stub, that test hasn't run yet.
+
+## Quick start
+
+```bash
+# From the BWUniCluster login node:
+./scripts/agent_loop.sh                        # default 24h budget, 20 issues max
+./scripts/agent_loop.sh --prd 78               # only drain children of PRD #78
+./scripts/agent_loop.sh --max-issues 1 smoke   # one-issue smoke test
+./scripts/agent_loop.sh --dry-run              # pick + log, do not invoke Claude
+```
+
+After launch you're attached to the tmux session. Detach with **Ctrl+b d** —
+the loop keeps running. Reattach later with `tmux attach -t agent-loop`.
+
+## Flags
+
+| Flag            | Default     | Meaning                                              |
+| --------------- | ----------- | ---------------------------------------------------- |
+| `--prd N`       | _(none)_    | Restrict picker to children of PRD #N.               |
+| `--max-issues N`| `20`        | Stop after N issues processed.                       |
+| `--time HH:MM:SS` | `24:00:00`| SLURM `--time` for the srun reservation.             |
+| `--partition X` | `gpu_h100`  | SLURM partition.                                     |
+| `--dry-run`     | off         | Pick the next issue, print it, exit. Skip Claude.    |
+| _(positional)_  | `agent-loop`| tmux session name.                                   |
+
+## What the loop does, per iteration
+
+1. `git fetch` + reset to `origin/main`.
+2. Pick the lowest-numbered open issue with `ready-for-agent` and without
+   `blocked` / `in-progress` / `needs-info`.
+3. Determine PRD parent from the issue body's `## Parent #N` reference.
+   Branch is `agent/prd-<N>` (PRD child) or `agent/issue-<M>` (orphan).
+4. Flip labels: `ready-for-agent` → `in-progress`.
+5. **Implement pass**: `claude -p --model claude-opus-4-7 --dangerously-skip-permissions`
+   on `scripts/agent_loop_prompts/implement.md`. Must produce ≥1 commit.
+6. **Review pass**: same flags on `scripts/agent_loop_prompts/review.md`.
+   Writes `APPROVED` or `BLOCKED: …` to `.agent_loop/review-verdict`.
+7. Push the branch.
+8. Close the issue with a branch-reference comment.
+9. **PR**: orphan → open immediately. PRD child → only when this PRD has
+   zero open siblings remaining.
+
+## Failure handling
+
+Hard-stop on first failure. The failing issue keeps `in-progress` and gets
+a comment containing the last 100 lines of stderr. The tmux pane prints
+`LOOP HALTED: see issue #<N>` and exits 1. No further issues are consumed.
+
+Recover by inspecting the issue + comment, fixing the root cause (in code,
+prompt, or issue body), then re-launching `agent_loop.sh`.
+
+## Files
+
+| Path                                                | Role                                  |
+| --------------------------------------------------- | ------------------------------------- |
+| `scripts/agent_loop.sh`                             | Outer wrapper (tmux + srun).          |
+| `scripts/agent_loop_inner.sh`                       | The loop itself (runs inside srun).   |
+| `scripts/agent_loop_prompts/implement.md`           | Implement-pass prompt template.       |
+| `scripts/agent_loop_prompts/review.md`              | Review-pass prompt template.          |
+| `.agent_loop/`                                      | Per-issue logs + the `review-verdict`. |
+
+## Feeding the loop
+
+The loop only sees issues with the `ready-for-agent` label. Two paths
+deliver issues into that state:
+
+1. **`/triage`** marks an existing issue `ready-for-agent` after triage.
+2. **`/to-issues` for AFK slices** — when an approved vertical slice is
+   tagged `AFK` (autonomous), apply `ready-for-agent` directly instead of
+   the default `needs-triage`. AFK slices are by definition fully specified
+   by the parent PRD and don't need a second pass through triage. **HITL**
+   slices still go through `needs-triage` — they're for a human, not the loop.
+
+See ADR 0001 for why `ready-for-agent` is the only picker label.
+
+## See also
+
+- `CONTEXT.md` — glossary (`agent loop`, `PRD branch`, `halt`, `drain`).
+- `docs/adr/0001-canonical-ready-for-agent-label.md` — why `ready-for-agent`.
+- `docs/agents/issue-tracker.md` — gh CLI conventions.
+- Issue #78 (PRD: Autoresearch) — the single-experiment ancestor of this loop.
+- Issue #114 — tracks removal of legacy `scripts/run_ralph.sh`.

--- a/scripts/agent_loop.sh
+++ b/scripts/agent_loop.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Tmux+srun outer wrapper for the agent loop.
+#
+# Picks `ready-for-agent` issues from GitHub, runs them through Claude
+# (implement + review), pushes commits, and opens one PR per PRD (or per
+# orphan issue) — all inside a tmux session that survives SSH disconnects.
+#
+# Usage:
+#   ./scripts/agent_loop.sh [flags] [session-name]
+#
+# Flags:
+#   --prd N            Only pick children of PRD #N (omit to drain the whole queue)
+#   --max-issues N     Stop after N issues processed (default 20)
+#   --time HH:MM:SS    SLURM --time (default 24:00:00)
+#   --partition NAME   SLURM partition (default gpu_h100)
+#   --dry-run          Pick + log + exit, do not invoke claude
+#
+# Reattach after disconnect:  tmux attach -t <session-name>
+# Detach:                     Ctrl+b d
+
+set -euo pipefail
+
+PRD=""
+MAX_ISSUES=20
+TIME="24:00:00"
+PARTITION="gpu_h100"
+DRY_RUN=false
+
+while [[ "${1:-}" == --* ]]; do
+    case "$1" in
+        --prd)        PRD="$2"; shift 2 ;;
+        --max-issues) MAX_ISSUES="$2"; shift 2 ;;
+        --time)       TIME="$2"; shift 2 ;;
+        --partition)  PARTITION="$2"; shift 2 ;;
+        --dry-run)    DRY_RUN=true; shift ;;
+        *)            echo "Unknown flag: $1" >&2; exit 1 ;;
+    esac
+done
+
+SESSION="${1:-agent-loop}"
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Build the inner command that runs inside srun
+INNER_CMD="cd $PROJECT_DIR && PRD='$PRD' MAX_ISSUES=$MAX_ISSUES DRY_RUN=$DRY_RUN bash scripts/agent_loop_inner.sh"
+
+# Already on a compute node: skip srun, run tmux directly
+if [[ "$(hostname)" == uc3n* ]]; then
+    if tmux has-session -t "$SESSION" 2>/dev/null; then
+        echo "Session '$SESSION' exists. Attaching..."
+        tmux attach -t "$SESSION"
+        exit 0
+    fi
+    echo "On compute node $(hostname); starting tmux without srun..."
+    tmux new-session -d -s "$SESSION" -c "$PROJECT_DIR"
+    tmux set-option -t "$SESSION" remain-on-exit on
+    tmux send-keys -t "$SESSION" "$INNER_CMD" Enter
+    tmux attach -t "$SESSION"
+    exit 0
+fi
+
+# Login node: wrap srun in tmux
+if tmux has-session -t "$SESSION" 2>/dev/null; then
+    echo "Session '$SESSION' exists. Attaching..."
+    tmux attach -t "$SESSION"
+    exit 0
+fi
+
+echo "Starting tmux session '$SESSION' with srun on $PARTITION ($TIME)..."
+tmux new-session -d -s "$SESSION" -c "$PROJECT_DIR"
+tmux set-option -t "$SESSION" remain-on-exit on
+tmux send-keys -t "$SESSION" \
+    "srun --partition=$PARTITION -n1 --gres=gpu:1 --time=$TIME --pty bash -c \"$INNER_CMD\"" Enter
+
+echo "Session '$SESSION' started."
+echo "  Attach:  tmux attach -t $SESSION"
+echo "  Detach:  Ctrl+b d"
+tmux attach -t "$SESSION"

--- a/scripts/agent_loop_inner.sh
+++ b/scripts/agent_loop_inner.sh
@@ -1,0 +1,206 @@
+#!/bin/bash
+# Inner loop for the agent dispatcher. Runs inside srun (or compute-node tmux).
+# Picks one ready-for-agent issue, implements it, reviews it, pushes, repeats.
+# Hard-stops on first failure; drains the queue cleanly otherwise.
+#
+# Environment (set by agent_loop.sh):
+#   PRD          — restrict to children of PRD #N (empty = drain whole queue)
+#   MAX_ISSUES   — upper bound on issues processed per run
+#   DRY_RUN      — "true" to pick + log + exit without invoking claude
+
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+PRD="${PRD:-}"
+MAX_ISSUES="${MAX_ISSUES:-20}"
+DRY_RUN="${DRY_RUN:-false}"
+
+PROMPT_DIR="scripts/agent_loop_prompts"
+WORK_DIR=".agent_loop"
+mkdir -p "$WORK_DIR"
+
+CLAUDE_FLAGS=(--print --dangerously-skip-permissions --max-turns 200 --model claude-opus-4-7)
+IMPLEMENT_TIMEOUT=1800   # 30 min per implement pass
+REVIEW_TIMEOUT=600       # 10 min per review pass
+
+log()  { echo "[agent-loop $(date +%H:%M:%S)] $*"; }
+halt() { local num="$1" reason="$2" tail="${3:-}"
+    log "HALT on issue #$num: $reason"
+    {
+        echo "Loop halted on this issue."
+        echo
+        echo "**Reason**: $reason"
+        if [[ -n "$tail" ]]; then
+            echo
+            echo "**Last output (truncated)**:"
+            echo '```'
+            echo "$tail" | tail -n 100
+            echo '```'
+        fi
+    } > "$WORK_DIR/halt-comment.md"
+    gh issue comment "$num" --body-file "$WORK_DIR/halt-comment.md" || true
+    echo "LOOP HALTED: see issue #$num" >&2
+    exit 1
+}
+
+pick_next_issue() {
+    # JQ filter avoids gh search-index lag. Sort by issue number ASC for FIFO.
+    local extra_filter=""
+    if [[ -n "$PRD" ]]; then
+        # gh search index can be a few minutes behind; for PRD scope we accept
+        # that lag because PRD child sets are written in batch by /to-issues.
+        gh issue list --label ready-for-agent --state open --limit 100 \
+            --search "in:body \"Parent #$PRD\"" \
+            --json number,title,body,labels
+    else
+        gh issue list --label ready-for-agent --state open --limit 100 \
+            --json number,title,body,labels
+    fi | jq -c '
+        [ .[]
+          | select(any(.labels[]; .name == "blocked" or .name == "in-progress" or .name == "needs-info") | not)
+        ]
+        | sort_by(.number)
+        | first // empty
+    '
+}
+
+extract_parent() {
+    # Parse the `## Parent` section of the issue body and return the first #N.
+    local body="$1"
+    sed -n '/^## Parent/,/^## /p' <<<"$body" | grep -oE '#[0-9]+' | head -1 | tr -d '#'
+}
+
+count_open_siblings() {
+    local prd="$1"
+    gh issue list --search "in:body \"Parent #$prd\"" --state open --limit 100 --json number \
+        | jq 'length'
+}
+
+children_summary() {
+    local prd="$1"
+    gh issue list --search "in:body \"Parent #$prd\"" --state closed --limit 100 \
+        --json number,title \
+        | jq -r '.[] | "- Closes #\(.number) — \(.title)"'
+}
+
+processed=0
+while [[ $processed -lt $MAX_ISSUES ]]; do
+    log "Refreshing main branch..."
+    git fetch origin main --quiet
+    git checkout main --quiet
+    git reset --hard origin/main --quiet
+
+    issue_json="$(pick_next_issue)"
+    if [[ -z "$issue_json" ]]; then
+        log "Queue drained (no ready-for-agent issues left). Exit 0."
+        exit 0
+    fi
+
+    num="$(jq -r '.number' <<<"$issue_json")"
+    title="$(jq -r '.title' <<<"$issue_json")"
+    body="$(jq -r '.body // ""' <<<"$issue_json")"
+    parent="$(extract_parent "$body" || true)"
+
+    if [[ -n "$parent" ]]; then
+        branch="agent/prd-$parent"
+    else
+        branch="agent/issue-$num"
+    fi
+
+    log "Picked #$num: $title  (branch=$branch, parent=${parent:-none})"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log "DRY_RUN: would process #$num on $branch"
+        processed=$((processed + 1))
+        # In dry-run we don't actually take the issue, so to avoid an infinite
+        # loop we exit after listing the next one.
+        log "DRY_RUN: stopping after first pick."
+        exit 0
+    fi
+
+    # Check out (or create) the branch off the latest main / existing remote.
+    if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+        git fetch origin "$branch" --quiet
+        git checkout -B "$branch" "origin/$branch" --quiet
+    else
+        git checkout -B "$branch" origin/main --quiet
+    fi
+
+    gh issue edit "$num" --add-label in-progress --remove-label ready-for-agent
+
+    # IMPLEMENT
+    log "Implement pass on #$num..."
+    impl_log="$WORK_DIR/implement-$num.log"
+    ISSUE_NUM="$num" ISSUE_TITLE="$title" ISSUE_BODY="$body" BRANCH="$branch" \
+        envsubst < "$PROMPT_DIR/implement.md" > "$WORK_DIR/implement-$num.prompt"
+    if ! timeout "$IMPLEMENT_TIMEOUT" claude "${CLAUDE_FLAGS[@]}" \
+            "$(cat "$WORK_DIR/implement-$num.prompt")" \
+            > "$impl_log" 2>&1; then
+        halt "$num" "implement pass exited non-zero (or timed out at ${IMPLEMENT_TIMEOUT}s)" "$(cat "$impl_log")"
+    fi
+
+    # Sanity: implement pass must have produced at least one new commit on the branch.
+    new_commits="$(git rev-list --count "origin/main..HEAD")"
+    if [[ "$new_commits" -eq 0 ]]; then
+        halt "$num" "implement pass left no new commits on $branch" "$(cat "$impl_log")"
+    fi
+
+    # REVIEW
+    log "Review pass on #$num..."
+    rev_log="$WORK_DIR/review-$num.log"
+    rm -f "$WORK_DIR/review-verdict"
+    ISSUE_NUM="$num" BRANCH="$branch" VERDICT_FILE="$WORK_DIR/review-verdict" \
+        envsubst < "$PROMPT_DIR/review.md" > "$WORK_DIR/review-$num.prompt"
+    if ! timeout "$REVIEW_TIMEOUT" claude "${CLAUDE_FLAGS[@]}" \
+            "$(cat "$WORK_DIR/review-$num.prompt")" \
+            > "$rev_log" 2>&1; then
+        halt "$num" "review pass exited non-zero (or timed out at ${REVIEW_TIMEOUT}s)" "$(cat "$rev_log")"
+    fi
+    verdict="$(cat "$WORK_DIR/review-verdict" 2>/dev/null || echo "MISSING")"
+    if [[ "$verdict" != APPROVED* ]]; then
+        halt "$num" "review verdict not APPROVED (got: $verdict)" "$(cat "$rev_log")"
+    fi
+
+    # PUSH
+    log "Pushing $branch..."
+    git push -u origin "$branch" --quiet || halt "$num" "git push failed" ""
+
+    # CLOSE issue with branch reference
+    gh issue close "$num" --comment "Implemented on \`$branch\`. PR will be opened when this PRD's last child closes (or immediately, for orphan issues)."
+
+    # OPEN PR — orphan immediately, PRD only when last sibling closes
+    if [[ -z "$parent" ]]; then
+        log "Orphan issue: opening PR $branch -> main"
+        gh pr create --base main --head "$branch" \
+            --title "$title" \
+            --body "Closes #$num.
+
+🤖 Generated by agent_loop.sh
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>" \
+            --label in-review || halt "$num" "gh pr create failed" ""
+    else
+        open_left="$(count_open_siblings "$parent")"
+        if [[ "$open_left" -eq 0 ]]; then
+            log "Last sibling of PRD #$parent closed: opening PR $branch -> main"
+            prd_title="$(gh issue view "$parent" --json title -q .title)"
+            children_md="$(children_summary "$parent")"
+            gh pr create --base main --head "$branch" \
+                --title "$prd_title" \
+                --body "Closes #$parent.
+
+Children implemented:
+$children_md
+
+🤖 Generated by agent_loop.sh
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>" \
+                --label in-review || halt "$num" "gh pr create for PRD #$parent failed" ""
+        else
+            log "PRD #$parent still has $open_left open child(ren); deferring PR."
+        fi
+    fi
+
+    processed=$((processed + 1))
+    log "Issue #$num done. Processed $processed/$MAX_ISSUES."
+done
+
+log "Hit max-issues budget ($MAX_ISSUES). Exit 0."

--- a/scripts/agent_loop_prompts/implement.md
+++ b/scripts/agent_loop_prompts/implement.md
@@ -1,0 +1,35 @@
+You are implementing a single GitHub issue end-to-end on the
+Master-Thesis-3D-VLA repository.
+
+## Issue
+
+- Number: #${ISSUE_NUM}
+- Title: ${ISSUE_TITLE}
+- Branch: you are already checked out on `${BRANCH}` (off latest `origin/main`).
+
+## Body
+
+${ISSUE_BODY}
+
+## Your task
+
+1. Read `CLAUDE.md` and any `docs/agents/*.md` relevant to the area you'll
+   touch before writing code. Honour the project's "no overengineering" and
+   "no unnecessary comments" rules from `CLAUDE.md`.
+2. Implement the change in the smallest correct way that satisfies the
+   acceptance criteria.
+3. Run any tests / lints / type-checks that apply to the files you touched.
+4. Commit your work with a Conventional-Commits style message; reference the
+   issue in the body (`Refs #${ISSUE_NUM}`).
+5. **Do NOT** push, open a PR, close the issue, or change labels — the outer
+   loop owns those.
+6. If a `gh` or `git` command fails with what looks like a transient error
+   (network, rate-limit, lock contention), retry exactly once after a 5-second
+   wait before treating it as a real failure.
+7. If you genuinely cannot complete the issue (acceptance criteria
+   underspecified, missing dependency, blocked by another open issue), do
+   **not** create a partial commit. Leave the working tree clean and exit;
+   the outer loop will detect the missing commit and halt with the issue
+   labelled `in-progress` for human triage.
+
+When you have committed your work, you are done. Exit normally.

--- a/scripts/agent_loop_prompts/review.md
+++ b/scripts/agent_loop_prompts/review.md
@@ -1,0 +1,30 @@
+You are the review pass for issue #${ISSUE_NUM} on branch `${BRANCH}`.
+The implement pass has already committed work to this branch.
+
+## Your task
+
+1. Run the project's review skill on the diff between this branch and
+   `origin/main`. Prefer:
+       /pr-review-toolkit:review-pr
+   If that skill is unavailable, perform an equivalent review using the
+   `pr-review-toolkit:code-reviewer` and `pr-review-toolkit:silent-failure-hunter`
+   subagents on the same diff.
+2. If the review surfaces *blocker-level* issues (correctness bugs, broken
+   tests, security problems, violations of the rules in `CLAUDE.md`), **fix
+   them and commit the fix to this branch**. Re-run the review on the new
+   diff. Iterate until no blocker-level issues remain.
+3. Non-blocker style nits should be ignored — the implement pass already
+   honours `CLAUDE.md`'s "no overengineering" rules; do not relitigate.
+
+## Verdict file
+
+When review is complete, write a single line to `${VERDICT_FILE}`:
+
+- `APPROVED` — the diff is ready for human review.
+- `BLOCKED: <one-line reason>` — the review found something you could not fix
+  (e.g. requires architectural decision, missing context, intentional design
+  question for a human).
+
+Do NOT push, open a PR, or close the issue. The outer loop owns those steps.
+
+When the verdict file is written, exit normally.


### PR DESCRIPTION
## Summary

A serial agent-loop that picks `ready-for-agent` issues from GitHub, implements + reviews them with Claude Opus 4.7, pushes commits, and opens one PR per PRD (or per orphan issue). Wraps `srun --gres=gpu:1` in a tmux session so the loop survives SSH disconnect on the login node. Generalises the single-experiment loop established by PRD #78.

- `scripts/agent_loop.sh` — outer tmux+srun wrapper
- `scripts/agent_loop_inner.sh` — the loop (jq-filtered picker, parent detection, implement+review passes, hard-stop on first failure)
- `scripts/agent_loop_prompts/{implement,review}.md` — prompt templates
- `docs/agents/agent-loop.md` — user-facing doc
- `docs/adr/0001-canonical-ready-for-agent-label.md` — ADR for the picker label choice
- `CONTEXT.md` — repo-root glossary
- Supersedes `scripts/run_ralph.sh` (issue #114).

Plan: `.claude/plans/my-team-want-a-purrfect-curry.md` (local).

## Test plan

- [x] `bash -n` syntax check on both scripts
- [x] Dry-run picker (`DRY_RUN=true MAX_ISSUES=1`) correctly picks #116 as orphan
- [x] Dry-run picker with `--prd 82` correctly drains-empty
- [x] `extract_parent` parses both block (`## Parent\n\n#78`) and heading-variant (`## Parent PRD … #19 …`) forms
- [x] `count_open_siblings(19) = 0` matches reality (#20, #21 closed)
- [ ] **Real Opus smoke test**: file an "Add Troubleshooting section to docs/agents/agent-loop.md" issue with `ready-for-agent`, run `MAX_ISSUES=2 bash scripts/agent_loop_inner.sh` (covers #116 + smoke). Pending merge of this PR — bootstrapping the loop's own scripts onto `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)