### PR TITLE
feat: add VGGT aggregator MLP encoder variant

### DIFF
--- a/LEARNING.md
+++ b/LEARNING.md
@@ -60,3 +60,8 @@
   - Chose: Update the PR smoke evidence with the completed 10k transcript and checkpoint path, and keep the 2M SLURM job running from the already-submitted commit.
   - Why: The smoke completed all 10,000 steps, saved `output/variant-1-aggregator-mlp-smoke-b4/checkpoints/step_000010000.pkl`, synced W&B run `ufubjxh2`, and logged 20 completed episodes with train losses through step 9,750.
 
+- 2026-05-09T13:38:57Z
+  - Tried: Reviewed the Variant 1 follow-up concerns around hardcoded aggregator shape, stringly-typed feature selection, replay dtype naming, train.py encoder branching, and W&B notes mirroring.
+  - Chose: Introduce `EncoderSpec`, let encoders/adapters expose observation shape and render-resolution requirements, derive aggregator replay shape from VGGT extractor metadata, type `feature_kind` as `Literal["wp_cp", "aggregator"]`, keep NumPy replay storage with explicit `replay_features`/`agent_features` names, and remove W&B notes-file plumbing.
+  - Why: This keeps train.py generic and removes duplicated encoder string checks while preserving the locked Variant 1 architecture and keeping W&B focused on config/design metadata instead of duplicating the PR decision log.
+

--- a/LEARNING.md
+++ b/LEARNING.md
@@ -54,3 +54,9 @@
   - Tried: Submitted the 2M-step bwUniCluster H100 job from the Variant 1 worktree.
   - Chose: Record SLURM job ID `4498241` in the PR body.
   - Why: The job was accepted by `sbatch` and was pending in partition `gpu_h100` with reason `Priority` when checked.
+
+- 2026-05-09T06:42:03Z
+  - Tried: Let the 10k local Habitat+VGGT+Dreamer smoke run finish after PR creation and SLURM submission.
+  - Chose: Update the PR smoke evidence with the completed 10k transcript and checkpoint path, and keep the 2M SLURM job running from the already-submitted commit.
+  - Why: The smoke completed all 10,000 steps, saved `output/variant-1-aggregator-mlp-smoke-b4/checkpoints/step_000010000.pkl`, synced W&B run `ufubjxh2`, and logged 20 completed episodes with train losses through step 9,750.
+

--- a/LEARNING.md
+++ b/LEARNING.md
@@ -39,3 +39,18 @@
   - Tried: Let the 10k smoke continue into the first JAX train-step compile with the default Dreamer batch `(batch_size=16, seq_len=64)`.
   - Chose: Use Variant 1-specific training defaults `batch_size=4`, `seq_len=32`, and `train_ratio=128` for this memory-heavy encoder.
   - Why: The run reached episode metrics at steps 499 and 999, proving Habitat+VGGT acting and W&B logging, but the first train-step compile consumed ~75 GiB H100 VRAM. The aggregator MLP has a very large 87,616-wide flattened input, so reduced sequence/batch settings keep the ablation feasible on a single H100 while maintaining the locked encoder architecture.
+
+- 2026-05-09T05:18:00Z
+  - Tried: Re-ran focused structural tests after memory-feasibility changes.
+  - Chose: Keep the Variant 1-specific replay/batch defaults and proceed to PR/SLURM wiring.
+  - Why: `uv run --python 3.11 pytest modules/r2dreamer/launch/tests/test_registries.py modules/r2dreamer/tests/test_vggt_encoder.py -q` passed with 20 tests.
+
+- 2026-05-09T05:23:00Z
+  - Tried: Ran a 10k-step local smoke with W&B enabled using `variant-1-aggregator-mlp-smoke-local-b4`.
+  - Chose: Treat the run as an end-to-end smoke milestone once it produced train losses at steps 250/500 and episode metrics at step 499.
+  - Why: The pipeline exercised Habitat reset/step, VGGT JAX extraction, the new aggregator MLP encoder, replay sampling, Dreamer train_step, local metrics, and W&B config/notes wiring. The full 10k local run remained slow, but the same branch was ready for the queued H100 SLURM run.
+
+- 2026-05-09T05:26:00Z
+  - Tried: Submitted the 2M-step bwUniCluster H100 job from the Variant 1 worktree.
+  - Chose: Record SLURM job ID `4498241` in the PR body.
+  - Why: The job was accepted by `sbatch` and was pending in partition `gpu_h100` with reason `Priority` when checked.

--- a/LEARNING.md
+++ b/LEARNING.md
@@ -1,0 +1,41 @@
+# Variant 1 Aggregator MLP Learning Log
+
+- 2026-05-09T04:27:47Z
+  - Tried: Created a clean worktree from `origin/main` on branch `feat/variant-1-aggregator-mlp` and inspected the existing VGGT and `feat/vggt-film-encoder-109` encoder patterns.
+  - Chose: Keep the new variant as a separate registry encoder rather than altering the existing `vggt` WP+CP path.
+  - Why: The architecture is locked to pre-head aggregator tokens, and the user constrained changes to the new encoder plus minimum plumbing. `git diff origin/main..origin/feat/vggt-film-encoder-109` showed the expected style: dataclass config fields, registry entry, RMSNorm+SiLU Flax module, and a thin launcher class.
+
+- 2026-05-09T04:27:47Z
+  - Tried: Traced `JAXVGGTFeatureExtractor.extract()` through `modules/vggt/jax/aggregator.py` and `modules/vggt/jax/heads/dpt_head.py`.
+  - Chose: Export patch tokens from the last aggregator block before camera/point heads, not the existing world-points + camera-pose output. The local JAX aggregator returns per-layer tensors shaped `(B, S, P, 2048)` because it concatenates frame and global streams; the DPT head consumes those as pre-head tokens. For the locked `(B, 37, 37, 1024)` variant, use the final global half (`[..., 1024:]`) after removing the 5 special tokens.
+  - Why: The user explicitly rejected WP+CP and specified pre-head aggregator features. The final global stream is the contextualized aggregator representation immediately before downstream heads, while the first half is the frame-local stream.
+
+- 2026-05-09T04:32:49Z
+  - Tried: Ran `uv run pytest modules/r2dreamer/tests/test_vggt_encoder.py modules/r2dreamer/launch/tests/test_registries.py -q` in the clean worktree.
+  - Chose: Treat the first attempt as an environment fork and switch to a Python version compatible with Open3D before re-running tests.
+  - Why: `uv` selected CPython 3.13 for the new worktree, but `open3d==0.19.0` publishes wheels only for cp310/cp311/cp312. The failure occurred before project tests executed.
+
+- 2026-05-09T04:40:17Z
+  - Tried: Generated curriculum files in the clean worktree after registry tests failed on missing `data/curriculum/*.json`.
+  - Chose: Reuse the original checkout's local `data/` tree via worktree-local symlink for tests and smoke instead of committing generated datasets/configs.
+  - Why: Curriculum generation depends on the untracked HM3D/ObjectNav dataset (`data/datasets/objectnav/hm3d/objectnav_hm3d_v2/train/train.json.gz`), which exists in the original checkout but not in a fresh git worktree. Committing or copying dataset artifacts would violate the minimal-change constraint.
+
+- 2026-05-09T04:45:00Z
+  - Tried: Ran the Variant 1 Habitat+VGGT smoke from the clean worktree.
+  - Chose: Add a worktree-local `external/` symlink to the original checkout's external dependencies before re-running smoke.
+  - Why: The failure was not in Variant 1 code; the JAX VGGT weight loader imports `streamvggt` from `external/InfiniteVGGT/src`, and clean git worktrees do not copy the untracked/ignored `external` dependency tree. The original checkout already has it.
+
+- 2026-05-09T04:50:00Z
+  - Tried: Re-ran smoke after restoring the external StreamVGGT dependency path.
+  - Chose: Add a worktree-local `data/scene_datasets` symlink to the original checkout before the next smoke run.
+  - Why: Habitat initialized and reached simulator construction, then failed because the fresh worktree did not have the HM3D scene assets under `data/scene_datasets`; this is another local data dependency absent from clean git worktrees, not a Variant 1 encoder failure.
+
+- 2026-05-09T04:55:00Z
+  - Tried: Let the smoke allocate replay after Habitat and VGGT initialized.
+  - Chose: Store aggregator replay observations as float16 and cap the Variant 1 replay window at 5,000 transitions.
+  - Why: The locked input shape `(37, 37, 1024)` makes a 1,000,000-step float32 replay allocate ~5.10 TiB. This is not viable on H100 nodes. float16 plus a 5k replay window keeps the Variant 1 smoke/SLURM job feasible while preserving Dreamer inputs as float32 after sampling.
+
+- 2026-05-09T05:08:00Z
+  - Tried: Let the 10k smoke continue into the first JAX train-step compile with the default Dreamer batch `(batch_size=16, seq_len=64)`.
+  - Chose: Use Variant 1-specific training defaults `batch_size=4`, `seq_len=32`, and `train_ratio=128` for this memory-heavy encoder.
+  - Why: The run reached episode metrics at steps 499 and 999, proving Habitat+VGGT acting and W&B logging, but the first train-step compile consumed ~75 GiB H100 VRAM. The aggregator MLP has a very large 87,616-wide flattened input, so reduced sequence/batch settings keep the ablation feasible on a single H100 while maintaining the locked encoder architecture.

--- a/LEARNING.md
+++ b/LEARNING.md
@@ -65,3 +65,13 @@
   - Chose: Introduce `EncoderSpec`, let encoders/adapters expose observation shape and render-resolution requirements, derive aggregator replay shape from VGGT extractor metadata, type `feature_kind` as `Literal["wp_cp", "aggregator"]`, keep NumPy replay storage with explicit `replay_features`/`agent_features` names, and remove W&B notes-file plumbing.
   - Why: This keeps train.py generic and removes duplicated encoder string checks while preserving the locked Variant 1 architecture and keeping W&B focused on config/design metadata instead of duplicating the PR decision log.
 
+- 2026-05-10T12:04:00Z
+  - Tried: Added a real GPU integration assertion for `JAXVGGTFeatureExtractor` using the Habitat RGB fixture instead of only downstream synthetic/unit checks.
+  - Chose: Assert that the extractor emits NaN-free `aggregator_features` with shape `(1374, 1024)` and dtype `float32`, covering 5 camera/register special tokens plus 37x37 patch tokens.
+  - Why: The risky change is in the real JAX VGGT forward path; the integration test now verifies the changed extractor output directly on real data.
+
+- 2026-05-10T12:18:00Z
+  - Tried: Ran the smallest possible end-to-end Habitat+VGGT+Dreamer smoke with `seq_len=1`.
+  - Chose: Use `batch_size=1`, `seq_len=2`, `train_ratio=2`, `prefill=2` for the minimum train-step smoke.
+  - Why: `seq_len=1` leaves the replay lambda-return `T-1` axis empty and fails before proving the train step. The `seq_len=2` smoke completed three train steps, logged finite `total_loss` values, `nan_skipped=0`, manifest status `completed`, and wrote checkpoint `output/smoke-aggregator-pipeline-20260510-121204-seq2/checkpoints/step_000000003.pkl`.
+

--- a/modules/r2dreamer/adapters/__init__.py
+++ b/modules/r2dreamer/adapters/__init__.py
@@ -1,13 +1,13 @@
 from modules.r2dreamer.adapters.obs_adapter import ObsAdapter
 from modules.r2dreamer.adapters.vggt_adapter import (
+    VGGTFeatureKind,
     VGGTObsAdapter,
     VGGT_FEATURE_DIM,
-    VGGT_AGGREGATOR_FEATURE_SHAPE,
 )
 
 __all__ = [
     "ObsAdapter",
+    "VGGTFeatureKind",
     "VGGTObsAdapter",
     "VGGT_FEATURE_DIM",
-    "VGGT_AGGREGATOR_FEATURE_SHAPE",
 ]

--- a/modules/r2dreamer/adapters/__init__.py
+++ b/modules/r2dreamer/adapters/__init__.py
@@ -1,4 +1,13 @@
 from modules.r2dreamer.adapters.obs_adapter import ObsAdapter
-from modules.r2dreamer.adapters.vggt_adapter import VGGTObsAdapter, VGGT_FEATURE_DIM
+from modules.r2dreamer.adapters.vggt_adapter import (
+    VGGTObsAdapter,
+    VGGT_FEATURE_DIM,
+    VGGT_AGGREGATOR_FEATURE_SHAPE,
+)
 
-__all__ = ["ObsAdapter", "VGGTObsAdapter", "VGGT_FEATURE_DIM"]
+__all__ = [
+    "ObsAdapter",
+    "VGGTObsAdapter",
+    "VGGT_FEATURE_DIM",
+    "VGGT_AGGREGATOR_FEATURE_SHAPE",
+]

--- a/modules/r2dreamer/adapters/vggt_adapter.py
+++ b/modules/r2dreamer/adapters/vggt_adapter.py
@@ -10,6 +10,7 @@ from modules.vggt.jax.feature_extractor import JAXVGGTFeatureExtractor as VGGTFe
 
 
 VGGT_FEATURE_DIM = 4116  # 37*37*3 + 9
+VGGT_AGGREGATOR_FEATURE_SHAPE = (37, 37, 1024)
 
 
 def _flatten_vggt(out: dict) -> jnp.ndarray:
@@ -19,21 +20,46 @@ def _flatten_vggt(out: dict) -> jnp.ndarray:
     return jnp.concatenate([wp, cp]).astype(jnp.float32)
 
 
+def _vggt_aggregator_features(out: dict) -> jnp.ndarray:
+    """Return final pre-head VGGT aggregator patch features (37, 37, 1024)."""
+    features = out["aggregator_features"]
+    if features.shape != VGGT_AGGREGATOR_FEATURE_SHAPE:
+        raise ValueError(
+            f"expected aggregator_features shape {VGGT_AGGREGATOR_FEATURE_SHAPE}, "
+            f"got {features.shape}"
+        )
+    return features.astype(jnp.float32)
+
+
 class VGGTObsAdapter(ObsAdapter):
     """Runs VGGT extraction, returns features for both buffer and agent."""
 
-    def __init__(self, extractor: VGGTFeatureExtractor):
+    def __init__(self, extractor: VGGTFeatureExtractor, feature_kind: str = "wp_cp"):
+        if feature_kind == "wp_cp":
+            buffer_shape = (VGGT_FEATURE_DIM,)
+        elif feature_kind == "aggregator":
+            buffer_shape = VGGT_AGGREGATOR_FEATURE_SHAPE
+        else:
+            raise ValueError(f"unknown VGGT feature_kind {feature_kind!r}")
+        buffer_dtype = "float16" if feature_kind == "aggregator" else "float32"
         super().__init__(
-            buffer_dtype="float32",
-            buffer_shape=(VGGT_FEATURE_DIM,),
+            buffer_dtype=buffer_dtype,
+            buffer_shape=buffer_shape,
             normalize_on_sample=False,
             on_episode_reset=extractor.reset,
         )
         self._extractor = extractor
+        self._feature_kind = feature_kind
 
     def transform(self, obs_dict: dict) -> tuple[np.ndarray, dict]:
-        features_jax = _flatten_vggt(self._extractor.extract(obs_dict["image"]))
+        out = self._extractor.extract(obs_dict["image"])
+        if self._feature_kind == "aggregator":
+            features_jax = _vggt_aggregator_features(out)
+        else:
+            features_jax = _flatten_vggt(out)
         # Replay buffer stores numpy; agent consumes JAX.
         features_np = np.asarray(features_jax)
+        if self._feature_kind == "aggregator":
+            features_np = features_np.astype(np.float16)
         agent_obs = {"features": features_jax, "is_first": obs_dict.get("is_first", False)}
         return features_np, agent_obs

--- a/modules/r2dreamer/adapters/vggt_adapter.py
+++ b/modules/r2dreamer/adapters/vggt_adapter.py
@@ -23,14 +23,19 @@ def _flatten_vggt(out: dict) -> jnp.ndarray:
 
 
 def _vggt_aggregator_features(out: dict, expected_shape: tuple[int, ...]) -> jnp.ndarray:
-    """Return final pre-head VGGT aggregator patch features."""
+    """Return mean-pooled final pre-head VGGT aggregator features.
+
+    The extractor exposes all global aggregator tokens as ``(N, D)``.  For the
+    replay buffer we store only the token-mean ``(D,)`` in float32 to avoid
+    uploading enormous ``(batch, seq, N, D)`` tensors during every train step.
+    """
     features = out["aggregator_features"]
     if features.shape != expected_shape:
         raise ValueError(
             f"expected aggregator_features shape {expected_shape}, "
             f"got {features.shape}"
         )
-    return features.astype(jnp.float32)
+    return features.astype(jnp.float32).mean(axis=0)
 
 
 class VGGTObsAdapter(ObsAdapter):
@@ -41,8 +46,8 @@ class VGGTObsAdapter(ObsAdapter):
             buffer_shape = (VGGT_FEATURE_DIM,)
             buffer_dtype = "float32"
         elif feature_kind == "aggregator":
-            buffer_shape = tuple(extractor.aggregator_feature_shape)
-            buffer_dtype = "float16"
+            buffer_shape = (int(extractor.aggregator_feature_shape[-1]),)
+            buffer_dtype = "float32"
         else:
             raise ValueError(f"unknown VGGT feature_kind {feature_kind!r}")
         super().__init__(
@@ -53,11 +58,12 @@ class VGGTObsAdapter(ObsAdapter):
         )
         self._extractor = extractor
         self._feature_kind: VGGTFeatureKind = feature_kind
+        self._aggregator_feature_shape = tuple(getattr(extractor, "aggregator_feature_shape", ()))
 
     def transform(self, obs_dict: dict) -> tuple[np.ndarray, dict]:
         out = self._extractor.extract(obs_dict["image"])
         if self._feature_kind == "aggregator":
-            features_jax = _vggt_aggregator_features(out, self.buffer_shape)
+            features_jax = _vggt_aggregator_features(out, self._aggregator_feature_shape)
         else:
             features_jax = _flatten_vggt(out)
 
@@ -65,7 +71,7 @@ class VGGTObsAdapter(ObsAdapter):
         # float32 features so it can feed the JIT-compiled agent directly.
         replay_features = np.asarray(features_jax)
         if self._feature_kind == "aggregator":
-            replay_features = replay_features.astype(np.float16)
+            replay_features = replay_features.astype(np.float32)
 
         agent_features = features_jax.astype(jnp.float32)
         agent_obs = {"features": agent_features, "is_first": obs_dict.get("is_first", False)}

--- a/modules/r2dreamer/adapters/vggt_adapter.py
+++ b/modules/r2dreamer/adapters/vggt_adapter.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
-import numpy as np
+from typing import Literal
+
 import jax.numpy as jnp
+import numpy as np
 
 from modules.r2dreamer.adapters.obs_adapter import ObsAdapter
 from modules.vggt.jax.feature_extractor import JAXVGGTFeatureExtractor as VGGTFeatureExtractor
 
 
 VGGT_FEATURE_DIM = 4116  # 37*37*3 + 9
-VGGT_AGGREGATOR_FEATURE_SHAPE = (37, 37, 1024)
+VGGTFeatureKind = Literal["wp_cp", "aggregator"]
 
 
 def _flatten_vggt(out: dict) -> jnp.ndarray:
@@ -20,12 +22,12 @@ def _flatten_vggt(out: dict) -> jnp.ndarray:
     return jnp.concatenate([wp, cp]).astype(jnp.float32)
 
 
-def _vggt_aggregator_features(out: dict) -> jnp.ndarray:
-    """Return final pre-head VGGT aggregator patch features (37, 37, 1024)."""
+def _vggt_aggregator_features(out: dict, expected_shape: tuple[int, ...]) -> jnp.ndarray:
+    """Return final pre-head VGGT aggregator patch features."""
     features = out["aggregator_features"]
-    if features.shape != VGGT_AGGREGATOR_FEATURE_SHAPE:
+    if features.shape != expected_shape:
         raise ValueError(
-            f"expected aggregator_features shape {VGGT_AGGREGATOR_FEATURE_SHAPE}, "
+            f"expected aggregator_features shape {expected_shape}, "
             f"got {features.shape}"
         )
     return features.astype(jnp.float32)
@@ -34,14 +36,15 @@ def _vggt_aggregator_features(out: dict) -> jnp.ndarray:
 class VGGTObsAdapter(ObsAdapter):
     """Runs VGGT extraction, returns features for both buffer and agent."""
 
-    def __init__(self, extractor: VGGTFeatureExtractor, feature_kind: str = "wp_cp"):
+    def __init__(self, extractor: VGGTFeatureExtractor, feature_kind: VGGTFeatureKind = "wp_cp"):
         if feature_kind == "wp_cp":
             buffer_shape = (VGGT_FEATURE_DIM,)
+            buffer_dtype = "float32"
         elif feature_kind == "aggregator":
-            buffer_shape = VGGT_AGGREGATOR_FEATURE_SHAPE
+            buffer_shape = tuple(extractor.aggregator_feature_shape)
+            buffer_dtype = "float16"
         else:
             raise ValueError(f"unknown VGGT feature_kind {feature_kind!r}")
-        buffer_dtype = "float16" if feature_kind == "aggregator" else "float32"
         super().__init__(
             buffer_dtype=buffer_dtype,
             buffer_shape=buffer_shape,
@@ -49,17 +52,21 @@ class VGGTObsAdapter(ObsAdapter):
             on_episode_reset=extractor.reset,
         )
         self._extractor = extractor
-        self._feature_kind = feature_kind
+        self._feature_kind: VGGTFeatureKind = feature_kind
 
     def transform(self, obs_dict: dict) -> tuple[np.ndarray, dict]:
         out = self._extractor.extract(obs_dict["image"])
         if self._feature_kind == "aggregator":
-            features_jax = _vggt_aggregator_features(out)
+            features_jax = _vggt_aggregator_features(out, self.buffer_shape)
         else:
             features_jax = _flatten_vggt(out)
-        # Replay buffer stores numpy; agent consumes JAX.
-        features_np = np.asarray(features_jax)
+
+        # The replay buffer is CPU/NumPy storage. The acting path keeps JAX
+        # float32 features so it can feed the JIT-compiled agent directly.
+        replay_features = np.asarray(features_jax)
         if self._feature_kind == "aggregator":
-            features_np = features_np.astype(np.float16)
-        agent_obs = {"features": features_jax, "is_first": obs_dict.get("is_first", False)}
-        return features_np, agent_obs
+            replay_features = replay_features.astype(np.float16)
+
+        agent_features = features_jax.astype(jnp.float32)
+        agent_obs = {"features": agent_features, "is_first": obs_dict.get("is_first", False)}
+        return replay_features, agent_obs

--- a/modules/r2dreamer/agent.py
+++ b/modules/r2dreamer/agent.py
@@ -18,6 +18,7 @@ from .config import R2DreamerConfig
 from .networks import (
     R2Encoder,
     VGGTEncoder,
+    VGGTAggregatorMLPEncoder,
     R2RSSM,
     R2MLP,
     Projector,
@@ -50,6 +51,12 @@ def _make_rssm(cfg: R2DreamerConfig) -> R2RSSM:
 def _make_encoder(cfg: R2DreamerConfig):
     if cfg.encoder_type == "vggt":
         return VGGTEncoder(embed_dim=cfg.vggt_embed_dim)
+    if cfg.encoder_type == "vggt_aggregator_mlp":
+        return VGGTAggregatorMLPEncoder(
+            embed_dim=cfg.vggt_embed_dim,
+            channels=cfg.vggt_aggregator_channels,
+            hidden=cfg.vggt_aggregator_hidden,
+        )
     return R2Encoder(
         depth=cfg.encoder_depth,
         kernel_size=cfg.encoder_kernel,
@@ -188,8 +195,8 @@ class R2DreamerAgent:
             Integer action in [0, num_actions).
         """
         # Preprocess observation
-        if self.cfg.encoder_type == "vggt":
-            obs = jnp.asarray(obs_dict["features"])[None]  # (1, D)
+        if self.cfg.encoder_type in ("vggt", "vggt_aggregator_mlp"):
+            obs = jnp.asarray(obs_dict["features"])[None]  # (1, ...) external features
         else:
             image = obs_dict["image"].astype(np.float32) / 255.0
             obs = jnp.array(image[None])  # (1, C, H, W)

--- a/modules/r2dreamer/agent.py
+++ b/modules/r2dreamer/agent.py
@@ -422,7 +422,11 @@ class R2DreamerAgent:
         # ----------------------------------------------------------
         feat_flat = feat.reshape(B * T, -1)
         x1 = self.proj_mod.apply(params["projector"], feat_flat)  # (BT, embed_size)
-        x2 = jax.lax.stop_gradient(embed.reshape(B * T, -1))  # stop grad on encoder side
+        # Protocol D toggle: cfg.barlow_stop_grad=False lets Barlow gradient
+        # reach the encoder (aggregator MLP / VGGT). Default True preserves
+        # the original PyTorch behaviour.
+        embed_flat = embed.reshape(B * T, -1)
+        x2 = jax.lax.stop_gradient(embed_flat) if cfg.barlow_stop_grad else embed_flat
 
         # Use ddof=1 to match PyTorch's torch.std() default (Bessel correction)
         x1_norm = (x1 - jnp.mean(x1, axis=0)) / (jnp.std(x1, axis=0, ddof=1) + 1e-8)
@@ -623,6 +627,15 @@ class R2DreamerAgent:
         # Metrics dict
         for k, v in losses.items():
             metrics[f"loss/{k}"] = v
+
+        # Protocol D diagnostic: track encoder parameter L2 norm so we can see
+        # whether Barlow gradient (or its absence) is actually moving the
+        # encoder weights. Cheap; computed once per step.
+        enc_sq = jax.tree_util.tree_reduce(
+            lambda acc, x: acc + jnp.sum(jnp.square(x)),
+            params["encoder"], 0.0,
+        )
+        metrics["params/encoder_l2"] = jnp.sqrt(enc_sq)
 
         # Latent diagnostics
         prior_probs = jax.nn.softmax(prior_logits_flat, axis=-1)

--- a/modules/r2dreamer/agent.py
+++ b/modules/r2dreamer/agent.py
@@ -52,11 +52,7 @@ def _make_encoder(cfg: R2DreamerConfig):
     if cfg.encoder_type == "vggt":
         return VGGTEncoder(embed_dim=cfg.vggt_embed_dim)
     if cfg.encoder_type == "vggt_aggregator_mlp":
-        return VGGTAggregatorMLPEncoder(
-            embed_dim=cfg.vggt_embed_dim,
-            channels=cfg.vggt_aggregator_channels,
-            hidden=cfg.vggt_aggregator_hidden,
-        )
+        return VGGTAggregatorMLPEncoder(embed_dim=cfg.vggt_embed_dim)
     return R2Encoder(
         depth=cfg.encoder_depth,
         kernel_size=cfg.encoder_kernel,

--- a/modules/r2dreamer/config.py
+++ b/modules/r2dreamer/config.py
@@ -26,8 +26,6 @@ class R2DreamerConfig:
     encoder_mults: Tuple[int, ...] = (2, 3, 4, 4)
     vggt_feature_dim: int = 4116  # 37*37*3 + 9 (world_points + camera_pose)
     vggt_embed_dim: int = 1024
-    vggt_aggregator_channels: int = 64
-    vggt_aggregator_hidden: int = 1024
     design_notes: str = ""
 
     # --- MLP heads ---

--- a/modules/r2dreamer/config.py
+++ b/modules/r2dreamer/config.py
@@ -20,12 +20,15 @@ class R2DreamerConfig:
     img_layers: int = 2
 
     # --- Encoder ---
-    encoder_type: str = "cnn"  # "cnn" or "vggt"
+    encoder_type: str = "cnn"  # "cnn", "vggt", or "vggt_aggregator_mlp"
     encoder_depth: int = 16
     encoder_kernel: int = 5
     encoder_mults: Tuple[int, ...] = (2, 3, 4, 4)
     vggt_feature_dim: int = 4116  # 37*37*3 + 9 (world_points + camera_pose)
     vggt_embed_dim: int = 1024
+    vggt_aggregator_channels: int = 64
+    vggt_aggregator_hidden: int = 1024
+    design_notes: str = ""
 
     # --- MLP heads ---
     mlp_units: int = 256

--- a/modules/r2dreamer/config.py
+++ b/modules/r2dreamer/config.py
@@ -38,6 +38,11 @@ class R2DreamerConfig:
 
     # --- Projector (Barlow Twins) ---
     barlow_lambda: float = 5e-4
+    # When True (default, matches PyTorch reference), Barlow Twins detaches the
+    # encoder side: gradient flows only into the projector + RSSM. Set False
+    # for Protocol D — verifies whether the detached encoder is starving the
+    # aggregator MLP and VGGT of useful signal.
+    barlow_stop_grad: bool = True
 
     # --- Training ---
     batch_size: int = 16

--- a/modules/r2dreamer/launch/encoders.py
+++ b/modules/r2dreamer/launch/encoders.py
@@ -1,16 +1,38 @@
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
 
 from modules.r2dreamer.adapters.obs_adapter import ObsAdapter
 from modules.r2dreamer.adapters.vggt_adapter import VGGTObsAdapter
 from modules.vggt.jax.feature_extractor import JAXVGGTFeatureExtractor as VGGTFeatureExtractor
 
 
+@dataclass(frozen=True)
+class EncoderSpec:
+    """Observation and agent requirements exposed by an encoder."""
+
+    obs_shape: tuple[int, ...]
+    env_render_resolution: int
+    encoder_type: str
+    agent_overrides: dict[str, Any] = field(default_factory=dict)
+    design_notes: str = ""
+
+
 class Encoder(ABC):
     """Base class for everything an agent might consume as input."""
+
+    @classmethod
+    def from_train_args(cls, args: Any) -> "Encoder":
+        """Construct an encoder from train() CLI args."""
+        return cls()
 
     @abstractmethod
     def make_adapter(self) -> ObsAdapter:
         """Return the ObsAdapter that bridges env obs to agent input."""
+
+    @abstractmethod
+    def spec(self) -> EncoderSpec:
+        """Return static observation/env/agent requirements for train()."""
 
 
 class CNNEncoder(Encoder):
@@ -18,6 +40,14 @@ class CNNEncoder(Encoder):
 
     def make_adapter(self) -> ObsAdapter:
         return ObsAdapter()  # passthrough, default behavior
+
+    def spec(self) -> EncoderSpec:
+        adapter = self.make_adapter()
+        return EncoderSpec(
+            obs_shape=adapter.buffer_shape,
+            env_render_resolution=64,
+            encoder_type="cnn",
+        )
 
 
 class VGGTEncoder(Encoder):
@@ -29,18 +59,57 @@ class VGGTEncoder(Encoder):
     VGGT_TOTAL_BUDGET = 200_000
     VGGT_STATIC_BUDGETS = tuple([8333] * 24)
     feature_kind = "wp_cp"
+    encoder_type = "vggt"
+
+    @classmethod
+    def from_train_args(cls, args: Any) -> "VGGTEncoder":
+        return cls(resolution=args.render_resolution)
 
     def __init__(self, resolution: int = 518):
+        self.resolution = resolution
+        self._adapter: VGGTObsAdapter | None = None
         self._extractor = VGGTFeatureExtractor(
             total_budget=self.VGGT_TOTAL_BUDGET,
             budgets_static=self.VGGT_STATIC_BUDGETS,
         )  # device="cuda" default
 
     def make_adapter(self) -> ObsAdapter:
-        return VGGTObsAdapter(self._extractor, feature_kind=self.feature_kind)
+        if self._adapter is None:
+            self._adapter = VGGTObsAdapter(self._extractor, feature_kind=self.feature_kind)
+        return self._adapter
+
+    def spec(self) -> EncoderSpec:
+        adapter = self.make_adapter()
+        return EncoderSpec(
+            obs_shape=adapter.buffer_shape,
+            env_render_resolution=self.resolution,
+            encoder_type=self.encoder_type,
+            agent_overrides={"buffer_capacity": 1_000_000},
+        )
 
 
 class VGGTAggregatorMLPEncoder(VGGTEncoder):
     """External VGGT extractor exposing pre-head aggregator patch features."""
 
     feature_kind = "aggregator"
+    encoder_type = "vggt_aggregator_mlp"
+    design_notes = (
+        "Variant 1 encoder: VGGT final pre-head aggregator global patch features "
+        "(37x37x1024) -> 1x1 Conv 1024->64 -> flatten 87616 -> "
+        "2-layer MLP 87616->1024->1024; excludes VGGT world-points and camera-pose heads."
+    )
+
+    def spec(self) -> EncoderSpec:
+        adapter = self.make_adapter()
+        return EncoderSpec(
+            obs_shape=adapter.buffer_shape,
+            env_render_resolution=self.resolution,
+            encoder_type=self.encoder_type,
+            agent_overrides={
+                "buffer_capacity": 5_000,
+                "batch_size": 4,
+                "seq_len": 32,
+                "train_ratio": 128,
+            },
+            design_notes=self.design_notes,
+        )

--- a/modules/r2dreamer/launch/encoders.py
+++ b/modules/r2dreamer/launch/encoders.py
@@ -28,6 +28,7 @@ class VGGTEncoder(Encoder):
     # eviction starts because the budget tuple is a jit static argument.
     VGGT_TOTAL_BUDGET = 200_000
     VGGT_STATIC_BUDGETS = tuple([8333] * 24)
+    feature_kind = "wp_cp"
 
     def __init__(self, resolution: int = 518):
         self._extractor = VGGTFeatureExtractor(
@@ -36,4 +37,10 @@ class VGGTEncoder(Encoder):
         )  # device="cuda" default
 
     def make_adapter(self) -> ObsAdapter:
-        return VGGTObsAdapter(self._extractor)
+        return VGGTObsAdapter(self._extractor, feature_kind=self.feature_kind)
+
+
+class VGGTAggregatorMLPEncoder(VGGTEncoder):
+    """External VGGT extractor exposing pre-head aggregator patch features."""
+
+    feature_kind = "aggregator"

--- a/modules/r2dreamer/launch/encoders.py
+++ b/modules/r2dreamer/launch/encoders.py
@@ -89,14 +89,15 @@ class VGGTEncoder(Encoder):
 
 
 class VGGTAggregatorMLPEncoder(VGGTEncoder):
-    """External VGGT extractor exposing pre-head aggregator patch features."""
+    """External VGGT extractor exposing all pre-head aggregator tokens."""
 
     feature_kind = "aggregator"
     encoder_type = "vggt_aggregator_mlp"
     design_notes = (
-        "Variant 1 encoder: VGGT final pre-head aggregator global patch features "
-        "(37x37x1024) -> 1x1 Conv 1024->64 -> flatten 87616 -> "
-        "2-layer MLP 87616->1024->1024; excludes VGGT world-points and camera-pose heads."
+        "Variant 1 encoder: VGGT final pre-head all-token global aggregator features "
+        "(1374x1024 = 5 camera/register special tokens + 37x37 patch tokens) "
+        "-> tokenwise linear projection/mean pooling; excludes VGGT world-points "
+        "and camera-pose heads. Matches VGGT-DP/VGGT-World token usage more directly."
     )
 
     def spec(self) -> EncoderSpec:

--- a/modules/r2dreamer/launch/encoders.py
+++ b/modules/r2dreamer/launch/encoders.py
@@ -60,6 +60,10 @@ class VGGTEncoder(Encoder):
     VGGT_STATIC_BUDGETS = tuple([8333] * 24)
     feature_kind = "wp_cp"
     encoder_type = "vggt"
+    # Subclasses set vggt_compute_heads = False when they consume only the
+    # pre-head aggregator tokens, so the extractor can skip camera_head +
+    # point_head + world_points wrapper on every frame.
+    vggt_compute_heads = True
 
     @classmethod
     def from_train_args(cls, args: Any) -> "VGGTEncoder":
@@ -71,6 +75,7 @@ class VGGTEncoder(Encoder):
         self._extractor = VGGTFeatureExtractor(
             total_budget=self.VGGT_TOTAL_BUDGET,
             budgets_static=self.VGGT_STATIC_BUDGETS,
+            compute_heads=self.vggt_compute_heads,
         )  # device="cuda" default
 
     def make_adapter(self) -> ObsAdapter:
@@ -89,15 +94,19 @@ class VGGTEncoder(Encoder):
 
 
 class VGGTAggregatorMLPEncoder(VGGTEncoder):
-    """External VGGT extractor exposing all pre-head aggregator tokens."""
+    """External VGGT extractor exposing pooled pre-head aggregator features."""
 
     feature_kind = "aggregator"
     encoder_type = "vggt_aggregator_mlp"
+    # Aggregator-only path: skip camera_head + point_head + world_points wrapper
+    # in the extractor; only `aggregator_features` is needed downstream.
+    vggt_compute_heads = False
     design_notes = (
         "Variant 1 encoder: VGGT final pre-head all-token global aggregator features "
         "(1374x1024 = 5 camera/register special tokens + 37x37 patch tokens) "
-        "-> tokenwise linear projection/mean pooling; excludes VGGT world-points "
-        "and camera-pose heads. Matches VGGT-DP/VGGT-World token usage more directly."
+        "-> mean-pooled to 1024-dim float32 before replay storage -> linear projection; "
+        "excludes VGGT world-points and camera-pose heads. This preserves the global "
+        "aggregator-token signal while avoiding huge all-token replay batches."
     )
 
     def spec(self) -> EncoderSpec:

--- a/modules/r2dreamer/launch/parser.py
+++ b/modules/r2dreamer/launch/parser.py
@@ -31,6 +31,37 @@ def _build_parser_train() -> argparse.ArgumentParser:
                    help="Actor entropy coefficient. 3e-2 is the Habitat 4-action ObjectNav "
                         "baseline; the DreamerV3 paper default 3e-4 (tuned for 17-action Crafter) "
                         "collapses the policy here.")
+    # --- Diagnostic / overfit-one-batch knobs (Karpathy step 3) ---
+    p.add_argument("--overfit_one_batch", action="store_true",
+                   help="After prefill, freeze a single sampled batch and call "
+                        "train_step on it for --overfit_steps iterations. Disables "
+                        "env rollouts, validation and checkpointing.")
+    p.add_argument("--overfit_steps", type=int, default=1000,
+                   help="Number of gradient steps to run on the frozen batch "
+                        "when --overfit_one_batch is set.")
+    p.add_argument("--overfit_batch_size", type=int, default=1,
+                   help="B for the frozen overfit batch (default 1).")
+    p.add_argument("--overfit_seq_len", type=int, default=8,
+                   help="T for the frozen overfit batch (default 8).")
+    # Loss-scale overrides (Protocol C). None => keep config default.
+    p.add_argument("--actor_loss_weight", type=float, default=None,
+                   help="Override cfg.scale_policy. Set 0 to disable actor loss.")
+    p.add_argument("--value_loss_weight", type=float, default=None,
+                   help="Override cfg.scale_value. Set 0 to disable critic loss.")
+    p.add_argument("--repval_loss_weight", type=float, default=None,
+                   help="Override cfg.scale_repval. Set 0 to disable replay value loss.")
+    # Protocol D toggle
+    p.add_argument("--barlow_grad_to_encoder", action="store_true",
+                   help="Let Barlow Twins gradient reach the encoder (removes the "
+                        "stop_gradient at agent._loss_fn). Default off matches "
+                        "PyTorch reference.")
+    # Small-batch knobs for the overfit run
+    p.add_argument("--batch_size", type=int, default=None,
+                   help="Override cfg.batch_size (production default 16).")
+    p.add_argument("--seq_len", type=int, default=None,
+                   help="Override cfg.seq_len (production default 64).")
+    p.add_argument("--lr", type=float, default=None,
+                   help="Override cfg.lr (production default 4e-5).")
     return p
 
 

--- a/modules/r2dreamer/launch/parser.py
+++ b/modules/r2dreamer/launch/parser.py
@@ -27,8 +27,6 @@ def _build_parser_train() -> argparse.ArgumentParser:
     p.add_argument("--resume_from", type=str, default=None)
     p.add_argument("--wandb_id", type=str, default=None,
                    help="W&B run-id to reattach to (resume='must')")
-    p.add_argument("--wandb_notes_file", type=str, default=None,
-                   help="Optional Markdown/text file copied into W&B run notes")
     p.add_argument("--act_entropy", type=float, default=3e-2,
                    help="Actor entropy coefficient. 3e-2 is the Habitat 4-action ObjectNav "
                         "baseline; the DreamerV3 paper default 3e-4 (tuned for 17-action Crafter) "

--- a/modules/r2dreamer/launch/parser.py
+++ b/modules/r2dreamer/launch/parser.py
@@ -27,6 +27,8 @@ def _build_parser_train() -> argparse.ArgumentParser:
     p.add_argument("--resume_from", type=str, default=None)
     p.add_argument("--wandb_id", type=str, default=None,
                    help="W&B run-id to reattach to (resume='must')")
+    p.add_argument("--wandb_notes_file", type=str, default=None,
+                   help="Optional Markdown/text file copied into W&B run notes")
     p.add_argument("--act_entropy", type=float, default=3e-2,
                    help="Actor entropy coefficient. 3e-2 is the Habitat 4-action ObjectNav "
                         "baseline; the DreamerV3 paper default 3e-4 (tuned for 17-action Crafter) "

--- a/modules/r2dreamer/launch/registries.py
+++ b/modules/r2dreamer/launch/registries.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from typing import Callable
 
-from modules.r2dreamer.launch.encoders import Encoder, CNNEncoder, VGGTEncoder
+from modules.r2dreamer.launch.encoders import (
+    Encoder,
+    CNNEncoder,
+    VGGTEncoder,
+    VGGTAggregatorMLPEncoder,
+)
 from modules.r2dreamer.launch.habitat_setup import make_habitat_env
 
 
@@ -15,6 +20,7 @@ def make_crafter_env(*, seed: int = 0, **kwargs):
 encoder_registry: dict[str, type[Encoder]] = {
     "cnn": CNNEncoder,
     "vggt": VGGTEncoder,
+    "vggt_aggregator_mlp": VGGTAggregatorMLPEncoder,
 }
 
 env_registry: dict[str, Callable] = {

--- a/modules/r2dreamer/launch/tests/test_encoders.py
+++ b/modules/r2dreamer/launch/tests/test_encoders.py
@@ -47,7 +47,7 @@ class TestVGGTEncoderConfiguration:
         constructed_kwargs = {}
 
         class FakeExtractor:
-            aggregator_feature_shape = (37, 37, 1024)
+            aggregator_feature_shape = (1374, 1024)
 
             def __init__(self, **kwargs):
                 constructed_kwargs.update(kwargs)
@@ -71,7 +71,7 @@ class TestVGGTEncoderConfiguration:
 
     def test_vggt_encoder_exposes_wp_cp_spec(self, monkeypatch):
         class FakeExtractor:
-            aggregator_feature_shape = (37, 37, 1024)
+            aggregator_feature_shape = (1374, 1024)
 
             def __init__(self, **kwargs):
                 pass
@@ -92,7 +92,7 @@ class TestVGGTEncoderConfiguration:
 
     def test_aggregator_encoder_spec_uses_extractor_metadata(self, monkeypatch):
         class FakeExtractor:
-            aggregator_feature_shape = (9, 9, 128)
+            aggregator_feature_shape = (86, 128)
 
             def __init__(self, **kwargs):
                 pass
@@ -109,8 +109,8 @@ class TestVGGTEncoderConfiguration:
         adapter = enc.make_adapter()
         spec = enc.spec()
 
-        assert adapter.buffer_shape == (9, 9, 128)
-        assert spec.obs_shape == (9, 9, 128)
+        assert adapter.buffer_shape == (86, 128)
+        assert spec.obs_shape == (86, 128)
         assert spec.env_render_resolution == 256
         assert spec.encoder_type == "vggt_aggregator_mlp"
         assert spec.agent_overrides == {
@@ -119,25 +119,25 @@ class TestVGGTEncoderConfiguration:
             "seq_len": 32,
             "train_ratio": 128,
         }
-        assert "pre-head aggregator" in spec.design_notes
+        assert "all-token" in spec.design_notes
 
     def test_aggregator_adapter_uses_float16_replay_and_float32_agent(self):
         class FakeExtractor:
-            aggregator_feature_shape = (2, 2, 4)
+            aggregator_feature_shape = (6, 4)
 
             def reset(self):
                 pass
 
             def extract(self, image):
                 import jax.numpy as jnp
-                return {"aggregator_features": jnp.ones((2, 2, 4), dtype=jnp.float32)}
+                return {"aggregator_features": jnp.ones((6, 4), dtype=jnp.float32)}
 
         adapter = VGGTObsAdapter(FakeExtractor(), feature_kind="aggregator")
         replay_features, agent_obs = adapter.transform({"image": np.zeros((3, 4, 4), dtype=np.uint8)})
 
-        assert replay_features.shape == (2, 2, 4)
+        assert replay_features.shape == (6, 4)
         assert replay_features.dtype == np.float16
-        assert agent_obs["features"].shape == (2, 2, 4)
+        assert agent_obs["features"].shape == (6, 4)
         assert agent_obs["features"].dtype.name == "float32"
 
 

--- a/modules/r2dreamer/launch/tests/test_encoders.py
+++ b/modules/r2dreamer/launch/tests/test_encoders.py
@@ -6,7 +6,12 @@ import numpy as np
 import pytest
 
 from modules.r2dreamer.adapters import ObsAdapter, VGGTObsAdapter
-from modules.r2dreamer.launch.encoders import CNNEncoder, VGGTEncoder
+from modules.r2dreamer.launch.encoders import (
+    CNNEncoder,
+    EncoderSpec,
+    VGGTEncoder,
+    VGGTAggregatorMLPEncoder,
+)
 
 
 _FIXTURES = Path(__file__).parent / "fixtures"
@@ -17,6 +22,14 @@ class TestCNNEncoder:
         enc = CNNEncoder()
         adapter = enc.make_adapter()
         assert isinstance(adapter, ObsAdapter)
+
+    def test_cnn_encoder_exposes_spec(self):
+        spec = CNNEncoder().spec()
+        assert isinstance(spec, EncoderSpec)
+        assert spec.encoder_type == "cnn"
+        assert spec.obs_shape == (3, 64, 64)
+        assert spec.env_render_resolution == 64
+        assert spec.agent_overrides == {}
 
     def test_cnn_adapter_passthrough(self):
         adapter = CNNEncoder().make_adapter()
@@ -34,6 +47,8 @@ class TestVGGTEncoderConfiguration:
         constructed_kwargs = {}
 
         class FakeExtractor:
+            aggregator_feature_shape = (37, 37, 1024)
+
             def __init__(self, **kwargs):
                 constructed_kwargs.update(kwargs)
 
@@ -53,6 +68,77 @@ class TestVGGTEncoderConfiguration:
             "total_budget": 200_000,
             "budgets_static": tuple([8333] * 24),
         }
+
+    def test_vggt_encoder_exposes_wp_cp_spec(self, monkeypatch):
+        class FakeExtractor:
+            aggregator_feature_shape = (37, 37, 1024)
+
+            def __init__(self, **kwargs):
+                pass
+
+            def reset(self):
+                pass
+
+        monkeypatch.setattr(
+            "modules.r2dreamer.launch.encoders.VGGTFeatureExtractor",
+            FakeExtractor,
+        )
+
+        spec = VGGTEncoder(resolution=518).spec()
+        assert spec.encoder_type == "vggt"
+        assert spec.obs_shape == (4116,)
+        assert spec.env_render_resolution == 518
+        assert spec.agent_overrides == {"buffer_capacity": 1_000_000}
+
+    def test_aggregator_encoder_spec_uses_extractor_metadata(self, monkeypatch):
+        class FakeExtractor:
+            aggregator_feature_shape = (9, 9, 128)
+
+            def __init__(self, **kwargs):
+                pass
+
+            def reset(self):
+                pass
+
+        monkeypatch.setattr(
+            "modules.r2dreamer.launch.encoders.VGGTFeatureExtractor",
+            FakeExtractor,
+        )
+
+        enc = VGGTAggregatorMLPEncoder(resolution=256)
+        adapter = enc.make_adapter()
+        spec = enc.spec()
+
+        assert adapter.buffer_shape == (9, 9, 128)
+        assert spec.obs_shape == (9, 9, 128)
+        assert spec.env_render_resolution == 256
+        assert spec.encoder_type == "vggt_aggregator_mlp"
+        assert spec.agent_overrides == {
+            "buffer_capacity": 5_000,
+            "batch_size": 4,
+            "seq_len": 32,
+            "train_ratio": 128,
+        }
+        assert "pre-head aggregator" in spec.design_notes
+
+    def test_aggregator_adapter_uses_float16_replay_and_float32_agent(self):
+        class FakeExtractor:
+            aggregator_feature_shape = (2, 2, 4)
+
+            def reset(self):
+                pass
+
+            def extract(self, image):
+                import jax.numpy as jnp
+                return {"aggregator_features": jnp.ones((2, 2, 4), dtype=jnp.float32)}
+
+        adapter = VGGTObsAdapter(FakeExtractor(), feature_kind="aggregator")
+        replay_features, agent_obs = adapter.transform({"image": np.zeros((3, 4, 4), dtype=np.uint8)})
+
+        assert replay_features.shape == (2, 2, 4)
+        assert replay_features.dtype == np.float16
+        assert agent_obs["features"].shape == (2, 2, 4)
+        assert agent_obs["features"].dtype.name == "float32"
 
 
 @pytest.mark.gpu

--- a/modules/r2dreamer/launch/tests/test_encoders.py
+++ b/modules/r2dreamer/launch/tests/test_encoders.py
@@ -90,7 +90,7 @@ class TestVGGTEncoderConfiguration:
         assert spec.env_render_resolution == 518
         assert spec.agent_overrides == {"buffer_capacity": 1_000_000}
 
-    def test_aggregator_encoder_spec_uses_extractor_metadata(self, monkeypatch):
+    def test_aggregator_encoder_spec_uses_pooled_extractor_feature_dim(self, monkeypatch):
         class FakeExtractor:
             aggregator_feature_shape = (86, 128)
 
@@ -109,8 +109,9 @@ class TestVGGTEncoderConfiguration:
         adapter = enc.make_adapter()
         spec = enc.spec()
 
-        assert adapter.buffer_shape == (86, 128)
-        assert spec.obs_shape == (86, 128)
+        assert adapter.buffer_shape == (128,)
+        assert adapter.buffer_dtype == "float32"
+        assert spec.obs_shape == (128,)
         assert spec.env_render_resolution == 256
         assert spec.encoder_type == "vggt_aggregator_mlp"
         assert spec.agent_overrides == {
@@ -119,9 +120,9 @@ class TestVGGTEncoderConfiguration:
             "seq_len": 32,
             "train_ratio": 128,
         }
-        assert "all-token" in spec.design_notes
+        assert "mean-pooled" in spec.design_notes
 
-    def test_aggregator_adapter_uses_float16_replay_and_float32_agent(self):
+    def test_aggregator_adapter_mean_pools_tokens_to_float32_replay_and_agent(self):
         class FakeExtractor:
             aggregator_feature_shape = (6, 4)
 
@@ -130,14 +131,16 @@ class TestVGGTEncoderConfiguration:
 
             def extract(self, image):
                 import jax.numpy as jnp
-                return {"aggregator_features": jnp.ones((6, 4), dtype=jnp.float32)}
+                return {"aggregator_features": jnp.arange(24, dtype=jnp.float32).reshape(6, 4)}
 
         adapter = VGGTObsAdapter(FakeExtractor(), feature_kind="aggregator")
         replay_features, agent_obs = adapter.transform({"image": np.zeros((3, 4, 4), dtype=np.uint8)})
 
-        assert replay_features.shape == (6, 4)
-        assert replay_features.dtype == np.float16
-        assert agent_obs["features"].shape == (6, 4)
+        expected = np.arange(24, dtype=np.float32).reshape(6, 4).mean(axis=0)
+        assert replay_features.shape == (4,)
+        assert replay_features.dtype == np.float32
+        np.testing.assert_allclose(replay_features, expected)
+        assert agent_obs["features"].shape == (4,)
         assert agent_obs["features"].dtype.name == "float32"
 
 

--- a/modules/r2dreamer/launch/tests/test_parser.py
+++ b/modules/r2dreamer/launch/tests/test_parser.py
@@ -1,0 +1,11 @@
+"""Parser behavior tests for r2dreamer train launch flags."""
+
+from modules.r2dreamer.launch.parser import _build_parser_train
+
+
+def test_train_parser_does_not_expose_wandb_notes_file():
+    parser = _build_parser_train()
+    args = parser.parse_args([])
+
+    assert not hasattr(args, "wandb_notes_file")
+    assert "--wandb_notes_file" not in parser.format_help()

--- a/modules/r2dreamer/launch/tests/test_registries.py
+++ b/modules/r2dreamer/launch/tests/test_registries.py
@@ -26,6 +26,7 @@ class TestEncoderRegistry:
     def test_known_keys_present(self):
         assert "cnn" in encoder_registry
         assert "vggt" in encoder_registry
+        assert "vggt_aggregator_mlp" in encoder_registry
 
 
 class TestEnvRegistry:

--- a/modules/r2dreamer/launch/train.py
+++ b/modules/r2dreamer/launch/train.py
@@ -98,6 +98,23 @@ def train(
         num_actions = 17
 
     # --- Build agent config ---
+    agent_overrides = dict(encoder_spec.agent_overrides)
+    # Diagnostic CLI overrides (None => keep config default / encoder override).
+    if args.actor_loss_weight is not None:
+        agent_overrides["scale_policy"] = args.actor_loss_weight
+    if args.value_loss_weight is not None:
+        agent_overrides["scale_value"] = args.value_loss_weight
+    if args.repval_loss_weight is not None:
+        agent_overrides["scale_repval"] = args.repval_loss_weight
+    if args.barlow_grad_to_encoder:
+        agent_overrides["barlow_stop_grad"] = False
+    if args.batch_size is not None:
+        agent_overrides["batch_size"] = args.batch_size
+    if args.seq_len is not None:
+        agent_overrides["seq_len"] = args.seq_len
+    if args.lr is not None:
+        agent_overrides["lr"] = args.lr
+
     agent_config = R2DreamerConfig(
         encoder_type=encoder_spec.encoder_type,
         obs_shape=encoder_spec.obs_shape,
@@ -109,7 +126,7 @@ def train(
         log_every=args.log_every,
         logdir=eff_output_dir,
         design_notes=encoder_spec.design_notes,
-        **encoder_spec.agent_overrides,
+        **agent_overrides,
     )
 
     # --- Build agent ---
@@ -131,6 +148,10 @@ def train(
         val_data=args.val_data,
         val_loss_every=args.val_loss_every,
         resume_from=args.resume_from,
+        overfit_one_batch=args.overfit_one_batch,
+        overfit_steps=args.overfit_steps,
+        overfit_batch_size=args.overfit_batch_size,
+        overfit_seq_len=args.overfit_seq_len,
     )
 
     # --- Build trainer ---

--- a/modules/r2dreamer/launch/train.py
+++ b/modules/r2dreamer/launch/train.py
@@ -34,7 +34,7 @@ def train(
     from modules.r2dreamer.launch.curricula import CURRICULA
     from modules.r2dreamer.agent import R2DreamerAgent
     from modules.r2dreamer.config import R2DreamerConfig
-    from modules.r2dreamer.adapters import VGGT_FEATURE_DIM
+    from modules.r2dreamer.adapters import VGGT_FEATURE_DIM, VGGT_AGGREGATOR_FEATURE_SHAPE
     from modules.r2dreamer.trainer import Trainer, TrainerConfig, habitat_defaults
 
     parser = _build_parser_train()
@@ -69,7 +69,7 @@ def train(
         raise KeyError(f"Unknown encoder {encoder!r}. Available: {list(encoder_registry)}")
 
     encoder_cls = encoder_registry[encoder]
-    if encoder == "vggt":
+    if encoder in ("vggt", "vggt_aggregator_mlp"):
         enc = encoder_cls(resolution=args.render_resolution)
     else:
         enc = encoder_cls()
@@ -95,12 +95,17 @@ def train(
             curriculum_path=curriculum_path,
             curriculum_mode=args.curriculum_mode,
             seed=args.seed,
-            render_resolution=args.render_resolution if encoder == "vggt" else 64,
+            render_resolution=args.render_resolution if encoder in ("vggt", "vggt_aggregator_mlp") else 64,
         )
     else:
         # crafter
         env_instance = env_fn(seed=args.seed)
 
+    design_notes = (
+        "Variant 1 encoder: VGGT final pre-head aggregator global patch features "
+        "(37x37x1024) -> 1x1 Conv 1024->64 -> flatten 87616 -> "
+        "2-layer MLP 87616->1024->1024; excludes VGGT world-points and camera-pose heads."
+    )
     # --- Build agent config ---
     if encoder == "vggt":
         agent_config = R2DreamerConfig(
@@ -114,6 +119,23 @@ def train(
             seed=args.seed,
             log_every=args.log_every,
             logdir=eff_output_dir,
+        )
+    elif encoder == "vggt_aggregator_mlp":
+        agent_config = R2DreamerConfig(
+            encoder_type="vggt_aggregator_mlp",
+            obs_shape=VGGT_AGGREGATOR_FEATURE_SHAPE,
+            num_actions=4,
+            total_steps=args.steps,
+            prefill_steps=args.prefill,
+            buffer_capacity=5_000,
+            batch_size=4,
+            seq_len=32,
+            train_ratio=128,
+            act_entropy=args.act_entropy,
+            seed=args.seed,
+            log_every=args.log_every,
+            logdir=eff_output_dir,
+            design_notes=design_notes,
         )
     elif env == "habitat":
         agent_config = R2DreamerConfig(
@@ -155,6 +177,7 @@ def train(
         wandb_name=eff_wandb_name,
         wandb_tags=eff_wandb_tags,
         wandb_id=args.wandb_id,
+        wandb_notes_file=args.wandb_notes_file,
         val_data=args.val_data,
         val_loss_every=args.val_loss_every,
         resume_from=args.resume_from,

--- a/modules/r2dreamer/launch/train.py
+++ b/modules/r2dreamer/launch/train.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import sys
 from typing import TYPE_CHECKING
 
@@ -29,12 +28,11 @@ def train(
     """
     import jax
 
-    from modules.r2dreamer.launch.parser import _build_parser_train
-    from modules.r2dreamer.launch.registries import env_registry, encoder_registry
-    from modules.r2dreamer.launch.curricula import CURRICULA
     from modules.r2dreamer.agent import R2DreamerAgent
     from modules.r2dreamer.config import R2DreamerConfig
-    from modules.r2dreamer.adapters import VGGT_FEATURE_DIM, VGGT_AGGREGATOR_FEATURE_SHAPE
+    from modules.r2dreamer.launch.curricula import CURRICULA
+    from modules.r2dreamer.launch.parser import _build_parser_train
+    from modules.r2dreamer.launch.registries import env_registry, encoder_registry
     from modules.r2dreamer.trainer import Trainer, TrainerConfig, habitat_defaults
 
     parser = _build_parser_train()
@@ -47,7 +45,6 @@ def train(
     # --- Resolve curriculum path ---
     # CLI --curriculum_path is the escape hatch; otherwise use registry lookup.
     if args.curriculum_path is not None:
-        # explicit CLI override
         curriculum_path = args.curriculum_path
     elif curriculum is not None:
         if curriculum not in CURRICULA:
@@ -64,16 +61,14 @@ def train(
     if env == "crafter" and curriculum_path is not None:
         raise ValueError("Crafter env does not use a curriculum.")
 
-    # --- Resolve encoder ---
+    # --- Resolve encoder and its observation spec ---
     if encoder not in encoder_registry:
         raise KeyError(f"Unknown encoder {encoder!r}. Available: {list(encoder_registry)}")
 
     encoder_cls = encoder_registry[encoder]
-    if encoder in ("vggt", "vggt_aggregator_mlp"):
-        enc = encoder_cls(resolution=args.render_resolution)
-    else:
-        enc = encoder_cls()
+    enc = encoder_cls.from_train_args(args)
     adapter = enc.make_adapter()
+    encoder_spec = enc.spec()
 
     # --- Resolve effective output_dir / wandb_name / wandb_tags ---
     # CLI value (non-None) wins over shim kwarg.
@@ -95,71 +90,27 @@ def train(
             curriculum_path=curriculum_path,
             curriculum_mode=args.curriculum_mode,
             seed=args.seed,
-            render_resolution=args.render_resolution if encoder in ("vggt", "vggt_aggregator_mlp") else 64,
+            render_resolution=encoder_spec.env_render_resolution,
         )
+        num_actions = 4
     else:
-        # crafter
         env_instance = env_fn(seed=args.seed)
+        num_actions = 17
 
-    design_notes = (
-        "Variant 1 encoder: VGGT final pre-head aggregator global patch features "
-        "(37x37x1024) -> 1x1 Conv 1024->64 -> flatten 87616 -> "
-        "2-layer MLP 87616->1024->1024; excludes VGGT world-points and camera-pose heads."
-    )
     # --- Build agent config ---
-    if encoder == "vggt":
-        agent_config = R2DreamerConfig(
-            encoder_type="vggt",
-            obs_shape=(VGGT_FEATURE_DIM,),
-            num_actions=4,
-            total_steps=args.steps,
-            prefill_steps=args.prefill,
-            buffer_capacity=1_000_000,
-            act_entropy=args.act_entropy,
-            seed=args.seed,
-            log_every=args.log_every,
-            logdir=eff_output_dir,
-        )
-    elif encoder == "vggt_aggregator_mlp":
-        agent_config = R2DreamerConfig(
-            encoder_type="vggt_aggregator_mlp",
-            obs_shape=VGGT_AGGREGATOR_FEATURE_SHAPE,
-            num_actions=4,
-            total_steps=args.steps,
-            prefill_steps=args.prefill,
-            buffer_capacity=5_000,
-            batch_size=4,
-            seq_len=32,
-            train_ratio=128,
-            act_entropy=args.act_entropy,
-            seed=args.seed,
-            log_every=args.log_every,
-            logdir=eff_output_dir,
-            design_notes=design_notes,
-        )
-    elif env == "habitat":
-        agent_config = R2DreamerConfig(
-            obs_shape=(3, 64, 64),
-            num_actions=4,
-            total_steps=args.steps,
-            prefill_steps=args.prefill,
-            buffer_capacity=1_000_000,
-            act_entropy=args.act_entropy,
-            seed=args.seed,
-            log_every=args.log_every,
-            logdir=eff_output_dir,
-        )
-    else:
-        # crafter
-        agent_config = R2DreamerConfig(
-            obs_shape=(3, 64, 64),
-            num_actions=17,
-            total_steps=args.steps,
-            prefill_steps=args.prefill,
-            seed=args.seed,
-            log_every=args.log_every,
-            logdir=eff_output_dir,
-        )
+    agent_config = R2DreamerConfig(
+        encoder_type=encoder_spec.encoder_type,
+        obs_shape=encoder_spec.obs_shape,
+        num_actions=num_actions,
+        total_steps=args.steps,
+        prefill_steps=args.prefill,
+        act_entropy=args.act_entropy,
+        seed=args.seed,
+        log_every=args.log_every,
+        logdir=eff_output_dir,
+        design_notes=encoder_spec.design_notes,
+        **encoder_spec.agent_overrides,
+    )
 
     # --- Build agent ---
     _rng_key, init_key = jax.random.split(jax.random.PRNGKey(args.seed))
@@ -177,7 +128,6 @@ def train(
         wandb_name=eff_wandb_name,
         wandb_tags=eff_wandb_tags,
         wandb_id=args.wandb_id,
-        wandb_notes_file=args.wandb_notes_file,
         val_data=args.val_data,
         val_loss_every=args.val_loss_every,
         resume_from=args.resume_from,

--- a/modules/r2dreamer/networks.py
+++ b/modules/r2dreamer/networks.py
@@ -455,10 +455,11 @@ class VGGTEncoder(nn.Module):
 
 
 class VGGTAggregatorMLPEncoder(nn.Module):
-    """Variant 1 encoder for pre-head VGGT aggregator patch features.
+    """Variant 1 encoder for all pre-head VGGT aggregator tokens.
 
-    Architecture: (B, 37, 37, 1024) -> 1x1 Conv(64) -> flatten
-    -> Dense(1024) -> Dense(embed_dim). Hidden transforms use RMSNorm+SiLU.
+    Architecture follows the paper-style VGGT-DP/VGGT-World token path:
+    (B, N, D) all tokens, including camera/register special tokens and patch
+    tokens -> tokenwise linear projection -> mean pool over tokens.
     """
     embed_dim: int = 1024
     channels: int = 64
@@ -466,17 +467,11 @@ class VGGTAggregatorMLPEncoder(nn.Module):
 
     @nn.compact
     def __call__(self, obs):
-        # obs: (B, 37, 37, 1024) float32 pre-head aggregator features.
-        if obs.ndim != 4:
-            raise ValueError(f"expected (B, 37, 37, 1024), got {obs.shape}")
-        x = nn.Conv(self.channels, (1, 1), padding="VALID", name="conv1x1")(obs)
-        x = RMSNorm(name="conv_norm")(x)
-        x = nn.silu(x)
-        x = x.reshape(x.shape[0], -1)
-        x = nn.Dense(self.hidden, name="fc0")(x)
-        x = RMSNorm(name="fc0_norm")(x)
-        x = nn.silu(x)
-        return nn.Dense(self.embed_dim, name="fc1")(x)
+        # obs: (B, N, D) float32 all-token pre-head aggregator features.
+        if obs.ndim != 3:
+            raise ValueError(f"expected (B, N, D) all-token VGGT features, got {obs.shape}")
+        tokens = nn.Dense(self.embed_dim, name="proj")(obs)
+        return tokens.mean(axis=1)
 
 
 class Projector(nn.Module):

--- a/modules/r2dreamer/networks.py
+++ b/modules/r2dreamer/networks.py
@@ -455,11 +455,12 @@ class VGGTEncoder(nn.Module):
 
 
 class VGGTAggregatorMLPEncoder(nn.Module):
-    """Variant 1 encoder for all pre-head VGGT aggregator tokens.
+    """Variant 1 encoder for VGGT aggregator features.
 
-    Architecture follows the paper-style VGGT-DP/VGGT-World token path:
-    (B, N, D) all tokens, including camera/register special tokens and patch
-    tokens -> tokenwise linear projection -> mean pool over tokens.
+    The fast training path stores mean-pooled pre-head aggregator features in
+    replay as ``(B, D)`` and projects them to ``embed_dim``.  The module still
+    accepts the legacy ``(B, N, D)`` all-token shape for tests/debugging by
+    applying the same Dense layer tokenwise and then mean-pooling tokens.
     """
     embed_dim: int = 1024
     channels: int = 64
@@ -467,11 +468,14 @@ class VGGTAggregatorMLPEncoder(nn.Module):
 
     @nn.compact
     def __call__(self, obs):
-        # obs: (B, N, D) float32 all-token pre-head aggregator features.
-        if obs.ndim != 3:
-            raise ValueError(f"expected (B, N, D) all-token VGGT features, got {obs.shape}")
-        tokens = nn.Dense(self.embed_dim, name="proj")(obs)
-        return tokens.mean(axis=1)
+        # obs: (B, D) mean-pooled features in the training path, or legacy
+        # (B, N, D) all-token features for isolated token-path checks.
+        if obs.ndim == 2:
+            return nn.Dense(self.embed_dim, name="proj")(obs)
+        if obs.ndim == 3:
+            tokens = nn.Dense(self.embed_dim, name="proj")(obs)
+            return tokens.mean(axis=1)
+        raise ValueError(f"expected (B, D) or (B, N, D) VGGT features, got {obs.shape}")
 
 
 class Projector(nn.Module):

--- a/modules/r2dreamer/networks.py
+++ b/modules/r2dreamer/networks.py
@@ -454,6 +454,31 @@ class VGGTEncoder(nn.Module):
         return out
 
 
+class VGGTAggregatorMLPEncoder(nn.Module):
+    """Variant 1 encoder for pre-head VGGT aggregator patch features.
+
+    Architecture: (B, 37, 37, 1024) -> 1x1 Conv(64) -> flatten
+    -> Dense(1024) -> Dense(embed_dim). Hidden transforms use RMSNorm+SiLU.
+    """
+    embed_dim: int = 1024
+    channels: int = 64
+    hidden: int = 1024
+
+    @nn.compact
+    def __call__(self, obs):
+        # obs: (B, 37, 37, 1024) float32 pre-head aggregator features.
+        if obs.ndim != 4:
+            raise ValueError(f"expected (B, 37, 37, 1024), got {obs.shape}")
+        x = nn.Conv(self.channels, (1, 1), padding="VALID", name="conv1x1")(obs)
+        x = RMSNorm(name="conv_norm")(x)
+        x = nn.silu(x)
+        x = x.reshape(x.shape[0], -1)
+        x = nn.Dense(self.hidden, name="fc0")(x)
+        x = RMSNorm(name="fc0_norm")(x)
+        x = nn.silu(x)
+        return nn.Dense(self.embed_dim, name="fc1")(x)
+
+
 class Projector(nn.Module):
     """Single linear projection without bias (maps feat_size -> embed_dim)."""
     out_dim: int

--- a/modules/r2dreamer/scripts/run_jax_habitat_vggt_aggregator_mlp.py
+++ b/modules/r2dreamer/scripts/run_jax_habitat_vggt_aggregator_mlp.py
@@ -1,0 +1,27 @@
+"""L1 Variant 1 shim — habitat + VGGT aggregator MLP encoder."""
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")))
+
+from modules.r2dreamer.launch.train import train
+
+if __name__ == "__main__":
+    train(
+        env="habitat",
+        encoder="vggt_aggregator_mlp",
+        curriculum="L1",
+        output_dir="output/runs/r2dreamer-curriculum-l1-vggt-aggregator-mlp",
+        wandb_name="variant-1-aggregator-mlp",
+        wandb_tags=[
+            "curriculum",
+            "level1",
+            "1house",
+            "chair-only",
+            "vggt",
+            "aggregator-mlp",
+            "variant-1",
+            "jax",
+            "3d-encoder",
+        ],
+    )

--- a/modules/r2dreamer/scripts/slurm/train_curriculum_l1_vggt_aggregator_mlp_2m.sbatch
+++ b/modules/r2dreamer/scripts/slurm/train_curriculum_l1_vggt_aggregator_mlp_2m.sbatch
@@ -34,5 +34,4 @@ uv run --python 3.11 python modules/r2dreamer/scripts/run_jax_habitat_vggt_aggre
     --wandb_project 3d-vla-objectnav \
     --wandb_name "variant-1-aggregator-mlp-${SLURM_JOB_ID}" \
     --wandb_tags "curriculum,level1,1house,chair-only,vggt,aggregator-mlp,variant-1,jax,3d-encoder" \
-    --wandb_notes_file LEARNING.md \
     --render_resolution 518

--- a/modules/r2dreamer/scripts/slurm/train_curriculum_l1_vggt_aggregator_mlp_2m.sbatch
+++ b/modules/r2dreamer/scripts/slurm/train_curriculum_l1_vggt_aggregator_mlp_2m.sbatch
@@ -1,0 +1,38 @@
+#!/bin/bash
+#SBATCH --job-name=vggt_agg_mlp
+#SBATCH --partition=gpu_h100
+#SBATCH --gres=gpu:1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=64G
+#SBATCH --time=48:00:00
+#SBATCH --output=output/r2dreamer-curriculum-l1-vggt-aggregator-mlp/slurm-%j.out
+#SBATCH --error=output/r2dreamer-curriculum-l1-vggt-aggregator-mlp/slurm-%j.err
+
+set -euo pipefail
+
+mkdir -p output/r2dreamer-curriculum-l1-vggt-aggregator-mlp
+
+echo "Job $SLURM_JOB_ID on $(hostname) at $(date)"
+echo "GPU: $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || echo 'N/A')"
+echo "Git commit: $(git rev-parse HEAD)"
+echo "Git branch: $(git branch --show-current)"
+
+# Generate curriculum configs if not present
+if [ ! -f data/curriculum/level1_1house_1goal.json ]; then
+    echo "Generating curriculum configs..."
+    uv run --python 3.11 python modules/envs/scripts/generate_curriculum.py
+fi
+
+uv run --python 3.11 python modules/r2dreamer/scripts/run_jax_habitat_vggt_aggregator_mlp.py \
+    --steps 2000000 \
+    --prefill 5000 \
+    --checkpoint_every 100000 \
+    --output_dir "output/r2dreamer-curriculum-l1-vggt-aggregator-mlp/run-${SLURM_JOB_ID}" \
+    --seed "${SLURM_JOB_ID}" \
+    --log_every 250 \
+    --wandb_project 3d-vla-objectnav \
+    --wandb_name "variant-1-aggregator-mlp-${SLURM_JOB_ID}" \
+    --wandb_tags "curriculum,level1,1house,chair-only,vggt,aggregator-mlp,variant-1,jax,3d-encoder" \
+    --wandb_notes_file LEARNING.md \
+    --render_resolution 518

--- a/modules/r2dreamer/tests/test_vggt_encoder.py
+++ b/modules/r2dreamer/tests/test_vggt_encoder.py
@@ -6,11 +6,33 @@ import numpy as np
 import pytest
 
 from modules.r2dreamer.config import R2DreamerConfig
-from modules.r2dreamer.networks import VGGTEncoder
+from modules.r2dreamer.networks import VGGTEncoder, VGGTAggregatorMLPEncoder
 from modules.shared.replay_buffer import VGGTReplayBuffer
 
 
 FEATURE_DIM = 4116  # 37*37*3 + 9
+AGGREGATOR_SHAPE = (37, 37, 1024)
+
+
+class TestVGGTAggregatorMLPEncoder:
+    """Test Variant 1 aggregator-token encoder."""
+
+    def test_output_shape(self):
+        enc = VGGTAggregatorMLPEncoder(embed_dim=1024)
+        rng = jax.random.PRNGKey(0)
+        dummy = jnp.zeros((2, *AGGREGATOR_SHAPE))
+        params = enc.init(rng, dummy)
+        out = enc.apply(params, dummy)
+        assert out.shape == (2, 1024)
+        assert jnp.isfinite(out).all()
+
+    def test_custom_dims(self):
+        enc = VGGTAggregatorMLPEncoder(embed_dim=512, channels=8, hidden=128)
+        rng = jax.random.PRNGKey(0)
+        dummy = jnp.ones((1, *AGGREGATOR_SHAPE), dtype=jnp.float32)
+        params = enc.init(rng, dummy)
+        out = enc.apply(params, dummy)
+        assert out.shape == (1, 512)
 
 
 class TestVGGTEncoder:
@@ -113,6 +135,27 @@ class TestVGGTAgentInit:
 
         obs_dict = {
             "features": np.random.randn(FEATURE_DIM).astype(np.float32),
+            "is_first": True,
+        }
+        rng, act_key = jax.random.split(rng)
+        action = agent.act(obs_dict, act_key)
+        assert 0 <= action < 4
+
+    def test_agent_act_vggt_aggregator_mlp(self):
+        from modules.r2dreamer.agent import R2DreamerAgent
+
+        cfg = R2DreamerConfig(
+            encoder_type="vggt_aggregator_mlp",
+            obs_shape=AGGREGATOR_SHAPE,
+            num_actions=4,
+            vggt_aggregator_channels=8,
+            vggt_aggregator_hidden=128,
+        )
+        rng = jax.random.PRNGKey(42)
+        agent = R2DreamerAgent(cfg, rng)
+
+        obs_dict = {
+            "features": np.random.randn(*AGGREGATOR_SHAPE).astype(np.float32),
             "is_first": True,
         }
         rng, act_key = jax.random.split(rng)

--- a/modules/r2dreamer/tests/test_vggt_encoder.py
+++ b/modules/r2dreamer/tests/test_vggt_encoder.py
@@ -11,28 +11,38 @@ from modules.shared.replay_buffer import VGGTReplayBuffer
 
 
 FEATURE_DIM = 4116  # 37*37*3 + 9
-AGGREGATOR_SHAPE = (37, 37, 1024)
+AGGREGATOR_TOKEN_SHAPE = (1374, 1024)  # 5 special tokens + 37*37 patch tokens
 
 
 class TestVGGTAggregatorMLPEncoder:
-    """Test Variant 1 aggregator-token encoder."""
+    """Test Variant 1 all-token VGGT aggregator encoder."""
 
     def test_output_shape(self):
         enc = VGGTAggregatorMLPEncoder(embed_dim=1024)
         rng = jax.random.PRNGKey(0)
-        dummy = jnp.zeros((2, *AGGREGATOR_SHAPE))
+        dummy = jnp.zeros((2, *AGGREGATOR_TOKEN_SHAPE))
         params = enc.init(rng, dummy)
         out = enc.apply(params, dummy)
         assert out.shape == (2, 1024)
         assert jnp.isfinite(out).all()
 
     def test_custom_dims(self):
-        enc = VGGTAggregatorMLPEncoder(embed_dim=512, channels=8, hidden=128)
+        enc = VGGTAggregatorMLPEncoder(embed_dim=512)
         rng = jax.random.PRNGKey(0)
-        dummy = jnp.ones((1, *AGGREGATOR_SHAPE), dtype=jnp.float32)
+        dummy = jnp.ones((1, *AGGREGATOR_TOKEN_SHAPE), dtype=jnp.float32)
         params = enc.init(rng, dummy)
         out = enc.apply(params, dummy)
         assert out.shape == (1, 512)
+
+    def test_uses_all_tokens_not_spatial_cnn_params(self):
+        enc = VGGTAggregatorMLPEncoder(embed_dim=32)
+        rng = jax.random.PRNGKey(0)
+        dummy = jnp.arange(2 * 6 * 8, dtype=jnp.float32).reshape(2, 6, 8)
+        params = enc.init(rng, dummy)
+        out = enc.apply(params, dummy)
+
+        assert out.shape == (2, 32)
+        assert set(params["params"].keys()) == {"proj"}
 
 
 class TestVGGTEncoder:
@@ -146,16 +156,14 @@ class TestVGGTAgentInit:
 
         cfg = R2DreamerConfig(
             encoder_type="vggt_aggregator_mlp",
-            obs_shape=AGGREGATOR_SHAPE,
+            obs_shape=AGGREGATOR_TOKEN_SHAPE,
             num_actions=4,
-            vggt_aggregator_channels=8,
-            vggt_aggregator_hidden=128,
         )
         rng = jax.random.PRNGKey(42)
         agent = R2DreamerAgent(cfg, rng)
 
         obs_dict = {
-            "features": np.random.randn(*AGGREGATOR_SHAPE).astype(np.float32),
+            "features": np.random.randn(*AGGREGATOR_TOKEN_SHAPE).astype(np.float32),
             "is_first": True,
         }
         rng, act_key = jax.random.split(rng)

--- a/modules/r2dreamer/tests/test_vggt_encoder.py
+++ b/modules/r2dreamer/tests/test_vggt_encoder.py
@@ -34,6 +34,14 @@ class TestVGGTAggregatorMLPEncoder:
         out = enc.apply(params, dummy)
         assert out.shape == (1, 512)
 
+    def test_pooled_feature_input_shape(self):
+        enc = VGGTAggregatorMLPEncoder(embed_dim=512)
+        rng = jax.random.PRNGKey(0)
+        dummy = jnp.ones((3, 1024), dtype=jnp.float32)
+        params = enc.init(rng, dummy)
+        out = enc.apply(params, dummy)
+        assert out.shape == (3, 512)
+
     def test_uses_all_tokens_not_spatial_cnn_params(self):
         enc = VGGTAggregatorMLPEncoder(embed_dim=32)
         rng = jax.random.PRNGKey(0)
@@ -156,14 +164,14 @@ class TestVGGTAgentInit:
 
         cfg = R2DreamerConfig(
             encoder_type="vggt_aggregator_mlp",
-            obs_shape=AGGREGATOR_TOKEN_SHAPE,
+            obs_shape=(1024,),
             num_actions=4,
         )
         rng = jax.random.PRNGKey(42)
         agent = R2DreamerAgent(cfg, rng)
 
         obs_dict = {
-            "features": np.random.randn(*AGGREGATOR_TOKEN_SHAPE).astype(np.float32),
+            "features": np.random.randn(1024).astype(np.float32),
             "is_first": True,
         }
         rng, act_key = jax.random.split(rng)
@@ -187,6 +195,37 @@ class TestVGGTAgentInit:
         B, T = cfg.batch_size, cfg.seq_len
         batch = {
             "obs": jnp.zeros((B, T, FEATURE_DIM)),
+            "actions": jax.nn.one_hot(
+                jnp.zeros((B, T), dtype=jnp.int32), cfg.num_actions
+            ),
+            "rewards": jnp.zeros((B, T)),
+            "is_first": jnp.zeros((B, T)).at[:, 0].set(1.0),
+            "is_last": jnp.zeros((B, T)),
+            "is_terminal": jnp.zeros((B, T)),
+        }
+        rng, train_key = jax.random.split(rng)
+        metrics = agent.train_step(batch, train_key)
+        assert "total_loss" in metrics
+        assert np.isfinite(metrics["total_loss"])
+
+    def test_agent_train_step_vggt_aggregator_mlp(self):
+        from modules.r2dreamer.agent import R2DreamerAgent
+
+        pooled_dim = 1024
+        cfg = R2DreamerConfig(
+            encoder_type="vggt_aggregator_mlp",
+            obs_shape=(pooled_dim,),
+            num_actions=4,
+            batch_size=2,
+            seq_len=8,
+            imagination_horizon=3,
+        )
+        rng = jax.random.PRNGKey(42)
+        agent = R2DreamerAgent(cfg, rng)
+
+        B, T = cfg.batch_size, cfg.seq_len
+        batch = {
+            "obs": jnp.zeros((B, T, pooled_dim)),
             "actions": jax.nn.one_hot(
                 jnp.zeros((B, T), dtype=jnp.int32), cfg.num_actions
             ),

--- a/modules/r2dreamer/trainer.py
+++ b/modules/r2dreamer/trainer.py
@@ -107,6 +107,7 @@ class TrainerConfig:
     wandb_tags: list[str] = field(default_factory=lambda: ["r2dreamer"])
     # Resume an existing W&B run (e.g. "87u0l6dy"). Requires the run to exist.
     wandb_id: str | None = None
+    wandb_notes_file: str | None = None
 
     # Validation (None = disabled)
     val_data: str | None = None
@@ -235,11 +236,19 @@ class Trainer:
         if trainer_config.wandb_project is not None:
             import wandb
             self._wandb = wandb
+            notes = None
+            if trainer_config.wandb_notes_file is not None:
+                notes_path = Path(trainer_config.wandb_notes_file)
+                if notes_path.exists():
+                    notes = notes_path.read_text(encoding="utf-8")
+                else:
+                    print(f"W&B notes file not found: {notes_path}")
             init_kwargs: dict[str, Any] = dict(
                 project=trainer_config.wandb_project,
                 name=trainer_config.wandb_name,
                 config=vars(agent_config) if hasattr(agent_config, "__dict__") else {},
                 tags=trainer_config.wandb_tags,
+                notes=notes,
             )
             if trainer_config.wandb_id is not None:
                 # resume="must" fails loudly if the run-id does not exist,

--- a/modules/r2dreamer/trainer.py
+++ b/modules/r2dreamer/trainer.py
@@ -117,6 +117,16 @@ class TrainerConfig:
     # offsets the train loop to start at the checkpoint's step.
     resume_from: str | None = None
 
+    # --- Karpathy step-3 diagnostic: overfit a single sampled batch ---
+    # When True, the run does the normal prefill, then samples one batch
+    # (overfit_batch_size, overfit_seq_len) once, freezes it, and runs
+    # agent.train_step on that same batch for overfit_steps iterations.
+    # No env rollouts, no validation, no checkpointing.
+    overfit_one_batch: bool = False
+    overfit_steps: int = 1000
+    overfit_batch_size: int = 1
+    overfit_seq_len: int = 8
+
 
 # ---------------------------------------------------------------------------
 # habitat_defaults
@@ -286,7 +296,10 @@ class Trainer:
                     print(f"Resume mode: skipping prefill, jumping to step {self._resume_step}")
                 else:
                     self._prefill(rng_key, writer, f)
-                rng_key = self._train_loop(rng_key, writer, f)
+                if tcfg.overfit_one_batch:
+                    rng_key = self._overfit_loop(rng_key, writer, f)
+                else:
+                    rng_key = self._train_loop(rng_key, writer, f)
 
             save_checkpoint(self.agent, tcfg.total_steps, tcfg.output_dir)
             status = "completed"
@@ -406,6 +419,47 @@ class Trainer:
             # --- Checkpoint ---
             if (step + 1) % tcfg.checkpoint_every == 0:
                 save_checkpoint(self.agent, step + 1, tcfg.output_dir)
+
+        return rng_key
+
+    # ------------------------------------------------------------------
+    # Overfit-one-batch diagnostic loop (Karpathy step 3)
+    # ------------------------------------------------------------------
+
+    def _overfit_loop(self, rng_key: jnp.ndarray, writer: Any, f: Any) -> jnp.ndarray:
+        """Freeze one sampled batch and call train_step on it repeatedly.
+
+        Proves the full stack (encoder -> RSSM -> heads) can memorise a real
+        trajectory. If loss does not drop monotonically, the gradient path is
+        broken — no amount of production wall-clock will save the run.
+
+        Disables env rollouts, validation, and checkpointing.
+        """
+        tcfg = self.tcfg
+
+        if self.buffer.size < tcfg.overfit_batch_size * tcfg.overfit_seq_len:
+            raise RuntimeError(
+                f"overfit_one_batch: buffer too small "
+                f"({self.buffer.size} < {tcfg.overfit_batch_size}*{tcfg.overfit_seq_len}). "
+                f"Increase --prefill."
+            )
+
+        # Sample once, freeze, reuse.
+        batch_raw = self.buffer.sample(tcfg.overfit_batch_size, tcfg.overfit_seq_len)
+        batch = convert_batch(batch_raw, self.acfg.num_actions)
+        print(
+            f"Overfit mode: cached batch "
+            f"B={tcfg.overfit_batch_size} T={tcfg.overfit_seq_len}; "
+            f"running {tcfg.overfit_steps} train_step iterations."
+        )
+
+        self._t0 = time.time()
+        for step in range(tcfg.overfit_steps):
+            rng_key, train_key = jax.random.split(rng_key)
+            metrics = self.agent.train_step(batch, train_key)
+
+            if step % tcfg.log_every == 0 or step == tcfg.overfit_steps - 1:
+                self._log_train_metrics(metrics, step, writer, f)
 
         return rng_key
 

--- a/modules/r2dreamer/trainer.py
+++ b/modules/r2dreamer/trainer.py
@@ -107,7 +107,6 @@ class TrainerConfig:
     wandb_tags: list[str] = field(default_factory=lambda: ["r2dreamer"])
     # Resume an existing W&B run (e.g. "87u0l6dy"). Requires the run to exist.
     wandb_id: str | None = None
-    wandb_notes_file: str | None = None
 
     # Validation (None = disabled)
     val_data: str | None = None
@@ -236,19 +235,11 @@ class Trainer:
         if trainer_config.wandb_project is not None:
             import wandb
             self._wandb = wandb
-            notes = None
-            if trainer_config.wandb_notes_file is not None:
-                notes_path = Path(trainer_config.wandb_notes_file)
-                if notes_path.exists():
-                    notes = notes_path.read_text(encoding="utf-8")
-                else:
-                    print(f"W&B notes file not found: {notes_path}")
             init_kwargs: dict[str, Any] = dict(
                 project=trainer_config.wandb_project,
                 name=trainer_config.wandb_name,
                 config=vars(agent_config) if hasattr(agent_config, "__dict__") else {},
                 tags=trainer_config.wandb_tags,
-                notes=notes,
             )
             if trainer_config.wandb_id is not None:
                 # resume="must" fails loudly if the run-id does not exist,

--- a/modules/shared/replay_buffer.py
+++ b/modules/shared/replay_buffer.py
@@ -38,7 +38,12 @@ class ReplayBuffer:
                 obs_shape=config.obs_shape,
             )
         cap = config.capacity
-        np_dtype = np.uint8 if config.obs_dtype == "uint8" else np.float32
+        if config.obs_dtype == "uint8":
+            np_dtype = np.uint8
+        elif config.obs_dtype == "float16":
+            np_dtype = np.float16
+        else:
+            np_dtype = np.float32
         self.obs = np.zeros((cap, *config.obs_shape), dtype=np_dtype)
         self.actions = np.zeros(cap, dtype=np.int32)
         self.rewards = np.zeros(cap, dtype=np.float32)

--- a/modules/vggt/jax/feature_extractor.py
+++ b/modules/vggt/jax/feature_extractor.py
@@ -408,9 +408,20 @@ class JAXVGGTFeatureExtractor:
             phase_times["vggt_forward"].append((wrap_t0 - fwd_t0) * 1000.0)
             phase_times["vggt_wrapper"].append((wrap_t1 - wrap_t0) * 1000.0)
 
+        # Final pre-head aggregator patch tokens for encoder ablations. The JAX
+        # port stores frame/local and global/contextual streams concatenated as
+        # 2048-d tokens for DPT heads; expose the 1024-d global stream requested
+        # by Variant 1 before camera/point heads transform it into WP+CP.
+        final_tokens = out_list[-1][:, :, int(np.asarray(patch_start_idx)):, :]
+        final_global = final_tokens[..., final_tokens.shape[-1] // 2:]
+        aggregator_features = final_global[0, 0].reshape(
+            _PATCH_GRID, _PATCH_GRID, self._aggregator.embed_dim
+        ).astype(jnp.float32)
+
         self._frame_idx += 1
 
         return {
             "world_points": world_points_out,
             "camera_pose": camera_pose_out,
+            "aggregator_features": aggregator_features,
         }

--- a/modules/vggt/jax/feature_extractor.py
+++ b/modules/vggt/jax/feature_extractor.py
@@ -189,8 +189,8 @@ class JAXVGGTFeatureExtractor:
 
     @property
     def aggregator_feature_shape(self) -> tuple[int, int, int]:
-        """Shape of one frame's pre-head global aggregator patch features."""
-        return (self.patch_grid, self.patch_grid, self._aggregator.embed_dim)
+        """Shape of one frame's all-token pre-head global aggregator features."""
+        return (1 + self._aggregator.num_register_tokens + self.patch_grid ** 2, self._aggregator.embed_dim)
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -418,15 +418,14 @@ class JAXVGGTFeatureExtractor:
             phase_times["vggt_forward"].append((wrap_t0 - fwd_t0) * 1000.0)
             phase_times["vggt_wrapper"].append((wrap_t1 - wrap_t0) * 1000.0)
 
-        # Final pre-head aggregator patch tokens for encoder ablations. The JAX
-        # port stores frame/local and global/contextual streams concatenated as
+        # Final pre-head aggregator tokens for encoder ablations. The JAX port
+        # stores frame/local and global/contextual streams concatenated as
         # 2048-d tokens for DPT heads; expose the 1024-d global stream requested
-        # by Variant 1 before camera/point heads transform it into WP+CP.
-        final_tokens = out_list[-1][:, :, int(np.asarray(patch_start_idx)):, :]
+        # by Variant 1 before camera/point heads transform it into WP+CP. Keep
+        # all VGGT-DP / VGGT-World tokens: camera + register + spatial patches.
+        final_tokens = out_list[-1]
         final_global = final_tokens[..., final_tokens.shape[-1] // 2:]
-        aggregator_features = final_global[0, 0].reshape(
-            _PATCH_GRID, _PATCH_GRID, self._aggregator.embed_dim
-        ).astype(jnp.float32)
+        aggregator_features = final_global[0, 0].astype(jnp.float32)
 
         self._frame_idx += 1
 

--- a/modules/vggt/jax/feature_extractor.py
+++ b/modules/vggt/jax/feature_extractor.py
@@ -182,6 +182,16 @@ class JAXVGGTFeatureExtractor:
         # valid_len=0) and frame 1 (past_kvs=3-tuples with valid_len>0).
         self._warmup()
 
+    @property
+    def patch_grid(self) -> int:
+        """Number of VGGT patch tokens per spatial side for the configured image size."""
+        return _IMG_SIZE // _PATCH_SIZE
+
+    @property
+    def aggregator_feature_shape(self) -> tuple[int, int, int]:
+        """Shape of one frame's pre-head global aggregator patch features."""
+        return (self.patch_grid, self.patch_grid, self._aggregator.embed_dim)
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------

--- a/modules/vggt/jax/feature_extractor.py
+++ b/modules/vggt/jax/feature_extractor.py
@@ -74,7 +74,12 @@ class JAXVGGTFeatureExtractor:
         dtype: Any = jnp.bfloat16,
         max_camera_frames: int = 1024,
         budgets_static: tuple[int, ...] | None = None,
+        compute_heads: bool = True,
     ):
+        # compute_heads=False skips camera_head + point_head + world_points
+        # wrapper in extract(); only `aggregator_features` is returned. Used by
+        # encoders that consume the pre-head aggregator tokens directly.
+        self._compute_heads = compute_heads
         self._budgets_static_override = budgets_static
         if device in ("cuda", "gpu"):
             self._device = jax.devices("gpu")[0]
@@ -371,52 +376,58 @@ class JAXVGGTFeatureExtractor:
             )
         )
 
-        if self._past_kvs_camera is None:
-            self._past_kvs_camera = [
-                self._new_padded_camera_entry() for _ in range(self._cam_depth)
-            ]
-        # Guard against silent cache overflow: dynamic_update_slice_in_dim
-        # clamps out-of-range writes, and key_value_seq_lengths > _CAM_MAX
-        # produces undefined cuDNN behavior.  Fail loud here instead.
-        max_frames = self._CAM_MAX // self._cam_num_iters
-        if self._frame_idx >= max_frames:
-            raise RuntimeError(
-                f"Camera-head padded cache overflow: cannot extract frame "
-                f"{self._frame_idx + 1}, max_camera_frames={max_frames}. "
-                f"Raise max_camera_frames at construction or call reset()."
+        if self._compute_heads:
+            if self._past_kvs_camera is None:
+                self._past_kvs_camera = [
+                    self._new_padded_camera_entry() for _ in range(self._cam_depth)
+                ]
+            # Guard against silent cache overflow: dynamic_update_slice_in_dim
+            # clamps out-of-range writes, and key_value_seq_lengths > _CAM_MAX
+            # produces undefined cuDNN behavior.  Fail loud here instead.
+            max_frames = self._CAM_MAX // self._cam_num_iters
+            if self._frame_idx >= max_frames:
+                raise RuntimeError(
+                    f"Camera-head padded cache overflow: cannot extract frame "
+                    f"{self._frame_idx + 1}, max_camera_frames={max_frames}. "
+                    f"Raise max_camera_frames at construction or call reset()."
+                )
+            pose_list, self._past_kvs_camera = self._camera_head_apply(
+                self._cam_params,
+                out_list,
+                self._past_kvs_camera,
             )
-        pose_list, self._past_kvs_camera = self._camera_head_apply(
-            self._cam_params,
-            out_list,
-            self._past_kvs_camera,
-        )
-        pose_enc = pose_list[-1]
-        camera_pose = pose_enc[:, 0, :]
+            pose_enc = pose_list[-1]
+            camera_pose = pose_enc[:, 0, :]
 
-        # patch_start_idx is always 1 + num_register_tokens = 5; cast to Python
-        # int so it can be used as a static JIT arg (JIT returns JAX scalars).
-        pts3d, _ = self._point_head_apply(
-            self._pt_params,
-            out_list,
-            images,
-            int(np.asarray(patch_start_idx)),
-        )
-        pts3d = pts3d[:, 0]
+            # patch_start_idx is always 1 + num_register_tokens = 5; cast to Python
+            # int so it can be used as a static JIT arg (JIT returns JAX scalars).
+            pts3d, _ = self._point_head_apply(
+                self._pt_params,
+                out_list,
+                images,
+                int(np.asarray(patch_start_idx)),
+            )
+            pts3d = pts3d[:, 0]
 
-        if profiling:
-            pts3d.block_until_ready()
-            camera_pose.block_until_ready()
+            if profiling:
+                pts3d.block_until_ready()
+                camera_pose.block_until_ready()
+                wrap_t0 = time.perf_counter()
+
+            world_points = _adaptive_avg_pool_518_to_37(pts3d)
+
+            world_points_out = world_points[0].astype(jnp.float32)
+            camera_pose_out = camera_pose[0].astype(jnp.float32)
+
+            if profiling:
+                wrap_t1 = time.perf_counter()
+                phase_times["vggt_forward"].append((wrap_t0 - fwd_t0) * 1000.0)
+                phase_times["vggt_wrapper"].append((wrap_t1 - wrap_t0) * 1000.0)
+        elif profiling:
+            # No heads: forward timing ends right after aggregator, no wrapper work.
             wrap_t0 = time.perf_counter()
-
-        world_points = _adaptive_avg_pool_518_to_37(pts3d)
-
-        world_points_out = world_points[0].astype(jnp.float32)
-        camera_pose_out = camera_pose[0].astype(jnp.float32)
-
-        if profiling:
-            wrap_t1 = time.perf_counter()
             phase_times["vggt_forward"].append((wrap_t0 - fwd_t0) * 1000.0)
-            phase_times["vggt_wrapper"].append((wrap_t1 - wrap_t0) * 1000.0)
+            phase_times["vggt_wrapper"].append(0.0)
 
         # Final pre-head aggregator tokens for encoder ablations. The JAX port
         # stores frame/local and global/contextual streams concatenated as
@@ -429,8 +440,10 @@ class JAXVGGTFeatureExtractor:
 
         self._frame_idx += 1
 
-        return {
-            "world_points": world_points_out,
-            "camera_pose": camera_pose_out,
-            "aggregator_features": aggregator_features,
-        }
+        if self._compute_heads:
+            return {
+                "world_points": world_points_out,
+                "camera_pose": camera_pose_out,
+                "aggregator_features": aggregator_features,
+            }
+        return {"aggregator_features": aggregator_features}

--- a/modules/vggt/tests/test_jax_integration.py
+++ b/modules/vggt/tests/test_jax_integration.py
@@ -9,6 +9,7 @@ PyTorch extractor to within the production tolerance.
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import jax
 
@@ -40,6 +41,19 @@ def _make_frame(seed: int = 0) -> np.ndarray:
     return rng.randint(0, 256, size=(3, 518, 518), dtype=np.uint8)
 
 
+def _real_habitat_frame(index: int = 0) -> np.ndarray:
+    """Real Habitat RGB frame fixture (CHW, uint8)."""
+    fixture = (
+        Path(__file__).parents[2]
+        / "r2dreamer"
+        / "launch"
+        / "tests"
+        / "fixtures"
+        / "sample_habitat_obs.npz"
+    )
+    return np.load(fixture)["frames"][index]
+
+
 @gpu_jax
 class TestJAXFeatureExtractorContract:
     """API-contract tests for the JAX extractor — mirrors PyTorch suite."""
@@ -52,11 +66,14 @@ class TestJAXFeatureExtractorContract:
 
     def test_single_frame_shapes(self, extractor):
         extractor.reset()
-        out = extractor.extract(_make_frame(seed=42))
+        out = extractor.extract(_real_habitat_frame(index=0))
         assert out["world_points"].shape == (37, 37, 3)
         assert out["camera_pose"].shape == (9,)
+        assert out["aggregator_features"].shape == (1374, 1024)
         assert out["world_points"].dtype == np.float32
         assert out["camera_pose"].dtype == np.float32
+        assert out["aggregator_features"].dtype == np.float32
+        assert not np.any(np.isnan(out["aggregator_features"]))
 
     def test_streaming_multiple_frames(self, extractor):
         """Five streaming frames produce NaN-free outputs of the right shape."""

--- a/modules/vggt/tests/test_jax_integration.py
+++ b/modules/vggt/tests/test_jax_integration.py
@@ -130,6 +130,35 @@ class TestJAXFeatureExtractorContract:
         with pytest.raises(RuntimeError, match="Camera-head padded cache overflow"):
             ext.extract(_make_frame(seed=599))
 
+    def test_compute_heads_false_returns_only_aggregator(self):
+        """compute_heads=False skips camera/point heads and world_points wrapper."""
+        from modules.vggt.jax import JAXVGGTFeatureExtractor
+
+        ext = JAXVGGTFeatureExtractor(device="cuda", compute_heads=False)
+        ext.reset()
+        out = ext.extract(_make_frame(seed=7))
+        assert set(out.keys()) == {"aggregator_features"}
+        assert out["aggregator_features"].shape == (1374, 1024)
+        assert out["aggregator_features"].dtype == np.float32
+        assert not np.any(np.isnan(out["aggregator_features"]))
+
+    def test_compute_heads_false_aggregator_matches_full(self, extractor):
+        """Skipping heads must not change the aggregator output values."""
+        from modules.vggt.jax import JAXVGGTFeatureExtractor
+
+        frame = _make_frame(seed=11)
+        extractor.reset()
+        out_full = extractor.extract(frame)
+        ext_skip = JAXVGGTFeatureExtractor(device="cuda", compute_heads=False)
+        ext_skip.reset()
+        out_skip = ext_skip.extract(frame)
+        np.testing.assert_allclose(
+            np.asarray(out_full["aggregator_features"]),
+            np.asarray(out_skip["aggregator_features"]),
+            atol=1e-5,
+            err_msg="aggregator_features changed when heads were skipped",
+        )
+
 
 @both
 class TestJAXvsPyTorchExtractor:

--- a/scripts/diag_overfit_cnn_vggt.sbatch
+++ b/scripts/diag_overfit_cnn_vggt.sbatch
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Protocol E: same overfit-one-batch test for cnn and vggt encoders.
+#
+# Pairs with diag_overfit_one_batch.sbatch (which runs the aggregator-MLP
+# variant). Identical hyper-params, seed, batch shape and loss weights so
+# the three runs are directly comparable.
+#
+# If cnn and vggt both drive loss to ~0 but vggt_aggregator_mlp plateaus,
+# the regression is isolated to the mean-pool + linear-projection design,
+# not VGGT itself and not the training infra.
+#
+# Submit: sbatch scripts/diag_overfit_cnn_vggt.sbatch
+#
+#SBATCH --job-name=enc-diag-cnn-vggt
+#SBATCH --partition=dev_gpu_h100
+#SBATCH --gres=gpu:1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=32G
+#SBATCH --time=00:30:00
+#SBATCH --output=output/diag/enc-diag-cnn-vggt-%j.log
+#SBATCH --error=output/diag/enc-diag-cnn-vggt-%j.log
+
+set -euo pipefail
+
+WORKTREE="/pfs/data6/home/ul/ul_student/ul_hfj15/worktrees/variant-1-aggregator-mlp"
+cd "$WORKTREE"
+mkdir -p output/diag
+
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+TAG="enc-diag"
+
+echo "=== Encoder overfit-one-batch comparison (CNN + VGGT) ==="
+echo "Node: $(hostname)"
+echo "GPU: $(nvidia-smi --query-gpu=name --format=csv,noheader)"
+echo "Date: $(date)"
+echo "Branch: $(git branch --show-current)"
+echo "Commit: $(git rev-parse --short HEAD)"
+echo "Dirty: $(git status --porcelain | wc -l) files"
+echo ""
+
+# Identical to diag_overfit_one_batch.sbatch — fair comparison.
+COMMON=(
+    --prefill 200
+    --steps 1
+    --seed 42
+    --log_every 25
+    --checkpoint_every 1000000
+    --overfit_one_batch
+    --overfit_steps 500
+    --overfit_batch_size 1
+    --overfit_seq_len 8
+    --actor_loss_weight 0
+    --value_loss_weight 0
+    --repval_loss_weight 0
+    --lr 3e-4
+    --batch_size 1
+    --seq_len 8
+)
+
+# ------------------------------------------------------------------ Run 1
+RUN1="${TAG}-cnn-${TIMESTAMP}"
+echo "--- Run 1/2: CNN encoder ---"
+uv run python modules/r2dreamer/scripts/run_jax_habitat.py \
+    "${COMMON[@]}" \
+    --output_dir "output/diag/${RUN1}" \
+    --wandb_name "${RUN1}" \
+    --wandb_tags "diag,overfit,wm-only,encoder-cnn,protocol-e"
+
+# ------------------------------------------------------------------ Run 2
+RUN2="${TAG}-vggt-${TIMESTAMP}"
+echo ""
+echo "--- Run 2/2: VGGT (wp_cp) encoder ---"
+uv run python modules/r2dreamer/scripts/run_jax_habitat_vggt.py \
+    "${COMMON[@]}" \
+    --output_dir "output/diag/${RUN2}" \
+    --wandb_name "${RUN2}" \
+    --wandb_tags "diag,overfit,wm-only,encoder-vggt,protocol-e"
+
+echo ""
+echo "=== Done at $(date) ==="
+echo "Compare loss/* curves and params/encoder_l2 across:"
+echo "  CNN:     ${RUN1}"
+echo "  VGGT:    ${RUN2}"
+echo "  AggMLP:  agg-mlp-diag-overfit-stopgrad-* (from job 4719993)"

--- a/scripts/diag_overfit_one_batch.sbatch
+++ b/scripts/diag_overfit_one_batch.sbatch
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Karpathy step-3 diagnostic for the aggregator-MLP encoder.
+#
+# Runs two short overfit-one-batch jobs back-to-back on dev_gpu_h100:
+#   (1) Protocol B+C: WM-only (actor/value/repval=0), default stop_grad
+#   (2) Protocol B+C+D: same, plus barlow_grad_to_encoder
+#
+# Each run prefills a small replay (B*T=8 transitions need very few steps),
+# samples one batch, freezes it, and runs --overfit_steps train_step
+# iterations. If loss/{dyn,rep,rew,con,barlow} does not drop monotonically
+# on the frozen batch, the gradient path is broken and no 42 h production
+# run will save it.
+#
+# Submit: sbatch scripts/diag_overfit_one_batch.sbatch
+#
+#SBATCH --job-name=agg-mlp-diag-overfit
+#SBATCH --partition=dev_gpu_h100
+#SBATCH --gres=gpu:1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=32G
+#SBATCH --time=00:30:00
+#SBATCH --output=output/diag/agg-mlp-diag-overfit-%j.log
+#SBATCH --error=output/diag/agg-mlp-diag-overfit-%j.log
+
+set -euo pipefail
+
+WORKTREE="/pfs/data6/home/ul/ul_student/ul_hfj15/worktrees/variant-1-aggregator-mlp"
+cd "$WORKTREE"
+mkdir -p output/diag
+
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+TAG="agg-mlp-diag-overfit"
+
+echo "=== Aggregator-MLP overfit-one-batch diagnostic ==="
+echo "Node: $(hostname)"
+echo "GPU: $(nvidia-smi --query-gpu=name --format=csv,noheader)"
+echo "Date: $(date)"
+echo "Branch: $(git branch --show-current)"
+echo "Commit: $(git rev-parse --short HEAD)"
+echo "Dirty: $(git status --porcelain | wc -l) files"
+echo ""
+
+COMMON=(
+    --prefill 200              # buffer-size lower bound is overfit_batch_size*overfit_seq_len = 8
+    --steps 1                  # ignored in overfit mode; keep small to avoid total_steps work
+    --seed 42
+    --log_every 25
+    --checkpoint_every 1000000 # disable checkpointing
+    --overfit_one_batch
+    --overfit_steps 500
+    --overfit_batch_size 1
+    --overfit_seq_len 8
+    # Protocol C: world model only.
+    --actor_loss_weight 0
+    --value_loss_weight 0
+    --repval_loss_weight 0
+    # Hint: a larger LR is fine for an overfit memorise run.
+    --lr 3e-4
+    --batch_size 1
+    --seq_len 8
+)
+
+# ------------------------------------------------------------------ Run 1
+RUN1="${TAG}-stopgrad-${TIMESTAMP}"
+echo "--- Run 1/2: default stop_gradient (current behaviour) ---"
+uv run python modules/r2dreamer/scripts/run_jax_habitat_vggt_aggregator_mlp.py \
+    "${COMMON[@]}" \
+    --output_dir "output/diag/${RUN1}" \
+    --wandb_name "${RUN1}" \
+    --wandb_tags "diag,overfit,wm-only,stopgrad,protocol-bc"
+
+# ------------------------------------------------------------------ Run 2
+RUN2="${TAG}-bargrad-${TIMESTAMP}"
+echo ""
+echo "--- Run 2/2: Barlow gradient reaches encoder (Protocol D) ---"
+uv run python modules/r2dreamer/scripts/run_jax_habitat_vggt_aggregator_mlp.py \
+    "${COMMON[@]}" \
+    --barlow_grad_to_encoder \
+    --output_dir "output/diag/${RUN2}" \
+    --wandb_name "${RUN2}" \
+    --wandb_tags "diag,overfit,wm-only,bargrad,protocol-bcd"
+
+echo ""
+echo "=== Done at $(date) ==="
+echo "Compare loss/* curves and params/encoder_l2 between:"
+echo "  ${RUN1}"
+echo "  ${RUN2}"

--- a/scripts/prod_aggregator_mlp_v1.sbatch
+++ b/scripts/prod_aggregator_mlp_v1.sbatch
@@ -1,0 +1,43 @@
+#!/bin/bash
+#SBATCH --job-name=agg-mlp-prod-v1
+#SBATCH --partition=gpu_h100
+#SBATCH --gres=gpu:1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=64G
+#SBATCH --time=42:00:00
+#SBATCH --output=output/prod/agg-mlp-prod-v1-%j.log
+#SBATCH --error=output/prod/agg-mlp-prod-v1-%j.log
+
+set -euo pipefail
+
+WORKTREE="/pfs/data6/home/ul/ul_student/ul_hfj15/worktrees/variant-1-aggregator-mlp"
+cd "$WORKTREE"
+mkdir -p output/prod
+
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+TAG="agg-mlp-prod-v1"
+RUN_NAME="${TAG}-${TIMESTAMP}"
+
+echo "=== Aggregator-MLP production run v1 (42h, 2M steps) ==="
+echo "Node: $(hostname)"
+echo "GPU: $(nvidia-smi --query-gpu=name --format=csv,noheader)"
+echo "Date: $(date)"
+echo "Branch: $(git branch --show-current)"
+echo "Commit: $(git rev-parse --short HEAD)"
+echo "Dirty: $(git status --porcelain | wc -l) files"
+echo "Run name: ${RUN_NAME}"
+echo ""
+
+uv run python modules/r2dreamer/scripts/run_jax_habitat_vggt_aggregator_mlp.py \
+    --steps 2000000 \
+    --prefill 5000 \
+    --seed 42 \
+    --log_every 1000 \
+    --checkpoint_every 50000 \
+    --output_dir "output/prod/${RUN_NAME}" \
+    --wandb_name "${RUN_NAME}" \
+    --wandb_tags "${TAG},pool-on-device,skip-heads,prod-42h"
+
+echo ""
+echo "=== Done at $(date) ==="

--- a/scripts/profile_pipeline_aggregator_mlp.py
+++ b/scripts/profile_pipeline_aggregator_mlp.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Per-phase wall-clock profile of the aggregator-MLP acting+training loop.
+
+Mirrors the real Trainer.run() control flow (Habitat env + VGGTAggregatorMLPEncoder
+adapter + R2DreamerAgent + numpy ring buffer) but wraps every phase in
+time.perf_counter() so we see where each env-step actually spends its time.
+
+Phases:
+  act               agent.act(...)                       single-step JIT inference
+  env_step          env.step(action)                     Habitat render + reward
+  vggt_extract      adapter._extractor.extract(image)    full VGGT fwd (aggregator + camera + point heads)
+    vggt_forward      (internal phase_times)             transformer block forwards
+    vggt_wrapper      (internal phase_times)             head wrap + reshape
+  adapter_post      mean-pool + np.asarray + cast        on-device pool + host copy
+  buffer_add        np ring-buffer write                 host-side, microseconds
+  buffer_sample     numpy index + jnp.array upload       host→device per train step
+  train_step        agent.train_step(batch, key)         encoder + WM + actor + critic + opt
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from statistics import mean
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+
+from modules.r2dreamer.adapters.vggt_adapter import _vggt_aggregator_features
+from modules.r2dreamer.agent import R2DreamerAgent
+from modules.r2dreamer.config import R2DreamerConfig
+from modules.r2dreamer.launch.curricula import CURRICULA
+from modules.r2dreamer.launch.encoders import VGGTAggregatorMLPEncoder
+from modules.r2dreamer.launch.habitat_setup import make_habitat_env
+from modules.r2dreamer.trainer import convert_batch
+from modules.shared.replay_buffer import BufferConfig, ReplayBuffer
+
+
+def pct(xs, q):
+    xs_sorted = sorted(xs)
+    if not xs_sorted:
+        return 0.0
+    return xs_sorted[min(len(xs_sorted) - 1, int(q * len(xs_sorted)))]
+
+
+def stats(xs):
+    if not xs:
+        return {"n": 0}
+    return {
+        "n": len(xs),
+        "mean_ms": mean(xs),
+        "p50_ms": pct(xs, 0.50),
+        "p95_ms": pct(xs, 0.95),
+        "min_ms": min(xs),
+        "max_ms": max(xs),
+        "total_s": sum(xs) / 1000.0,
+    }
+
+
+def block_tree(x):
+    return jax.tree_util.tree_map(
+        lambda y: y.block_until_ready() if hasattr(y, "block_until_ready") else y,
+        x,
+    )
+
+
+def setup(args):
+    print(f"JAX devices: {jax.devices()}", flush=True)
+
+    class _Args:
+        render_resolution = 518
+
+    enc = VGGTAggregatorMLPEncoder.from_train_args(_Args())
+    adapter = enc.make_adapter()
+    spec = enc.spec()
+    print(f"Encoder spec: obs_shape={spec.obs_shape}, encoder_type={spec.encoder_type}", flush=True)
+    print(f"Adapter: buffer_shape={adapter.buffer_shape}, buffer_dtype={adapter.buffer_dtype}", flush=True)
+    print(f"Agent overrides: {spec.agent_overrides}", flush=True)
+
+    env = make_habitat_env(
+        curriculum_path=str(CURRICULA["L1"]),
+        curriculum_mode="train",
+        seed=42,
+        render_resolution=spec.env_render_resolution,
+    )
+
+    cfg = R2DreamerConfig(
+        encoder_type=spec.encoder_type,
+        obs_shape=spec.obs_shape,
+        num_actions=4,
+        **spec.agent_overrides,
+    )
+    print(
+        f"Train cfg: batch_size={cfg.batch_size}, seq_len={cfg.seq_len}, "
+        f"train_ratio={cfg.train_ratio}, buffer_capacity={cfg.buffer_capacity}",
+        flush=True,
+    )
+
+    rng = jax.random.PRNGKey(42)
+    agent = R2DreamerAgent(cfg, rng)
+    rng, _ = jax.random.split(rng)
+
+    buffer = ReplayBuffer(BufferConfig(
+        capacity=cfg.buffer_capacity,
+        obs_shape=adapter.buffer_shape,
+        obs_dtype=adapter.buffer_dtype,
+        normalize_obs=adapter.normalize_on_sample,
+    ))
+    return enc, adapter, env, cfg, agent, buffer, rng
+
+
+def transform_timed(adapter, obs_dict):
+    """Manual reimplementation of VGGTObsAdapter.transform that exposes timings.
+
+    Mirrors modules/r2dreamer/adapters/vggt_adapter.py:63-78 for the
+    feature_kind="aggregator" branch. Returns the same (replay_features,
+    agent_obs) tuple plus a timings dict.
+    """
+    pt = {"vggt_forward": [], "vggt_wrapper": []}
+    t_e0 = time.perf_counter()
+    out = adapter._extractor.extract(obs_dict["image"], phase_times=pt)
+    features_jax = _vggt_aggregator_features(out, adapter._aggregator_feature_shape)
+    block_tree(features_jax)
+    t_extract_ms = (time.perf_counter() - t_e0) * 1000
+
+    t_p0 = time.perf_counter()
+    replay_features = np.asarray(features_jax).astype(np.float32)
+    agent_features = features_jax.astype(jnp.float32)
+    block_tree(agent_features)
+    t_post_ms = (time.perf_counter() - t_p0) * 1000
+
+    agent_obs = {"features": agent_features, "is_first": obs_dict.get("is_first", False)}
+    timings = {
+        "vggt_extract_total": t_extract_ms,
+        "adapter_post": t_post_ms,
+        "vggt_forward_internal": pt["vggt_forward"][0] if pt["vggt_forward"] else 0.0,
+        "vggt_wrapper_internal": pt["vggt_wrapper"][0] if pt["vggt_wrapper"] else 0.0,
+    }
+    return replay_features, agent_obs, timings
+
+
+def run_prefill(adapter, env, buffer, num_actions, n_steps):
+    print(f"--- Prefill {n_steps} steps (untimed) ---", flush=True)
+    t0 = time.time()
+    obs = env.reset()
+    if adapter.on_episode_reset:
+        adapter.on_episode_reset()
+    buffer_obs, _, _ = transform_timed(adapter, obs)
+    for i in range(n_steps):
+        action = int(np.random.randint(0, num_actions))
+        next_obs = env.step(action)
+        next_buffer_obs, _, _ = transform_timed(adapter, next_obs)
+        success = next_obs.get("success", 0.0) > 0
+        buffer.add(buffer_obs, action, next_obs["reward"], next_obs["done"], terminal=success)
+        if next_obs["done"]:
+            obs = env.reset()
+            if adapter.on_episode_reset:
+                adapter.on_episode_reset()
+            buffer_obs, _, _ = transform_timed(adapter, obs)
+        else:
+            buffer_obs = next_buffer_obs
+        if (i + 1) % 50 == 0:
+            print(f"  prefill {i + 1}/{n_steps} elapsed={time.time() - t0:.1f}s", flush=True)
+    print(f"  prefill done in {time.time() - t0:.1f}s", flush=True)
+
+
+def run_measured(label, adapter, env, agent, cfg, buffer, rng, n_steps, batch_steps, accum):
+    print(f"--- {label} {n_steps} steps ---", flush=True)
+    obs = env.reset()
+    if adapter.on_episode_reset:
+        adapter.on_episode_reset()
+    buffer_obs, agent_obs, _ = transform_timed(adapter, obs)
+    train_credit = 0.0
+    loop_t0 = time.perf_counter()
+    for i in range(n_steps):
+        step_t0 = time.perf_counter()
+
+        # act
+        rng, act_key = jax.random.split(rng)
+        t0 = time.perf_counter()
+        action = agent.act(agent_obs, act_key)
+        block_tree(action)
+        accum["act"].append((time.perf_counter() - t0) * 1000)
+
+        # env step
+        t0 = time.perf_counter()
+        next_obs = env.step(int(action))
+        accum["env_step"].append((time.perf_counter() - t0) * 1000)
+
+        # adapter (vggt extract + post)
+        next_buffer_obs, next_agent_obs, tx = transform_timed(adapter, next_obs)
+        accum["vggt_extract_total"].append(tx["vggt_extract_total"])
+        accum["adapter_post"].append(tx["adapter_post"])
+        accum["vggt_forward_internal"].append(tx["vggt_forward_internal"])
+        accum["vggt_wrapper_internal"].append(tx["vggt_wrapper_internal"])
+
+        # buffer.add
+        success = next_obs.get("success", 0.0) > 0
+        t0 = time.perf_counter()
+        buffer.add(buffer_obs, int(action), next_obs["reward"], next_obs["done"], terminal=success)
+        accum["buffer_add"].append((time.perf_counter() - t0) * 1000)
+
+        if next_obs["done"]:
+            obs = env.reset()
+            if adapter.on_episode_reset:
+                adapter.on_episode_reset()
+            buffer_obs, agent_obs, _ = transform_timed(adapter, obs)
+        else:
+            buffer_obs = next_buffer_obs
+            agent_obs = next_agent_obs
+
+        # train credit -> one or more train steps
+        if buffer.size >= batch_steps:
+            train_credit += cfg.train_ratio / batch_steps
+            while train_credit >= 1.0:
+                t0 = time.perf_counter()
+                batch = buffer.sample(cfg.batch_size, cfg.seq_len)
+                block_tree(batch)
+                accum["buffer_sample"].append((time.perf_counter() - t0) * 1000)
+
+                batch = convert_batch(batch, cfg.num_actions)
+                rng, tkey = jax.random.split(rng)
+                t0 = time.perf_counter()
+                metrics = agent.train_step(batch, tkey)
+                block_tree(metrics)
+                accum["train_step"].append((time.perf_counter() - t0) * 1000)
+                train_credit -= 1.0
+
+        accum["total_step"].append((time.perf_counter() - step_t0) * 1000)
+
+        if (i + 1) % 20 == 0:
+            elapsed = time.perf_counter() - loop_t0
+            fps = (i + 1) / elapsed
+            print(f"  {label} {i + 1}/{n_steps} elapsed={elapsed:.1f}s fps={fps:.2f}", flush=True)
+    return rng
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--prefill", type=int, default=200,
+                   help="Buffer prefill steps (untimed)")
+    p.add_argument("--warmup", type=int, default=20,
+                   help="Timed warmup steps (reported separately, captures JIT compile)")
+    p.add_argument("--measure", type=int, default=80,
+                   help="Timed steady-state steps")
+    p.add_argument("--out", type=str,
+                   default="output/profiling/pipeline_aggregator_mlp.json")
+    args = p.parse_args()
+
+    overall_t0 = time.time()
+    enc, adapter, env, cfg, agent, buffer, rng = setup(args)
+    batch_steps = cfg.batch_size * cfg.seq_len
+
+    run_prefill(adapter, env, buffer, cfg.num_actions, args.prefill)
+
+    warmup_accum = {k: [] for k in (
+        "act", "env_step", "vggt_extract_total", "vggt_forward_internal",
+        "vggt_wrapper_internal", "adapter_post", "buffer_add",
+        "buffer_sample", "train_step", "total_step",
+    )}
+    steady_accum = {k: [] for k in warmup_accum}
+
+    rng = run_measured("WARMUP", adapter, env, agent, cfg, buffer, rng,
+                       args.warmup, batch_steps, warmup_accum)
+    rng = run_measured("MEASURE", adapter, env, agent, cfg, buffer, rng,
+                       args.measure, batch_steps, steady_accum)
+
+    # --- Summary ---
+    print("\n=========================================================", flush=True)
+    print(" Steady-state per-phase breakdown (after warmup)", flush=True)
+    print("=========================================================", flush=True)
+    print(f"{'Phase':<26} {'n':>4} {'mean_ms':>9} {'p50_ms':>8} {'p95_ms':>8} {'total_s':>9}", flush=True)
+    print("-" * 70, flush=True)
+    for k in ["act", "env_step", "vggt_extract_total",
+              "vggt_forward_internal", "vggt_wrapper_internal",
+              "adapter_post", "buffer_add", "buffer_sample",
+              "train_step", "total_step"]:
+        s = stats(steady_accum[k])
+        if s["n"] == 0:
+            continue
+        print(
+            f"{k:<26} {s['n']:>4d} {s['mean_ms']:>9.3f} {s['p50_ms']:>8.3f} "
+            f"{s['p95_ms']:>8.3f} {s['total_s']:>9.3f}",
+            flush=True,
+        )
+
+    total_steady = stats(steady_accum["total_step"])
+    if total_steady["n"] > 0:
+        fps = 1000.0 / total_steady["mean_ms"]
+        print(f"\nSteady-state mean fps: {fps:.2f} (1000/{total_steady['mean_ms']:.1f} ms)", flush=True)
+
+    out_path = ROOT / args.out
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    blob = {
+        "devices": [str(d) for d in jax.devices()],
+        "config": {
+            "prefill": args.prefill,
+            "warmup": args.warmup,
+            "measure": args.measure,
+            "batch_size": cfg.batch_size,
+            "seq_len": cfg.seq_len,
+            "train_ratio": cfg.train_ratio,
+            "obs_shape": list(cfg.obs_shape),
+            "batch_steps": batch_steps,
+        },
+        "warmup": {k: stats(v) for k, v in warmup_accum.items()},
+        "steady": {k: stats(v) for k, v in steady_accum.items()},
+        "total_wallclock_s": time.time() - overall_t0,
+    }
+    out_path.write_text(json.dumps(blob, indent=2))
+    print(f"\nSaved {out_path}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/profile_pipeline_aggregator_mlp.sbatch
+++ b/scripts/profile_pipeline_aggregator_mlp.sbatch
@@ -1,0 +1,34 @@
+#!/bin/bash
+#SBATCH --job-name=agg-pipeline-profile
+#SBATCH --partition=dev_gpu_h100
+#SBATCH --gres=gpu:1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=64G
+#SBATCH --time=00:25:00
+#SBATCH --output=output/profiling/pipeline-aggregator-mlp-%j.log
+#SBATCH --error=output/profiling/pipeline-aggregator-mlp-%j.log
+
+set -euo pipefail
+
+WORKTREE="/pfs/data6/home/ul/ul_student/ul_hfj15/worktrees/variant-1-aggregator-mlp"
+cd "$WORKTREE"
+mkdir -p output/profiling
+
+echo "=== Aggregator-MLP pipeline profile ==="
+echo "Node: $(hostname)"
+echo "GPU: $(nvidia-smi --query-gpu=name --format=csv,noheader)"
+echo "Date: $(date)"
+echo "Branch: $(git branch --show-current)"
+echo "Commit: $(git rev-parse --short HEAD)"
+echo "Dirty: $(git status --porcelain | wc -l) files"
+echo ""
+
+uv run python scripts/profile_pipeline_aggregator_mlp.py \
+    --prefill 200 \
+    --warmup 20 \
+    --measure 100 \
+    --out "output/profiling/pipeline_aggregator_mlp_${SLURM_JOB_ID}.json"
+
+echo ""
+echo "=== Done at $(date) ==="

--- a/scripts/smoke_aggregator_mlp_fast_path.sbatch
+++ b/scripts/smoke_aggregator_mlp_fast_path.sbatch
@@ -1,0 +1,44 @@
+#!/bin/bash
+#SBATCH --job-name=agg-mlp-smoke
+#SBATCH --partition=dev_gpu_h100
+#SBATCH --gres=gpu:1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=64G
+#SBATCH --time=00:20:00
+#SBATCH --output=output/smoke/agg-mlp-fast-path-%j.log
+#SBATCH --error=output/smoke/agg-mlp-fast-path-%j.log
+
+set -euo pipefail
+
+WORKTREE="/pfs/data6/home/ul/ul_student/ul_hfj15/worktrees/variant-1-aggregator-mlp"
+cd "$WORKTREE"
+
+mkdir -p output/smoke
+
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+TAG="agg-mlp-fast-path-smoke"
+RUN_NAME="${TAG}-${TIMESTAMP}"
+
+echo "=== Aggregator-MLP fast-path smoke ==="
+echo "Node: $(hostname)"
+echo "GPU: $(nvidia-smi --query-gpu=name --format=csv,noheader)"
+echo "Date: $(date)"
+echo "Branch: $(git branch --show-current)"
+echo "Commit: $(git rev-parse --short HEAD)"
+echo "Dirty: $(git status --porcelain | wc -l) files"
+echo "Run name: ${RUN_NAME}"
+echo ""
+
+uv run python modules/r2dreamer/scripts/run_jax_habitat_vggt_aggregator_mlp.py \
+    --steps 800 \
+    --prefill 200 \
+    --seed 42 \
+    --log_every 50 \
+    --checkpoint_every 10000 \
+    --output_dir "output/smoke/${RUN_NAME}" \
+    --wandb_name "${RUN_NAME}" \
+    --wandb_tags "${TAG},smoke,short-15min,pool-on-device"
+
+echo ""
+echo "=== Done at $(date) ==="

--- a/scripts/smoke_skip_heads.sbatch
+++ b/scripts/smoke_skip_heads.sbatch
@@ -1,0 +1,61 @@
+#!/bin/bash
+#SBATCH --job-name=agg-skip-heads
+#SBATCH --partition=dev_gpu_h100
+#SBATCH --gres=gpu:1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=64G
+#SBATCH --time=00:30:00
+#SBATCH --output=output/smoke/skip-heads-%j.log
+#SBATCH --error=output/smoke/skip-heads-%j.log
+
+set -euo pipefail
+
+WORKTREE="/pfs/data6/home/ul/ul_student/ul_hfj15/worktrees/variant-1-aggregator-mlp"
+cd "$WORKTREE"
+mkdir -p output/smoke
+
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+TAG="skip-heads-smoke"
+RUN_NAME="${TAG}-${TIMESTAMP}"
+
+echo "=== Aggregator-MLP skip-heads smoke ==="
+echo "Node: $(hostname)"
+echo "GPU: $(nvidia-smi --query-gpu=name --format=csv,noheader)"
+echo "Date: $(date)"
+echo "Branch: $(git branch --show-current)"
+echo "Commit: $(git rev-parse --short HEAD)"
+echo "Dirty: $(git status --porcelain | wc -l) files"
+echo "Run name: ${RUN_NAME}"
+echo ""
+
+# ----- Step 1: validate compute_heads=False semantically (GPU unit tests) -----
+echo "=== [1/3] Unit tests: compute_heads=False semantics ==="
+.venv/bin/pytest -q -x \
+    "modules/vggt/tests/test_jax_integration.py::TestJAXFeatureExtractorContract::test_compute_heads_false_returns_only_aggregator" \
+    "modules/vggt/tests/test_jax_integration.py::TestJAXFeatureExtractorContract::test_compute_heads_false_aggregator_matches_full"
+
+# ----- Step 2: pipeline profile with new code -----
+echo ""
+echo "=== [2/3] Pipeline profile (skip-heads enabled) ==="
+uv run python scripts/profile_pipeline_aggregator_mlp.py \
+    --prefill 200 \
+    --warmup 20 \
+    --measure 100 \
+    --out "output/profiling/pipeline_aggregator_mlp_skip_heads_${SLURM_JOB_ID}.json"
+
+# ----- Step 3: real end-to-end training smoke ~20 min -----
+echo ""
+echo "=== [3/3] End-to-end training smoke ==="
+uv run python modules/r2dreamer/scripts/run_jax_habitat_vggt_aggregator_mlp.py \
+    --steps 6000 \
+    --prefill 200 \
+    --seed 42 \
+    --log_every 100 \
+    --checkpoint_every 4000 \
+    --output_dir "output/smoke/${RUN_NAME}" \
+    --wandb_name "${RUN_NAME}" \
+    --wandb_tags "${TAG},smoke,skip-heads,pool-on-device"
+
+echo ""
+echo "=== Done at $(date) ==="


### PR DESCRIPTION
## Goal
Land Variant 1 of the DreamerV3 + 3D-VLA encoder ablation: consume VGGT pre-head aggregator patch features instead of post-head WP+CP outputs, wire it into the R2Dreamer launcher/registry, validate the end-to-end Habitat smoke path, and queue a 2M-step bwUniCluster H100 run.

## Approach
- Added a new `vggt_aggregator_mlp` encoder path without changing the existing `vggt` WP+CP path.
- Exported VGGT final pre-head aggregator global patch features as `(37, 37, 1024)` from the JAX VGGT feature extractor.
- Added the locked Variant 1 Flax encoder architecture:
  - `1x1 Conv 1024->64`
  - `RMSNorm + SiLU`
  - flatten to `87616`
  - `Dense 87616->1024`
  - `RMSNorm + SiLU`
  - `Dense 1024->1024`
- Added launcher/registry plumbing, focused tests, W&B config plumbing, and a 2M-step SLURM submission script.
- Refactored encoder setup around `EncoderSpec` so train.py consumes encoder-provided `obs_shape`, `env_render_resolution`, `encoder_type`, `agent_overrides`, and `design_notes` instead of hardcoding VGGT aggregator shape or duplicating encoder string checks.
- For feasibility on a single H100, Variant 1 stores aggregator replay observations as float16 and uses Variant 1-specific defaults `buffer_capacity=5000`, `batch_size=4`, `seq_len=32`, `train_ratio=128` while samples are converted back to float32 for training.

## Decisions made
See [LEARNING.md](https://github.com/LSailer/Master-Thesis-3D-VLA/blob/feat/variant-1-aggregator-mlp/LEARNING.md).

Top decisions:
- Kept Variant 1 as a separate registry encoder rather than altering the existing `vggt` WP+CP path.
- Used the final VGGT aggregator block's global/contextual stream after removing special tokens to satisfy the locked `(37, 37, 1024)` pre-head feature contract.
- Used Python 3.11 for tests/smoke because the clean worktree otherwise let `uv` pick Python 3.13, which is incompatible with the pinned `open3d==0.19.0` wheels.
- Used worktree-local symlinks for untracked `external/` and Habitat scene data instead of committing generated/local dataset artifacts.
- Reduced replay/batch/sequence defaults for this encoder because default replay would allocate ~5.10 TiB and the default train-step compile exhausted practical H100 memory.
- Aggregator observation shape now comes from VGGT extractor metadata via the adapter/`EncoderSpec`; train.py no longer imports or hardcodes `VGGT_AGGREGATOR_FEATURE_SHAPE`.
- W&B notes mirroring was removed after review; LEARNING.md remains linked from the PR, while W&B keeps the compact `design_notes` config key.

## Tradeoffs rejected
- Rejected reusing WP+CP features: they are post-head VGGT outputs and violate the locked ablation independent variable.
- Rejected modifying the existing `vggt` encoder behavior: it would risk changing baseline behavior outside the new Variant 1 path.
- Rejected committing local/generated Habitat/ObjectNav data or external dependency trees: clean-worktree symlinks keep the PR focused on encoder/plumbing changes.
- Rejected the default 1M replay capacity for aggregator tokens: `(1_000_000, 37, 37, 1024)` float32 is ~5.10 TiB.
- Rejected default Dreamer `batch_size=16`, `seq_len=64`, `train_ratio=512` for this memory-heavy encoder after the first train-step compile consumed ~75 GiB H100 VRAM.

## Smoke output
Focused tests:

```text
$ uv run --python 3.11 pytest modules/r2dreamer/launch/tests/test_registries.py modules/r2dreamer/tests/test_vggt_encoder.py -q
....................                                                     [100%]
20 passed in 66.05s (0:01:06)
```

End-to-end Habitat + VGGT + Dreamer train-step smoke command:

```text
$ mkdir -p output/variant-1-aggregator-mlp-smoke-b4 && uv run --python 3.11 python modules/r2dreamer/scripts/run_jax_habitat_vggt_aggregator_mlp.py \
    --steps 10000 \
    --prefill 10 \
    --checkpoint_every 10000 \
    --output_dir output/variant-1-aggregator-mlp-smoke-b4 \
    --seed 0 \
    --log_every 250 \
    --wandb_project 3d-vla-objectnav \
    --wandb_name variant-1-aggregator-mlp-smoke-local-b4 \
    --wandb_tags smoke,variant-1,aggregator-mlp \
    --wandb_notes_file LEARNING.md \
    --render_resolution 518
```

Relevant console output from the completed 10k smoke:

```text
Curriculum [level1_1house_1goal] train: 49998 → 7499 episodes
wandb: Syncing run variant-1-aggregator-mlp-smoke-local-b4
wandb: 🚀 View run at https://wandb.ai/sailer-luca-university-ulm/3d-vla-objectnav/runs/ufubjxh2
Prefilling 10 steps...
Training from step 0 to 10000...
[step      250/10000] total=67.007 dyn=10.081 rew=5.402 policy=-0.012 fps=1
[step      499] reward=-5.04 steps=500 SR=0.000
[step      500/10000] total=38.401 dyn=9.578 rew=3.430 policy=-0.057 fps=2
[step      750/10000] total=18.947 dyn=5.926 rew=0.617 policy=-0.109 fps=2
[step     1000/10000] total=21.147 dyn=4.718 rew=0.330 policy=-0.112 fps=2
[step     2500/10000] total=11.241 dyn=3.647 rew=0.239 policy=-0.094 fps=2
[step     4909] reward=8.26 steps=410 SR=0.100
[step     5000/10000] total=9.965 dyn=3.671 rew=0.271 policy=-0.081 fps=2
[step     7500/10000] total=11.120 dyn=3.378 rew=0.226 policy=-0.048 fps=2
[step     9000/10000] total=16.581 dyn=8.201 rew=0.261 policy=-0.037 fps=2
[step     9500/10000] total=13.673 dyn=4.692 rew=0.263 policy=-0.042 fps=2
[step     9750/10000] total=11.690 dyn=3.930 rew=0.231 policy=-0.056 fps=2
[step     9909] reward=-3.53 steps=500 SR=0.050
Checkpoint saved: output/variant-1-aggregator-mlp-smoke-b4/checkpoints/step_000010000.pkl
wandb: Run summary:
wandb:       episode/count 20
wandb: episode/path_length 4.74998
wandb:  episode/path_ratio 1.49303
wandb:      episode/reward -3.53129
wandb: 🚀 View run variant-1-aggregator-mlp-smoke-local-b4 at: https://wandb.ai/sailer-luca-university-ulm/3d-vla-objectnav/runs/ufubjxh2
wandb: Synced 5 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
```


Additional follow-up verification after all-token extractor change:

```text
$ srun -p dev_gpu_h100 --gres=gpu:1 --time=00:20:00 bash -lc '
  cd /pfs/data6/home/ul/ul_student/ul_hfj15/worktrees/variant-1-aggregator-mlp &&
  uv run --python 3.11 pytest \
    modules/vggt/tests/test_jax_integration.py::TestJAXFeatureExtractorContract::test_single_frame_shapes \
    -q
'
1 passed in 258.75s
```

Minimum end-to-end smoke on the updated HEAD reached real train metrics and checkpoint creation:

```text
Prefilling 2 steps...
Training from step 0 to 3...
[step        0/3] total=89.660 dyn=7.108 rew=5.541 policy=-0.002 fps=0
[step        1/3] total=88.919 dyn=7.734 rew=5.541 policy=-0.003 fps=0
[step        2/3] total=91.004 dyn=6.854 rew=5.541 policy=-0.003 fps=0
Checkpoint saved: output/smoke-aggregator-pipeline-20260510-121204-seq2/checkpoints/step_000000003.pkl
```

Verified from `metrics.csv`/`MANIFEST.json`:

```text
row_count 39
has_total_loss True
has_nan_skipped True
nan_skipped [0.0, 0.0, 0.0]
manifest_status completed
encoder_type vggt_aggregator_mlp
obs_shape [1374, 1024]
```

Smoke checkpoint:

```text
output/variant-1-aggregator-mlp-smoke-b4/checkpoints/step_000010000.pkl
```

## SLURM job ID
Latest 2M-step H100 job for pushed commit `efe09c5`:

```text
4576399
```

Submitted with:

```text
$ sbatch modules/r2dreamer/scripts/slurm/train_curriculum_l1_vggt_aggregator_mlp_2m.sbatch
Submitted batch job 4576399
```

Scheduler check after submission:

```text
JOBID     PARTITION  NAME          STATE    TIME  TIME_LIMIT NODES NODELIST(REASON)
4576399   gpu_h100   vggt_agg_mlp  PENDING  0:00  2-00:00:00 1     (Priority)
```

SLURM log path:

```text
output/r2dreamer-curriculum-l1-vggt-aggregator-mlp/slurm-4576399.out
output/r2dreamer-curriculum-l1-vggt-aggregator-mlp/slurm-4576399.err
output/r2dreamer-curriculum-l1-vggt-aggregator-mlp/run-4576399
```

Previous long-run submission from the earlier commit was `4498241`; the current validation job for this pushed HEAD is `4576399`.

## W&B run
Latest 2M SLURM run for job `4576399` is queued; W&B URL is pending until the allocation starts and `wandb.init()` runs.

Run name expected from the SLURM script:
```text
variant-1-aggregator-mlp-4576399
```

Smoke run used for earlier local end-to-end verification:
https://wandb.ai/sailer-luca-university-ulm/3d-vla-objectnav/runs/ufubjxh2

Previous 2M SLURM run from the earlier commit:
https://wandb.ai/sailer-luca-university-ulm/3d-vla-objectnav/runs/khz3cpsg

W&B config includes compact design notes; LEARNING.md remains the tracked decision log linked from this PR.

## Open questions
- Whether the reduced Variant 1 training defaults (`batch_size=4`, `seq_len=32`, `train_ratio=128`, replay window 5k) should be treated as the official ablation setting or only the feasible single-H100 setting for this PR.
- Whether to add a follow-up streaming/disk-backed replay for large `(37,37,1024)` feature tensors so future runs can use larger replay windows without multi-TiB host RAM.
