### PR TITLE
Address Linear metrics and boundary test issues

### DIFF
--- a/docs/plans/baseline-training-plan.md
+++ b/docs/plans/baseline-training-plan.md
@@ -60,7 +60,8 @@ The no-goal R2Dreamer baseline is validated when **all four** hold:
 **4. Latent diagnostics logging**
 - Modify: `modules/r2dreamer/agent.py` (train_step return dict)
 - Add to training metrics:
-  - `latent/prior_entropy`, `latent/posterior_entropy`, `latent/kl_divergence`
+  - `latent/prior_entropy`, `latent/posterior_entropy`
+  - Use `loss/dyn` for the logged dynamics KL scalar
 - Shows whether RSSM is learning meaningful dynamics vs outputting uniform noise
 
 ### Phase 3 -- Evaluation Pipeline

--- a/modules/envs/habitat.py
+++ b/modules/envs/habitat.py
@@ -23,6 +23,22 @@ DATA_DIR = Path("data/datasets/objectnav/hm3d/objectnav_hm3d_v2")
 GOAL_RADIUS = 0.2
 
 
+def _validate_goal_distance(dist: float) -> float:
+    if dist is None:
+        raise ValueError("distance_to_goal must be a finite non-negative value, got None")
+    dist = float(dist)
+    if not np.isfinite(dist) or dist < 0.0:
+        raise ValueError(
+            "distance_to_goal must be a finite non-negative value, "
+            f"got {dist!r}"
+        )
+    return dist
+
+
+def _is_success_distance(dist: float) -> bool:
+    return _validate_goal_distance(dist) < GOAL_RADIUS
+
+
 def find_nearest_viewpoint(env):
     """Find nearest viewpoint across all goal instances of a habitat.Env.
 
@@ -220,9 +236,9 @@ class HabitatObjectNavEnv:
         self._path_length += np.linalg.norm(current_position - self._prev_position)
         self._prev_position = current_position
 
-        dist = metrics.get("distance_to_goal", float("inf"))
+        dist = _validate_goal_distance(metrics.get("distance_to_goal", float("inf")))
         reward = self._compute_reward(dist)
-        success = 1.0 if dist < GOAL_RADIUS else 0.0
+        success = 1.0 if _is_success_distance(dist) else 0.0
         done = success > 0 or self._step_count >= self._cfg.max_episode_steps
 
         spl = 0.0
@@ -254,15 +270,19 @@ class HabitatObjectNavEnv:
         return np.transpose(rgb, (2, 0, 1))  # (3, H, W)
 
     def _compute_reward(self, dist: float) -> float:
+        dist = _validate_goal_distance(dist)
         if self._cfg.reward_type == "sparse":
-            bonus = self._cfg.success_bonus if dist < GOAL_RADIUS else 0.0
+            bonus = self._cfg.success_bonus if _is_success_distance(dist) else 0.0
             return bonus + self._cfg.step_penalty
 
-        reward = self._prev_dist - dist  # geodesic delta
-        self._prev_dist = dist
-        if dist < GOAL_RADIUS:
-            reward += self._cfg.success_bonus
-        return reward + self._cfg.step_penalty
+        if self._cfg.reward_type == "geodesic_delta":
+            reward = self._prev_dist - dist
+            self._prev_dist = dist
+            if _is_success_distance(dist):
+                reward += self._cfg.success_bonus
+            return reward + self._cfg.step_penalty
+
+        raise ValueError(f"Unknown reward_type: {self._cfg.reward_type!r}")
 
     def close(self):
         self._env.close()

--- a/modules/envs/tests/test_reward.py
+++ b/modules/envs/tests/test_reward.py
@@ -5,8 +5,13 @@ with only the fields _compute_reward() depends on.
 """
 
 import pytest
+import numpy as np
 from modules.shared.configs import DreamerConfig
-from modules.envs.habitat import HabitatObjectNavEnv
+from modules.envs.habitat import (
+    GOAL_RADIUS,
+    HabitatObjectNavEnv,
+    _is_success_distance,
+)
 
 
 class _RewardTestEnv:
@@ -18,6 +23,51 @@ class _RewardTestEnv:
 
     def _compute_reward(self, dist: float) -> float:
         return HabitatObjectNavEnv._compute_reward(self, dist)
+
+
+class _FakeAgentState:
+    def __init__(self, position):
+        self.position = position
+
+
+class _FakeSim:
+    def __init__(self, position):
+        self._position = position
+
+    def get_agent_state(self):
+        return _FakeAgentState(self._position)
+
+
+class _FakeHabitatEnv:
+    def __init__(self, distance):
+        self._distance = distance
+        self.sim = _FakeSim([0.1, 0.0, 0.0])
+
+    def step(self, action):
+        assert action == 1
+        return {"rgb": np.zeros((1, 1, 3), dtype=np.uint8)}
+
+    def get_metrics(self):
+        return {"distance_to_goal": self._distance}
+
+
+def _make_step_test_env(distance: float) -> HabitatObjectNavEnv:
+    env = object.__new__(HabitatObjectNavEnv)
+    env._cfg = DreamerConfig(
+        obs_shape=(3, 1, 1),
+        max_episode_steps=10,
+        reward_type="geodesic_delta",
+        step_penalty=0.0,
+        success_bonus=1.0,
+    )
+    env._env = _FakeHabitatEnv(distance)
+    env._last_obs = {"rgb": np.zeros((1, 1, 3), dtype=np.uint8)}
+    env._prev_dist = 1.0
+    env._start_geodesic = 1.0
+    env._step_count = 0
+    env._path_length = 0.0
+    env._prev_position = [0.0, 0.0, 0.0]
+    return env
 
 
 def test_config_defaults():
@@ -107,3 +157,55 @@ def test_sparse_reward_failure():
     env = _RewardTestEnv(cfg)
     reward = env._compute_reward(5.0)  # far from goal
     assert reward == pytest.approx(cfg.step_penalty)
+
+
+@pytest.mark.parametrize(
+    ("dist", "expected"),
+    [
+        (GOAL_RADIUS, False),
+        (GOAL_RADIUS - 1e-6, True),
+        (GOAL_RADIUS + 1e-6, False),
+    ],
+)
+def test_success_boundary_is_strictly_inside_goal_radius(dist, expected):
+    assert _is_success_distance(dist) is expected
+
+
+@pytest.mark.parametrize("dist", [None, float("nan"), float("inf"), -0.01])
+def test_invalid_goal_distances_raise_clear_error(dist):
+    cfg = DreamerConfig(reward_type="geodesic_delta")
+    env = _RewardTestEnv(cfg)
+    with pytest.raises(ValueError, match="distance_to_goal"):
+        env._compute_reward(dist)
+
+
+def test_invalid_distance_does_not_update_prev_dist():
+    cfg = DreamerConfig(reward_type="geodesic_delta")
+    env = _RewardTestEnv(cfg)
+    env._prev_dist = 5.0
+    with pytest.raises(ValueError):
+        env._compute_reward(float("nan"))
+    assert env._prev_dist == 5.0
+
+
+def test_unknown_reward_type_raises_explicit_error():
+    cfg = DreamerConfig(reward_type="dense-but-misspelled")
+    env = _RewardTestEnv(cfg)
+    with pytest.raises(ValueError, match="Unknown reward_type"):
+        env._compute_reward(5.0)
+
+
+def test_step_marks_success_distance_as_done():
+    env = _make_step_test_env(GOAL_RADIUS - 1e-6)
+    obs = env.step(1)
+    assert obs["success"] == 1.0
+    assert obs["done"] is True
+    assert obs["spl"] > 0.0
+
+
+def test_step_does_not_end_episode_at_exact_goal_radius():
+    env = _make_step_test_env(GOAL_RADIUS)
+    obs = env.step(1)
+    assert obs["success"] == 0.0
+    assert obs["done"] is False
+    assert obs["spl"] == 0.0

--- a/modules/r2dreamer/scripts/plot_baseline_analysis.py
+++ b/modules/r2dreamer/scripts/plot_baseline_analysis.py
@@ -126,7 +126,7 @@ def plot_world_model_losses(metrics: dict, out_dir: Path):
         ("loss/dyn", "KL / Dynamics Loss", "tab:blue", axes[0, 0]),
         ("loss/rew", "Reward Prediction Loss", "tab:orange", axes[0, 1]),
         ("total_loss", "Total Loss", "tab:red", axes[1, 0]),
-        ("latent/kl_divergence", "KL Divergence", "tab:purple", axes[1, 1]),
+        ("loss/rep", "Representation KL Loss", "tab:purple", axes[1, 1]),
     ]
 
     for metric_name, title, color, ax in loss_configs:

--- a/modules/r2dreamer/scripts/plot_l1_baseline.py
+++ b/modules/r2dreamer/scripts/plot_l1_baseline.py
@@ -130,7 +130,7 @@ def plot_world_model_losses(df: pd.DataFrame, out_path: str):
 def plot_policy_and_kl(df: pd.DataFrame, out_path: str):
     policy = load_metric(df, "loss/policy", rolling=50)
     value = load_metric(df, "loss/value", rolling=50)
-    kl = load_metric(df, "latent/kl_divergence", rolling=50)
+    kl = load_metric(df, "loss/dyn", rolling=50)
 
     fig, axes = plt.subplots(1, 2, figsize=(14, 5))
 
@@ -147,7 +147,7 @@ def plot_policy_and_kl(df: pd.DataFrame, out_path: str):
 
     # KL divergence
     ax = axes[1]
-    ax.plot(kl["step"] / 1e6, kl["smooth"], color=AMBER, linewidth=2, label="KL divergence")
+    ax.plot(kl["step"] / 1e6, kl["smooth"], color=AMBER, linewidth=2, label="Dynamics KL")
     ax.set_xlabel("Environment Steps (M)")
     ax.set_ylabel("KL (nats)")
     ax.set_title("Latent KL Divergence", fontweight="bold", fontsize=13)

--- a/modules/r2dreamer/world_model/loss.py
+++ b/modules/r2dreamer/world_model/loss.py
@@ -97,6 +97,5 @@ def world_model_loss(*, forward, params, batch, modules, cfg, twohot):
         jnp.sum(prior_probs * jnp.log(prior_probs + 1e-8), axis=-1))
     metrics["latent/posterior_entropy"] = -jnp.mean(
         jnp.sum(post_probs * jnp.log(post_probs + 1e-8), axis=-1))
-    metrics["latent/kl_divergence"] = jnp.mean(dyn_loss)
 
     return losses, metrics

--- a/modules/shared/tests/test_replay_buffer.py
+++ b/modules/shared/tests/test_replay_buffer.py
@@ -190,6 +190,87 @@ class TestWriteHeadSafety:
         assert batch["obs"].shape == (4, seq_len, 2)
 
 
+class TestEpisodeBoundaries:
+    """Document how ReplayBuffer exposes episode boundaries to the RSSM."""
+
+    def test_done_boundary_sets_following_is_first(self):
+        cfg = BufferConfig(capacity=20, obs_shape=(2,),
+                           obs_dtype="float32", normalize_obs=False)
+        buf = ReplayBuffer(cfg)
+        for episode in range(3):
+            for step in range(4):
+                buf.add(
+                    np.array([episode, step], dtype=np.float32),
+                    action=episode,
+                    reward=float(episode * 10 + step),
+                    done=(step == 3),
+                )
+
+        np.random.seed(0)
+        for _ in range(50):
+            batch = buf.sample(batch_size=4, seq_len=5)
+            obs = np.array(batch["obs"])
+            dones = np.array(batch["dones"])
+            is_first = np.array(batch["is_first"])
+
+            assert np.all(is_first[:, 0] == 1.0)
+            for b in range(obs.shape[0]):
+                for t in range(1, obs.shape[1]):
+                    episode_changed = obs[b, t, 0] != obs[b, t - 1, 0]
+                    if episode_changed:
+                        assert dones[b, t - 1] == 1.0
+                        assert is_first[b, t] == 1.0
+
+    def test_terminal_flag_survives_successful_episode_end(self):
+        cfg = BufferConfig(capacity=12, obs_shape=(2,),
+                           obs_dtype="float32", normalize_obs=False)
+        buf = ReplayBuffer(cfg)
+        for step in range(6):
+            buf.add(
+                np.array([0, step], dtype=np.float32),
+                action=0,
+                reward=float(step),
+                done=(step == 2 or step == 5),
+                terminal=(step == 2),
+            )
+
+        np.random.seed(1)
+        batch = buf.sample(batch_size=8, seq_len=3)
+        dones = np.array(batch["dones"])
+        terminals = np.array(batch["terminals"])
+
+        assert np.any(terminals == 1.0)
+        assert np.all(terminals <= dones)
+        assert np.any((dones == 1.0) & (terminals == 0.0))
+
+    def test_wraparound_episode_change_has_reset_marker(self):
+        cfg = BufferConfig(capacity=10, obs_shape=(2,),
+                           obs_dtype="float32", normalize_obs=False)
+        buf = ReplayBuffer(cfg)
+        for i in range(16):
+            episode, step = divmod(i, 4)
+            buf.add(
+                np.array([episode, step], dtype=np.float32),
+                action=0,
+                reward=float(i),
+                done=(step == 3),
+                terminal=(episode == 2 and step == 3),
+            )
+
+        assert buf.size == cfg.capacity
+        np.random.seed(2)
+        for _ in range(100):
+            batch = buf.sample(batch_size=6, seq_len=4)
+            obs = np.array(batch["obs"])
+            dones = np.array(batch["dones"])
+            is_first = np.array(batch["is_first"])
+            for b in range(obs.shape[0]):
+                for t in range(1, obs.shape[1]):
+                    if obs[b, t, 0] != obs[b, t - 1, 0]:
+                        assert dones[b, t - 1] == 1.0
+                        assert is_first[b, t] == 1.0
+
+
 class TestValReplayDataset:
     """Test ValReplayDataset normalization behavior."""
 


### PR DESCRIPTION
## Summary

- Drop redundant latent/kl_divergence logging and update active plot/plan references to loss/dyn or loss/rep
- Add explicit ObjectNav goal-distance validation, strict goal-radius success semantics, and fake-wrapper step tests
- Strengthen ReplayBuffer tests around episode boundary reset markers, terminal flags, and wraparound sampling

## Linear

- 3D-6
- 3D-10
- 3D-11

## Tests

- .venv/bin/python -m pytest modules/envs/tests/test_reward.py modules/shared/tests/test_replay_buffer.py