### PR TITLE
[codex] Prepare held-out L3 ObjectNav eval

### DIFF
--- a/docs/reports/3d-8-heldout-l3-eval.md
+++ b/docs/reports/3d-8-heldout-l3-eval.md
@@ -1,0 +1,84 @@
+# 3D-8 Held-Out-House L3 Evaluation
+
+## Goal
+
+Evaluate the L3 CNN/R2-Dreamer ObjectNav checkpoint on HM3D houses that are
+disjoint from the original `level3_10houses_1goal` curriculum, then rerun the
+baseline under the same held-out eval config.
+
+## Held-Out Curriculum
+
+Generate the eval curriculum:
+
+```bash
+python modules/r2dreamer/scripts/build_l3_heldout_curriculum.py
+```
+
+Default output:
+
+```text
+data/curriculum/level3_heldout_10houses_1goal.json
+```
+
+The generator selects 10 chair-containing HM3D train-split scenes with the most
+chair episodes after excluding the original L3 scenes. It samples 200 eval
+episodes per held-out house by default and records the original L3 scenes in
+`heldout_from_scenes`.
+
+## Candidate Checkpoint
+
+The strongest available L3 CNN checkpoint discovered locally is:
+
+```text
+output/r2dreamer-curriculum-l3/run-4194045/checkpoints/step_002400000.pkl
+```
+
+There is also an earlier actfix run:
+
+```text
+output/runs/r2dreamer-curriculum-l3-actfix/run-4119016/checkpoints/step_002400000.pkl
+```
+
+Choose one explicitly in the eval artifact note; do not mix checkpoint results.
+
+## Eval Command
+
+```bash
+python modules/r2dreamer/scripts/eval_habitat.py \
+  --checkpoint output/r2dreamer-curriculum-l3/run-4194045/checkpoints/step_002400000.pkl \
+  --encoder cnn \
+  --episodes 2000 \
+  --curriculum_path data/curriculum/level3_heldout_10houses_1goal.json \
+  --output_dir output/eval/l3-heldout-cnn-step-2400000 \
+  --split train \
+  --render_topdown
+```
+
+The curriculum filter uses HM3D train-split scene files; the held-out guarantee
+comes from disjoint scene IDs, not the Habitat `val` split.
+
+## Baseline Rerun
+
+Use the same held-out curriculum and episode count for the baseline:
+
+```bash
+python modules/r2dreamer/scripts/eval_habitat.py \
+  --random \
+  --encoder cnn \
+  --episodes 2000 \
+  --curriculum_path data/curriculum/level3_heldout_10houses_1goal.json \
+  --output_dir output/eval/l3-heldout-random \
+  --split train
+```
+
+## Artifact Checklist
+
+- Commit SHA
+- Checkpoint path and checkpoint step
+- Generated held-out curriculum path
+- Held-out scene list
+- Eval command
+- W&B run URL, if used
+- Aggregate SR, SPL, mean episode length
+- Per-house SR for model and baseline
+- Thesis wording update location

--- a/modules/r2dreamer/scripts/build_l3_heldout_curriculum.py
+++ b/modules/r2dreamer/scripts/build_l3_heldout_curriculum.py
@@ -1,0 +1,137 @@
+"""Build a held-out-house L3 chair-only curriculum for ObjectNav eval.
+
+The generated curriculum uses HM3D train-split scenes that are disjoint from
+the existing L3 10-house curriculum. It keeps the same key format consumed by
+``HabitatObjectNavEnv``: ``[episode_id, object_category, scene_name]``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import random
+from pathlib import Path
+
+
+def _scene_name(path: Path) -> str:
+    return path.name.replace(".json.gz", "")
+
+
+def _load_scene_episodes(path: Path) -> list[dict]:
+    with gzip.open(path, "rt") as f:
+        return json.load(f).get("episodes", [])
+
+
+def _episode_key(ep: dict, scene: str) -> list[str]:
+    return [str(ep["episode_id"]), ep["object_category"], scene]
+
+
+def build_curriculum(
+    *,
+    source_curriculum: Path,
+    content_dir: Path,
+    output: Path,
+    houses: int,
+    eval_episodes_per_house: int,
+    seed: int,
+) -> dict:
+    source = json.loads(source_curriculum.read_text())
+    source_scenes = set(source["scenes"])
+    candidates: list[tuple[str, list[dict]]] = []
+
+    for path in sorted(content_dir.glob("*.json.gz")):
+        scene = _scene_name(path)
+        if scene in source_scenes:
+            continue
+        chair_eps = [
+            ep for ep in _load_scene_episodes(path)
+            if ep.get("object_category") == "chair"
+        ]
+        if chair_eps:
+            candidates.append((scene, chair_eps))
+
+    if len(candidates) < houses:
+        raise RuntimeError(
+            f"Only found {len(candidates)} held-out chair scenes, need {houses}"
+        )
+
+    candidates.sort(key=lambda item: (-len(item[1]), item[0]))
+    selected = candidates[:houses]
+    rng = random.Random(seed)
+
+    train_keys: list[list[str]] = []
+    eval_keys: list[list[str]] = []
+    stats: dict[str, dict[str, int]] = {}
+    for scene, episodes in selected:
+        shuffled = list(episodes)
+        rng.shuffle(shuffled)
+        eval_eps = shuffled[:eval_episodes_per_house]
+        train_eps = shuffled[eval_episodes_per_house:]
+        eval_keys.extend(_episode_key(ep, scene) for ep in eval_eps)
+        train_keys.extend(_episode_key(ep, scene) for ep in train_eps)
+        stats[scene] = {
+            "chair_episodes": len(episodes),
+            "eval_episodes": len(eval_eps),
+            "unused_train_keys": len(train_eps),
+        }
+
+    result = {
+        "name": "level3_heldout_10houses_1goal",
+        "description": (
+            "Held-out-house L3 ObjectNav eval curriculum: chair episodes from "
+            "10 HM3D train-split scenes disjoint from level3_10houses_1goal."
+        ),
+        "source_curriculum": str(source_curriculum),
+        "heldout_from_scenes": sorted(source_scenes),
+        "scenes": [scene for scene, _episodes in selected],
+        "categories": ["chair"],
+        "seed": seed,
+        "train_ratio": None,
+        "eval_sample_size": len(eval_keys),
+        "train_episode_keys": train_keys,
+        "eval_episode_keys": eval_keys,
+        "stats": stats,
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(result, indent=2) + "\n")
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--source_curriculum",
+        type=Path,
+        default=Path("data/curriculum/level3_10houses_1goal.json"),
+    )
+    parser.add_argument(
+        "--content_dir",
+        type=Path,
+        default=Path("data/datasets/objectnav/hm3d/objectnav_hm3d_v2/train/content"),
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("data/curriculum/level3_heldout_10houses_1goal.json"),
+    )
+    parser.add_argument("--houses", type=int, default=10)
+    parser.add_argument("--eval_episodes_per_house", type=int, default=200)
+    parser.add_argument("--seed", type=int, default=3)
+    args = parser.parse_args()
+
+    curriculum = build_curriculum(
+        source_curriculum=args.source_curriculum,
+        content_dir=args.content_dir,
+        output=args.output,
+        houses=args.houses,
+        eval_episodes_per_house=args.eval_episodes_per_house,
+        seed=args.seed,
+    )
+    print(f"Wrote {args.output}")
+    print(f"Held-out scenes: {', '.join(curriculum['scenes'])}")
+    print(f"Eval episodes: {curriculum['eval_sample_size']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed

- Added a reproducible generator for a held-out-house L3 chair-only ObjectNav curriculum.
- Added an experiment runbook documenting the held-out-house setup, candidate checkpoints, model eval command, baseline rerun command, and artifact checklist.

## Why

Linear 3D-8 needs a held-out-house evaluation so the thesis can distinguish fixed-house scaling from cross-house generalization. This PR prepares the rerunnable eval config and run documentation before launching the longer cluster jobs.

## Linear issue

3D-8

## Acceptance criteria addressed in this PR

- Held-out house selection is generated from scenes disjoint from the original L3 10-house curriculum.
- Eval script/config can be rerun from the repo.
- Experiment note records checkpoint candidates, commands, output paths, and required result artifacts.

## Verification

- `./.venv/bin/python -m py_compile modules/r2dreamer/scripts/build_l3_heldout_curriculum.py`
- `./.venv/bin/python modules/r2dreamer/scripts/build_l3_heldout_curriculum.py --output /tmp/level3_heldout_10houses_1goal.json --eval_episodes_per_house 3`
  - Result: wrote a held-out curriculum with 10 disjoint scenes and 30 eval episodes.

## Risk

Low for code/docs. The actual evaluation remains a cluster/runtime task and still needs result artifacts before the Linear issue can be completed.

## What was intentionally not done

- Did not commit the generated full curriculum JSON; the generator creates it reproducibly from local HM3D data.
- Did not run the long model/baseline held-out evaluations yet.
- Did not update thesis text yet because results are not available.

## Agent involvement

Implemented by Codex.

## Follow-up issues created

None.