### PR TITLE
3D-35: metrics & logging overhaul (val-episode-loop, SoftSPL/DTG, collision_rate, per-cat SPL)

### DIFF
--- a/scripts/verify_3d_35_metrics.sbatch
+++ b/scripts/verify_3d_35_metrics.sbatch
@@ -1,0 +1,74 @@
+#!/bin/bash
+#SBATCH --job-name=3d-35-verify-metrics
+#SBATCH --partition=dev_gpu_h100
+#SBATCH --gres=gpu:1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=64G
+#SBATCH --time=00:28:00
+#SBATCH --output=output/verify-3d-35/slurm-%j.log
+#SBATCH --error=output/verify-3d-35/slurm-%j.log
+
+# Verification run for the 3D-35 metrics overhaul. Dev-sized CNN + L1
+# training on dev_gpu_h100 (30-min cap) that fires the new Val-Episode-Loop
+# ~3 times (val_every=5k) so every new metric shows up in W&B during the
+# run, not just at the end:
+#   val/metrics/sr,spl,softspl,dtg,collision_rate,reward
+#   val/goal/{chair,bed,plant,sofa,toilet,tv_monitor}/{sr,spl,reward}
+#   val/episode/{softspl,dtg,collision_rate}
+#   val/episode_video           (deterministic playback)
+# And confirms removal of the old offline val_loss keys (no val/total_loss,
+# no val/loss/*).
+#
+# Submit from the project root:
+#   sbatch scripts/verify_3d_35_metrics.sbatch
+#
+# When the run starts, watch the W&B dashboard the SLURM stdout prints.
+
+set -euo pipefail
+
+# Run from wherever sbatch was submitted so worktrees + main checkout both work.
+cd "${SLURM_SUBMIT_DIR:-$(pwd)}"
+mkdir -p output/verify-3d-35
+
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+TAG="verify-3d-35"
+RUN_NAME="${TAG}-cnn-l1-${TIMESTAMP}"
+
+echo "=== 3D-35 metrics-overhaul verification (15k steps, CNN, L1, val every 5k, dev_gpu_h100) ==="
+echo "Node:    $(hostname)"
+echo "GPU:     $(nvidia-smi --query-gpu=name --format=csv,noheader)"
+echo "Date:    $(date)"
+echo "Branch:  $(git branch --show-current)"
+echo "Commit:  $(git rev-parse --short HEAD)"
+echo "Dirty:   $(git status --porcelain | wc -l) files"
+echo "Run:     ${RUN_NAME}"
+echo ""
+
+uv run python -m src.main train \
+    --env habitat \
+    --encoder cnn \
+    --curriculum L1 \
+    --steps 15000 \
+    --prefill 2000 \
+    --seed 0 \
+    --log_every 250 \
+    --checkpoint_every 5000 \
+    --val_every 5000 \
+    --val_episodes 10 \
+    --val_video_episodes 1 \
+    --val_max_episode_steps 300 \
+    --act_entropy 3e-2 \
+    --output_dir "output/verify-3d-35/${RUN_NAME}" \
+    --wandb_name "${RUN_NAME}" \
+    --wandb_tags "3D-35,metrics-overhaul,verify,cnn,L1"
+
+echo ""
+echo "=== Done at $(date) ==="
+echo ""
+echo "Verify in W&B:"
+echo "  - val/metrics/{sr,spl,softspl,dtg,collision_rate,reward} at steps 5k/10k/15k"
+echo "  - val/goal/*/spl and val/goal/*/sr"
+echo "  - val/episode_video (3 deterministic videos, same scene across runs)"
+echo "  - NO val/total_loss, NO val/loss/* keys (3D-37 removed them)"
+echo "  - NO kl_prior / kl_post duplicates (3D-42 — already absent in current code)"

--- a/src/environments/habitat.py
+++ b/src/environments/habitat.py
@@ -224,20 +224,6 @@ class HabitatObjectNavEnv:
             done = self._step_count >= self._cfg.max_episode_steps
             # If the timeout fires on STOP, the agent ended at _prev_dist
             # with the current path_length — surface SoftSPL/DTG accordingly.
-            shortest = self._start_geodesic
-            length_ratio = (
-                shortest / max(shortest, self._path_length)
-                if shortest > 0 else 0.0
-            )
-            softspl = 0.0
-            dtg = 0.0
-            collision_rate = 0.0
-            if done:
-                dist = self._prev_dist
-                if shortest > 0:
-                    softspl = max(0.0, 1.0 - dist / shortest) * length_ratio
-                dtg = dist
-                collision_rate = self._compute_collision_rate()
             return {
                 "image": image,
                 "reward": self._cfg.step_penalty,
@@ -245,9 +231,7 @@ class HabitatObjectNavEnv:
                 "is_first": False,
                 "success": 0.0,
                 "spl": 0.0,
-                "softspl": softspl,
-                "dtg": dtg,
-                "collision_rate": collision_rate,
+                **self._episode_end_metrics(self._prev_dist, done),
             }
 
         obs = self._env.step(action=action)
@@ -275,26 +259,7 @@ class HabitatObjectNavEnv:
         success = 1.0 if _is_success_distance(dist) else 0.0
         done = success > 0 or self._step_count >= self._cfg.max_episode_steps
 
-        shortest = self._start_geodesic
-        length_ratio = shortest / max(shortest, self._path_length) if shortest > 0 else 0.0
-
-        spl = 0.0
-        if done and success > 0:
-            spl = length_ratio
-
-        # SoftSPL: progress toward goal × path-length efficiency (habitat-lab convention,
-        # progress clipped at 0 so moving away from the goal floors SoftSPL at 0, not below).
-        # Computed every step but only meaningful at episode end (when path_length is final).
-        softspl = 0.0
-        if done and shortest > 0:
-            progress = max(0.0, 1.0 - dist / shortest)
-            softspl = progress * length_ratio
-
-        # DTG: distance-to-goal at episode end (absolute, complements SoftSPL).
-        dtg = dist if done else 0.0
-
-        # collision_rate is a per-episode ratio, only meaningful at episode end
-        collision_rate = self._compute_collision_rate() if done else 0.0
+        spl = self._length_ratio() if (done and success > 0) else 0.0
 
         image = self._obs_to_image(obs)
 
@@ -305,9 +270,27 @@ class HabitatObjectNavEnv:
             "is_first": False,
             "success": success,
             "spl": spl,
-            "softspl": softspl,
-            "dtg": dtg,
-            "collision_rate": collision_rate,
+            **self._episode_end_metrics(dist, done),
+        }
+
+    def _length_ratio(self) -> float:
+        """shortest_geodesic / max(shortest_geodesic, path_length). 0 if degenerate."""
+        shortest = self._start_geodesic
+        if shortest <= 0:
+            return 0.0
+        return shortest / max(shortest, self._path_length)
+
+    def _episode_end_metrics(self, dist: float, done: bool) -> dict[str, float]:
+        """SoftSPL / DTG / collision_rate. Zero mid-episode; only meaningful at done."""
+        if not done:
+            return {"softspl": 0.0, "dtg": 0.0, "collision_rate": 0.0}
+        shortest = self._start_geodesic
+        # Progress clipped at 0 — moving away from the goal floors SoftSPL at 0.
+        progress = max(0.0, 1.0 - dist / shortest) if shortest > 0 else 0.0
+        return {
+            "softspl": progress * self._length_ratio(),
+            "dtg": dist,
+            "collision_rate": self._compute_collision_rate(),
         }
 
     def _compute_collision_rate(self) -> float:

--- a/src/environments/habitat.py
+++ b/src/environments/habitat.py
@@ -200,6 +200,8 @@ class HabitatObjectNavEnv:
         self._start_geodesic = 0.0
         self._path_length = 0.0
         self._prev_position = None
+        self._collisions = 0
+        self._forward_steps = 0
 
     def reset(self) -> dict:
         obs = self._env.reset()
@@ -208,6 +210,8 @@ class HabitatObjectNavEnv:
         self._prev_position = np.array(self._env.sim.get_agent_state().position)
         self._path_length = 0.0
         self._step_count = 0
+        self._collisions = 0
+        self._forward_steps = 0
         image = self._obs_to_image(obs)
         self._last_obs = obs
         return {"image": image, "is_first": True, "reward": 0.0, "done": False}
@@ -227,11 +231,13 @@ class HabitatObjectNavEnv:
             )
             softspl = 0.0
             dtg = 0.0
+            collision_rate = 0.0
             if done:
                 dist = self._prev_dist
                 if shortest > 0:
                     softspl = max(0.0, 1.0 - dist / shortest) * length_ratio
                 dtg = dist
+                collision_rate = self._compute_collision_rate()
             return {
                 "image": image,
                 "reward": self._cfg.step_penalty,
@@ -241,6 +247,7 @@ class HabitatObjectNavEnv:
                 "spl": 0.0,
                 "softspl": softspl,
                 "dtg": dtg,
+                "collision_rate": collision_rate,
             }
 
         obs = self._env.step(action=action)
@@ -249,7 +256,18 @@ class HabitatObjectNavEnv:
         metrics = self._env.get_metrics()
 
         current_position = np.array(self._env.sim.get_agent_state().position)
-        self._path_length += np.linalg.norm(current_position - self._prev_position)
+        delta = float(np.linalg.norm(current_position - self._prev_position))
+        self._path_length += delta
+        # Habitat has no direct collision API. Workaround: a FORWARD step that
+        # moves the agent < 0.01 m is treated as a collision. Nominal forward
+        # step is 0.25 m, so genuine motion is ~25x above the threshold; this
+        # leaves headroom for sliding along walls without false positives.
+        # TURN_LEFT/TURN_RIGHT rotate without translating, so only action == 1
+        # counts toward forward_steps.
+        if action == 1:
+            self._forward_steps += 1
+            if delta < 0.01:
+                self._collisions += 1
         self._prev_position = current_position
 
         dist = _validate_goal_distance(metrics.get("distance_to_goal", float("inf")))
@@ -275,6 +293,9 @@ class HabitatObjectNavEnv:
         # DTG: distance-to-goal at episode end (absolute, complements SoftSPL).
         dtg = dist if done else 0.0
 
+        # collision_rate is a per-episode ratio, only meaningful at episode end
+        collision_rate = self._compute_collision_rate() if done else 0.0
+
         image = self._obs_to_image(obs)
 
         return {
@@ -286,7 +307,13 @@ class HabitatObjectNavEnv:
             "spl": spl,
             "softspl": softspl,
             "dtg": dtg,
+            "collision_rate": collision_rate,
         }
+
+    def _compute_collision_rate(self) -> float:
+        if self._forward_steps <= 0:
+            return 0.0
+        return self._collisions / self._forward_steps
 
     def find_nearest_viewpoint(self):
         """Find nearest viewpoint. Delegates to module-level function."""

--- a/src/environments/habitat.py
+++ b/src/environments/habitat.py
@@ -218,6 +218,20 @@ class HabitatObjectNavEnv:
             self._step_count += 1
             image = self._obs_to_image(self._last_obs)
             done = self._step_count >= self._cfg.max_episode_steps
+            # If the timeout fires on STOP, the agent ended at _prev_dist
+            # with the current path_length — surface SoftSPL/DTG accordingly.
+            shortest = self._start_geodesic
+            length_ratio = (
+                shortest / max(shortest, self._path_length)
+                if shortest > 0 else 0.0
+            )
+            softspl = 0.0
+            dtg = 0.0
+            if done:
+                dist = self._prev_dist
+                if shortest > 0:
+                    softspl = max(0.0, 1.0 - dist / shortest) * length_ratio
+                dtg = dist
             return {
                 "image": image,
                 "reward": self._cfg.step_penalty,
@@ -225,6 +239,8 @@ class HabitatObjectNavEnv:
                 "is_first": False,
                 "success": 0.0,
                 "spl": 0.0,
+                "softspl": softspl,
+                "dtg": dtg,
             }
 
         obs = self._env.step(action=action)
@@ -241,10 +257,23 @@ class HabitatObjectNavEnv:
         success = 1.0 if _is_success_distance(dist) else 0.0
         done = success > 0 or self._step_count >= self._cfg.max_episode_steps
 
+        shortest = self._start_geodesic
+        length_ratio = shortest / max(shortest, self._path_length) if shortest > 0 else 0.0
+
         spl = 0.0
         if done and success > 0:
-            shortest = self._start_geodesic
-            spl = shortest / max(shortest, self._path_length) if shortest > 0 else 0.0
+            spl = length_ratio
+
+        # SoftSPL: progress toward goal × path-length efficiency (habitat-lab convention,
+        # progress clipped at 0 so moving away from the goal floors SoftSPL at 0, not below).
+        # Computed every step but only meaningful at episode end (when path_length is final).
+        softspl = 0.0
+        if done and shortest > 0:
+            progress = max(0.0, 1.0 - dist / shortest)
+            softspl = progress * length_ratio
+
+        # DTG: distance-to-goal at episode end (absolute, complements SoftSPL).
+        dtg = dist if done else 0.0
 
         image = self._obs_to_image(obs)
 
@@ -255,6 +284,8 @@ class HabitatObjectNavEnv:
             "is_first": False,
             "success": success,
             "spl": spl,
+            "softspl": softspl,
+            "dtg": dtg,
         }
 
     def find_nearest_viewpoint(self):

--- a/src/r2dreamer/agent.py
+++ b/src/r2dreamer/agent.py
@@ -208,7 +208,6 @@ class R2DreamerAgent:
 
         # ---- JIT-compiled functions ----
         self._jit_train_step = jax.jit(self._train_step)
-        self._jit_eval_loss = jax.jit(self._eval_loss_fn)
         self._jit_act = jax.jit(self._act_jit)
 
     # ------------------------------------------------------------------
@@ -345,25 +344,6 @@ class R2DreamerAgent:
         metrics["total_loss"] = total_loss
         metrics["nan_skipped"] = 1.0 - is_finite.astype(jnp.float32)
         return new_params, new_opt_state, new_slow, new_ema_state, metrics
-
-    def eval_loss(self, batch: Dict[str, jnp.ndarray], rng_key: jnp.ndarray) -> Dict[str, float]:
-        """Forward-only loss for validation. Same metrics as `train_step`."""
-        metrics = self._jit_eval_loss(
-            self.params, self.slow_critic_params, self.ema_state, batch, rng_key,
-        )
-        return {k: float(v) for k, v in metrics.items()}
-
-    def _eval_loss_fn(self, params, slow_critic_params, ema_state, batch, rng_key):
-        total_loss, aux = self._loss_fn(
-            params,
-            slow_critic_params=slow_critic_params,
-            ema_state=ema_state,
-            batch=batch,
-            rng_key=rng_key,
-        )
-        metrics = aux["metrics"]
-        metrics["total_loss"] = total_loss
-        return metrics
 
     # ------------------------------------------------------------------
     # Composition root: shared forward + 3 sub-losses

--- a/src/r2dreamer/launch/parser.py
+++ b/src/r2dreamer/launch/parser.py
@@ -24,6 +24,16 @@ def _build_parser_train() -> argparse.ArgumentParser:
                    help="Render resolution for VGGT encoder")
     p.add_argument("--val_data", type=str, default=None)
     p.add_argument("--val_loss_every", type=int, default=10_000)
+    # Val-Episode-Loop (3D-36). 0 disables. Default 50_000 matches the
+    # checkpoint cadence so val signals land alongside checkpoints.
+    p.add_argument("--val_every", type=int, default=50_000,
+                   help="Run a deterministic val-episode loop every N steps (0 disables)")
+    p.add_argument("--val_episodes", type=int, default=50,
+                   help="Episodes per val-loop trigger")
+    p.add_argument("--val_video_episodes", type=int, default=1,
+                   help="Number of val episodes to record as W&B videos per trigger")
+    p.add_argument("--val_max_episode_steps", type=int, default=500,
+                   help="Per-episode step cap inside the val loop")
     p.add_argument("--resume_from", type=str, default=None)
     p.add_argument("--wandb_id", type=str, default=None,
                    help="W&B run-id to reattach to (resume='must')")

--- a/src/r2dreamer/launch/parser.py
+++ b/src/r2dreamer/launch/parser.py
@@ -22,8 +22,6 @@ def _build_parser_train() -> argparse.ArgumentParser:
     p.add_argument("--curriculum_mode", type=str, default="train")
     p.add_argument("--render_resolution", type=int, default=518,
                    help="Render resolution for VGGT encoder")
-    p.add_argument("--val_data", type=str, default=None)
-    p.add_argument("--val_loss_every", type=int, default=10_000)
     # Val-Episode-Loop (3D-36). 0 disables. Default 50_000 matches the
     # checkpoint cadence so val signals land alongside checkpoints.
     p.add_argument("--val_every", type=int, default=50_000,

--- a/src/r2dreamer/launch/train.py
+++ b/src/r2dreamer/launch/train.py
@@ -158,8 +158,6 @@ def train(
         wandb_id=args.wandb_id,
         video_log_every=args.video_log_every,
         video_log_episodes=args.video_log_episodes,
-        val_data=args.val_data,
-        val_loss_every=args.val_loss_every,
         val_every=args.val_every,
         val_episodes=args.val_episodes,
         val_video_episodes=args.val_video_episodes,

--- a/src/r2dreamer/launch/train.py
+++ b/src/r2dreamer/launch/train.py
@@ -85,6 +85,7 @@ def train(
 
     # --- Build env ---
     env_fn = env_registry[env]
+    val_env_instance = None
     if env == "habitat":
         env_instance = env_fn(
             curriculum_path=curriculum_path,
@@ -92,6 +93,15 @@ def train(
             seed=args.seed,
             render_resolution=encoder_spec.env_render_resolution,
         )
+        # Val env: same curriculum JSON, eval-key set. Skip when val is off
+        # or the user is in train-of-train mode (curriculum_mode != "train").
+        if args.val_every > 0 and args.curriculum_mode == "train":
+            val_env_instance = env_fn(
+                curriculum_path=curriculum_path,
+                curriculum_mode="eval",
+                seed=args.seed,
+                render_resolution=encoder_spec.env_render_resolution,
+            )
         num_actions = 4
     else:
         env_instance = env_fn(seed=args.seed)
@@ -150,6 +160,10 @@ def train(
         video_log_episodes=args.video_log_episodes,
         val_data=args.val_data,
         val_loss_every=args.val_loss_every,
+        val_every=args.val_every,
+        val_episodes=args.val_episodes,
+        val_video_episodes=args.val_video_episodes,
+        val_max_episode_steps=args.val_max_episode_steps,
         resume_from=args.resume_from,
         overfit_one_batch=args.overfit_one_batch,
         overfit_steps=args.overfit_steps,
@@ -161,6 +175,18 @@ def train(
     # --- Build trainer ---
     if env == "habitat":
         hab = habitat_defaults(env_instance)
+        val_kwargs: dict[str, object] = {}
+        if val_env_instance is not None:
+            # Val-Episode-Loop (3D-36) wiring: own adapter so the train
+            # VGGT video buffer isn't disturbed; own tracker so val
+            # rolling means stay independent of train rollouts.
+            val_adapter = enc.make_adapter()
+            val_hab = habitat_defaults(val_env_instance, track_collision_rate=True)
+            val_kwargs = {
+                "val_env": val_env_instance,
+                "val_obs_adapter": val_adapter,
+                "val_episode_metrics_fn": val_hab["episode_metrics_fn"],
+            }
         trainer = Trainer(
             agent=agent,
             env=env_instance,
@@ -168,6 +194,7 @@ def train(
             trainer_config=trainer_config,
             obs_adapter=adapter,
             episode_metrics_fn=hab["episode_metrics_fn"],
+            **val_kwargs,
         )
     else:
         trainer = Trainer(

--- a/src/r2dreamer/trainer.py
+++ b/src/r2dreamer/trainer.py
@@ -657,10 +657,12 @@ class Trainer:
     def _run_val_loop(
         self, rng_key: jnp.ndarray, step: int, writer: Any, f: Any,
     ) -> None:
-        """Deterministic Val-Episode-Loop (3D-36).
+        """Deterministic Val-Episode-Loop (3D-36) + video recording (3D-41).
 
         Runs `val_episodes` greedy rollouts in the pinned eval env and logs
-        rolling val/* metrics. Video recording is handled by 3D-41.
+        rolling val/* metrics. The first val_video_episodes are captured
+        as W&B videos (deterministic playback — same scene across runs
+        because the eval episode order is pinned by the curriculum JSON).
         """
         tcfg = self.tcfg
         if (self.val_env is None or self.val_obs_adapter is None
@@ -669,6 +671,7 @@ class Trainer:
 
         val_adapter = self.val_obs_adapter
         last_val_metrics: dict[str, Any] = {}
+        videos_recorded = 0
         val_t0 = time.time()
 
         for ep_idx in range(tcfg.val_episodes):
@@ -681,6 +684,10 @@ class Trainer:
             episode_steps = 0
             action_counts = np.zeros(self.acfg.num_actions, dtype=int)
 
+            recording = None
+            if videos_recorded < tcfg.val_video_episodes and self._wandb is not None:
+                recording = self._start_val_video_recording(obs)
+
             for _ in range(tcfg.val_max_episode_steps):
                 rng_key, act_key = jax.random.split(rng_key)
                 action = self.agent.act(agent_obs, act_key, training=False)
@@ -690,6 +697,8 @@ class Trainer:
                 action_counts[action] += 1
                 episode_reward += next_obs["reward"]
                 episode_steps += 1
+                if recording is not None:
+                    self._append_val_video_frame(recording, next_obs)
 
                 if next_obs["done"]:
                     obs = next_obs
@@ -700,6 +709,12 @@ class Trainer:
             last_val_metrics = self.val_episode_metrics_fn(
                 self.val_env, obs, episode_reward, episode_steps, action_counts,
             )
+            if recording is not None:
+                log_episode_video(
+                    self._wandb, "val/episode_video",
+                    recording["frames"], step,
+                )
+                videos_recorded += 1
 
         # Prefix the final episode's tracker snapshot with `val/`. The
         # rolling-mean fields already reflect the whole val loop (since the
@@ -728,4 +743,41 @@ class Trainer:
             f"sr={sr_str} spl={spl_str} softspl={soft_str} dtg={dtg_str}m "
             f"({tcfg.val_episodes} eps in {elapsed:.1f}s)"
         )
+
+    # ------------------------------------------------------------------
+    # Val-episode video helpers (3D-41) — mirror the train video helpers
+    # but bound to self.val_env so the train env isn't disturbed.
+    # ------------------------------------------------------------------
+
+    def _start_val_video_recording(self, obs: dict) -> dict[str, Any]:
+        recording = {
+            "trajectory": [self._val_agent_position()],
+            "goals": self._val_goal_positions(),
+            "frames": [],
+        }
+        self._append_val_video_frame(recording, obs)
+        return recording
+
+    def _append_val_video_frame(self, recording: dict[str, Any], obs: dict) -> None:
+        if "image" not in obs:
+            return
+        if recording["frames"]:
+            recording["trajectory"].append(self._val_agent_position())
+        topdown = render_topdown_frame(
+            self.val_env, recording["trajectory"], recording["goals"])
+        recording["frames"].append(compose_frame(obs["image"], topdown))
+
+    def _val_goal_positions(self) -> list[list[float]]:
+        positions = []
+        for goal in self.val_env._env.current_episode.goals:
+            if goal.view_points:
+                pos = goal.view_points[0].agent_state.position
+            else:
+                pos = goal.position
+            positions.append(pos.tolist() if hasattr(pos, "tolist") else list(pos))
+        return positions
+
+    def _val_agent_position(self) -> list[float]:
+        pos = self.val_env._env.sim.get_agent_state().position
+        return pos.tolist() if hasattr(pos, "tolist") else list(pos)
 

--- a/src/r2dreamer/trainer.py
+++ b/src/r2dreamer/trainer.py
@@ -156,6 +156,7 @@ def habitat_defaults(env: Any) -> dict[str, Any]:
         spl = last_obs.get("spl", 0.0)
         softspl = last_obs.get("softspl", 0.0)
         dtg = last_obs.get("dtg", 0.0)
+        collision_rate = last_obs.get("collision_rate", 0.0)
         category = getattr(env._env.current_episode, "object_category", "unknown")
         scene_raw = getattr(env._env.current_episode, "scene_id", "")
         path_length = env._path_length
@@ -165,7 +166,7 @@ def habitat_defaults(env: Any) -> dict[str, Any]:
         tracked = tracker.record(
             reward=episode_reward, success=success, spl=spl,
             category=category, scene_id=scene_raw,
-            softspl=softspl, dtg=dtg,
+            softspl=softspl, dtg=dtg, collision_rate=collision_rate,
         )
 
         action_pcts = action_counts / max(episode_steps, 1)

--- a/src/r2dreamer/trainer.py
+++ b/src/r2dreamer/trainer.py
@@ -154,6 +154,8 @@ def habitat_defaults(env: Any) -> dict[str, Any]:
     ) -> dict[str, Any]:
         success = last_obs.get("success", 0.0)
         spl = last_obs.get("spl", 0.0)
+        softspl = last_obs.get("softspl", 0.0)
+        dtg = last_obs.get("dtg", 0.0)
         category = getattr(env._env.current_episode, "object_category", "unknown")
         scene_raw = getattr(env._env.current_episode, "scene_id", "")
         path_length = env._path_length
@@ -163,6 +165,7 @@ def habitat_defaults(env: Any) -> dict[str, Any]:
         tracked = tracker.record(
             reward=episode_reward, success=success, spl=spl,
             category=category, scene_id=scene_raw,
+            softspl=softspl, dtg=dtg,
         )
 
         action_pcts = action_counts / max(episode_steps, 1)

--- a/src/r2dreamer/trainer.py
+++ b/src/r2dreamer/trainer.py
@@ -111,12 +111,8 @@ class TrainerConfig:
     video_log_every: int = 25_000
     video_log_episodes: int = 1
 
-    # Validation (None = disabled)
-    val_data: str | None = None
-    val_loss_every: int = 10_000
-
-    # Deterministic Val-Episode-Loop (separate from offline val_loss above).
-    # val_every=0 disables. Requires a val_env to be passed to Trainer.
+    # Deterministic Val-Episode-Loop. val_every=0 disables. Requires a
+    # val_env to be passed to Trainer.
     val_every: int = 50_000
     val_episodes: int = 50
     val_video_episodes: int = 1
@@ -283,15 +279,6 @@ class Trainer:
                 init_kwargs.update(id=trainer_config.wandb_id, resume="must")
             wandb.init(**init_kwargs)
 
-        # Optional val dataset
-        self._val_dataset = None
-        if trainer_config.val_data is not None:
-            from src.buffer.replay_buffer import ValReplayDataset
-            self._val_dataset = ValReplayDataset(
-                trainer_config.val_data,
-                normalize=self.obs_adapter.normalize_on_sample,
-            )
-
     def run(self) -> None:
         """Execute full training run: prefill + train loop + final checkpoint."""
         tcfg, acfg = self.tcfg, self.acfg
@@ -452,12 +439,6 @@ class Trainer:
 
                 if step % tcfg.log_every == 0 and metrics:
                     self._log_train_metrics(metrics, step, writer, f)
-
-            # --- Val loss ---
-            if (self._val_dataset is not None
-                    and (step + 1) % tcfg.val_loss_every == 0):
-                rng_key, val_key = jax.random.split(rng_key)
-                self._log_val_loss(val_key, step, writer, f)
 
             # --- Val-Episode-Loop (3D-36): deterministic held-out rollouts ---
             if (self.val_env is not None
@@ -632,26 +613,6 @@ class Trainer:
             f"rew={metrics.get('loss/rew', 0):.3f} "
             f"policy={metrics.get('loss/policy', 0):.3f} "
             f"fps={fps:.0f}"
-        )
-
-    def _log_val_loss(
-        self, val_key: jnp.ndarray, step: int, writer: Any, f: Any,
-    ) -> None:
-        val_batch = self._val_dataset.sample(
-            self.acfg.batch_size, self.acfg.seq_len)
-        val_batch = convert_batch(val_batch, self.acfg.num_actions)
-        val_metrics = self.agent.eval_loss(val_batch, val_key)
-        val_logged = {f"val/{k}": v for k, v in val_metrics.items()}
-        for k, v in val_logged.items():
-            writer.writerow([step, k, v])
-        f.flush()
-        if self._wandb is not None:
-            self._wandb.log(val_logged, step=step)
-        print(
-            f"[step {step:>8d}] VAL: "
-            f"total={val_logged.get('val/total_loss', 0):.3f} "
-            f"dyn={val_logged.get('val/loss/dyn', 0):.3f} "
-            f"rew={val_logged.get('val/loss/rew', 0):.3f}"
         )
 
     def _run_val_loop(

--- a/src/r2dreamer/trainer.py
+++ b/src/r2dreamer/trainer.py
@@ -115,6 +115,13 @@ class TrainerConfig:
     val_data: str | None = None
     val_loss_every: int = 10_000
 
+    # Deterministic Val-Episode-Loop (separate from offline val_loss above).
+    # val_every=0 disables. Requires a val_env to be passed to Trainer.
+    val_every: int = 50_000
+    val_episodes: int = 50
+    val_video_episodes: int = 1
+    val_max_episode_steps: int = 500
+
     # Resume from checkpoint (.pkl produced by save_checkpoint). When set,
     # restores agent.{params, opt_state, slow_critic_params, ema_state} and
     # offsets the train loop to start at the checkpoint's step.
@@ -139,13 +146,16 @@ class TrainerConfig:
 EpisodeMetricsFn = Callable[..., dict[str, Any]]
 
 
-def habitat_defaults(env: Any) -> dict[str, Any]:
+def habitat_defaults(env: Any, *, track_collision_rate: bool = False) -> dict[str, Any]:
     """Pre-configured ObsAdapter and episode_metrics_fn for Habitat+CNN.
 
     Returns dict with keys "obs_adapter" and "episode_metrics_fn".
+
+    Pass track_collision_rate=True for the val-loop tracker; train rollouts
+    leave it False so the dashboard isn't doubly-noisy.
     """
     from src.shared.wandb_utils import EpisodeTracker
-    tracker = EpisodeTracker(window=100)
+    tracker = EpisodeTracker(window=100, track_collision_rate=track_collision_rate)
     action_names = {0: "stop", 1: "forward", 2: "left", 3: "right"}
 
     def episode_metrics_fn(
@@ -212,6 +222,9 @@ class Trainer:
         trainer_config: TrainerConfig,
         obs_adapter: ObsAdapter | None = None,
         episode_metrics_fn: EpisodeMetricsFn | None = None,
+        val_env: Env | None = None,
+        val_obs_adapter: ObsAdapter | None = None,
+        val_episode_metrics_fn: EpisodeMetricsFn | None = None,
     ) -> None:
         self.agent = agent
         self.env = env
@@ -219,6 +232,11 @@ class Trainer:
         self.tcfg = trainer_config
         self.obs_adapter = obs_adapter or ObsAdapter()
         self.episode_metrics_fn = episode_metrics_fn
+        # Val-Episode-Loop wiring (3D-36). All three must be non-None for the
+        # loop to run; the launcher constructs them together when val is on.
+        self.val_env = val_env
+        self.val_obs_adapter = val_obs_adapter
+        self.val_episode_metrics_fn = val_episode_metrics_fn
 
         # Build buffer from adapter settings
         self.buffer = ReplayBuffer(BufferConfig(
@@ -319,6 +337,8 @@ class Trainer:
             if self._wandb is not None:
                 self._wandb.finish()
             self.env.close()
+            if self.val_env is not None:
+                self.val_env.close()
 
     # ------------------------------------------------------------------
     # Prefill
@@ -438,6 +458,13 @@ class Trainer:
                     and (step + 1) % tcfg.val_loss_every == 0):
                 rng_key, val_key = jax.random.split(rng_key)
                 self._log_val_loss(val_key, step, writer, f)
+
+            # --- Val-Episode-Loop (3D-36): deterministic held-out rollouts ---
+            if (self.val_env is not None
+                    and tcfg.val_every > 0
+                    and (step + 1) % tcfg.val_every == 0):
+                rng_key, val_key = jax.random.split(rng_key)
+                self._run_val_loop(val_key, step, writer, f)
 
             # --- Checkpoint ---
             if (step + 1) % tcfg.checkpoint_every == 0:
@@ -626,3 +653,79 @@ class Trainer:
             f"dyn={val_logged.get('val/loss/dyn', 0):.3f} "
             f"rew={val_logged.get('val/loss/rew', 0):.3f}"
         )
+
+    def _run_val_loop(
+        self, rng_key: jnp.ndarray, step: int, writer: Any, f: Any,
+    ) -> None:
+        """Deterministic Val-Episode-Loop (3D-36).
+
+        Runs `val_episodes` greedy rollouts in the pinned eval env and logs
+        rolling val/* metrics. Video recording is handled by 3D-41.
+        """
+        tcfg = self.tcfg
+        if (self.val_env is None or self.val_obs_adapter is None
+                or self.val_episode_metrics_fn is None):
+            return
+
+        val_adapter = self.val_obs_adapter
+        last_val_metrics: dict[str, Any] = {}
+        val_t0 = time.time()
+
+        for ep_idx in range(tcfg.val_episodes):
+            obs = self.val_env.reset()
+            if val_adapter.on_episode_reset:
+                val_adapter.on_episode_reset()
+            _, agent_obs = val_adapter.transform(obs)
+
+            episode_reward = 0.0
+            episode_steps = 0
+            action_counts = np.zeros(self.acfg.num_actions, dtype=int)
+
+            for _ in range(tcfg.val_max_episode_steps):
+                rng_key, act_key = jax.random.split(rng_key)
+                action = self.agent.act(agent_obs, act_key, training=False)
+                next_obs = self.val_env.step(action)
+                _, next_agent_obs = val_adapter.transform(next_obs)
+
+                action_counts[action] += 1
+                episode_reward += next_obs["reward"]
+                episode_steps += 1
+
+                if next_obs["done"]:
+                    obs = next_obs
+                    break
+                obs = next_obs
+                agent_obs = next_agent_obs
+
+            last_val_metrics = self.val_episode_metrics_fn(
+                self.val_env, obs, episode_reward, episode_steps, action_counts,
+            )
+
+        # Prefix the final episode's tracker snapshot with `val/`. The
+        # rolling-mean fields already reflect the whole val loop (since the
+        # tracker is shared across episodes within this run).
+        val_logged = {
+            f"val/{k}" if not k.startswith("val/") else k: v
+            for k, v in last_val_metrics.items()
+        }
+        for k, v in val_logged.items():
+            writer.writerow([step, k, v])
+        f.flush()
+        if self._wandb is not None:
+            self._wandb.log(val_logged, step=step)
+
+        elapsed = time.time() - val_t0
+        sr = val_logged.get("val/metrics/sr", 0.0)
+        spl = val_logged.get("val/metrics/spl", 0.0)
+        softspl = val_logged.get("val/metrics/softspl", 0.0)
+        dtg = val_logged.get("val/metrics/dtg", 0.0)
+        sr_str = f"{sr:.3f}" if isinstance(sr, float) else str(sr)
+        spl_str = f"{spl:.3f}" if isinstance(spl, float) else str(spl)
+        soft_str = f"{softspl:.3f}" if isinstance(softspl, float) else str(softspl)
+        dtg_str = f"{dtg:.3f}" if isinstance(dtg, float) else str(dtg)
+        print(
+            f"[step {step:>8d}] VAL-LOOP "
+            f"sr={sr_str} spl={spl_str} softspl={soft_str} dtg={dtg_str}m "
+            f"({tcfg.val_episodes} eps in {elapsed:.1f}s)"
+        )
+

--- a/src/r2dreamer/trainer.py
+++ b/src/r2dreamer/trainer.py
@@ -381,7 +381,7 @@ class Trainer:
         train_credit = 0.0
         metrics: dict[str, Any] = {}
         video_next_step = start_step
-        video_recording = self._start_video_recording(obs) if self._should_record_video(start_step, video_next_step) else None
+        video_recording = self._start_video_recording(self.env, obs) if self._should_record_video(start_step, video_next_step) else None
 
         for step in range(start_step, tcfg.total_steps):
             rng_key, act_key = jax.random.split(rng_key)
@@ -396,7 +396,7 @@ class Trainer:
             episode_reward += next_obs["reward"]
             episode_steps += 1
             if video_recording is not None:
-                self._append_video_frame(video_recording, next_obs)
+                self._append_video_frame(self.env, video_recording, next_obs)
 
             if next_obs["done"]:
                 episode_count += 1
@@ -421,7 +421,7 @@ class Trainer:
                     self.obs_adapter.on_episode_reset()
                 buffer_obs, agent_obs = self.obs_adapter.transform(obs)
                 if self._should_record_video(step + 1, video_next_step):
-                    video_recording = self._start_video_recording(obs)
+                    video_recording = self._start_video_recording(self.env, obs)
             else:
                 obs = next_obs
                 buffer_obs = next_buffer_obs
@@ -462,9 +462,9 @@ class Trainer:
             and hasattr(self.env, "_env")
         )
 
-    def _goal_positions(self) -> list[list[float]]:
+    def _goal_positions(self, env: Env) -> list[list[float]]:
         positions = []
-        for goal in self.env._env.current_episode.goals:
+        for goal in env._env.current_episode.goals:
             if goal.view_points:
                 pos = goal.view_points[0].agent_state.position
             else:
@@ -472,26 +472,26 @@ class Trainer:
             positions.append(pos.tolist() if hasattr(pos, "tolist") else list(pos))
         return positions
 
-    def _agent_position(self) -> list[float]:
-        pos = self.env._env.sim.get_agent_state().position
+    def _agent_position(self, env: Env) -> list[float]:
+        pos = env._env.sim.get_agent_state().position
         return pos.tolist() if hasattr(pos, "tolist") else list(pos)
 
-    def _start_video_recording(self, obs: dict) -> dict[str, Any]:
+    def _start_video_recording(self, env: Env, obs: dict) -> dict[str, Any]:
         recording = {
-            "trajectory": [self._agent_position()],
-            "goals": self._goal_positions(),
+            "trajectory": [self._agent_position(env)],
+            "goals": self._goal_positions(env),
             "frames": [],
         }
-        self._append_video_frame(recording, obs)
+        self._append_video_frame(env, recording, obs)
         return recording
 
-    def _append_video_frame(self, recording: dict[str, Any], obs: dict) -> None:
+    def _append_video_frame(self, env: Env, recording: dict[str, Any], obs: dict) -> None:
         if "image" not in obs:
             return
         if recording["frames"]:
-            recording["trajectory"].append(self._agent_position())
+            recording["trajectory"].append(self._agent_position(env))
         topdown = render_topdown_frame(
-            self.env, recording["trajectory"], recording["goals"])
+            env, recording["trajectory"], recording["goals"])
         recording["frames"].append(compose_frame(obs["image"], topdown))
 
     # ------------------------------------------------------------------
@@ -647,7 +647,7 @@ class Trainer:
 
             recording = None
             if videos_recorded < tcfg.val_video_episodes and self._wandb is not None:
-                recording = self._start_val_video_recording(obs)
+                recording = self._start_video_recording(self.val_env, obs)
 
             for _ in range(tcfg.val_max_episode_steps):
                 rng_key, act_key = jax.random.split(rng_key)
@@ -659,7 +659,7 @@ class Trainer:
                 episode_reward += next_obs["reward"]
                 episode_steps += 1
                 if recording is not None:
-                    self._append_val_video_frame(recording, next_obs)
+                    self._append_video_frame(self.val_env, recording, next_obs)
 
                 if next_obs["done"]:
                     obs = next_obs
@@ -704,41 +704,4 @@ class Trainer:
             f"sr={sr_str} spl={spl_str} softspl={soft_str} dtg={dtg_str}m "
             f"({tcfg.val_episodes} eps in {elapsed:.1f}s)"
         )
-
-    # ------------------------------------------------------------------
-    # Val-episode video helpers (3D-41) — mirror the train video helpers
-    # but bound to self.val_env so the train env isn't disturbed.
-    # ------------------------------------------------------------------
-
-    def _start_val_video_recording(self, obs: dict) -> dict[str, Any]:
-        recording = {
-            "trajectory": [self._val_agent_position()],
-            "goals": self._val_goal_positions(),
-            "frames": [],
-        }
-        self._append_val_video_frame(recording, obs)
-        return recording
-
-    def _append_val_video_frame(self, recording: dict[str, Any], obs: dict) -> None:
-        if "image" not in obs:
-            return
-        if recording["frames"]:
-            recording["trajectory"].append(self._val_agent_position())
-        topdown = render_topdown_frame(
-            self.val_env, recording["trajectory"], recording["goals"])
-        recording["frames"].append(compose_frame(obs["image"], topdown))
-
-    def _val_goal_positions(self) -> list[list[float]]:
-        positions = []
-        for goal in self.val_env._env.current_episode.goals:
-            if goal.view_points:
-                pos = goal.view_points[0].agent_state.position
-            else:
-                pos = goal.position
-            positions.append(pos.tolist() if hasattr(pos, "tolist") else list(pos))
-        return positions
-
-    def _val_agent_position(self) -> list[float]:
-        pos = self.val_env._env.sim.get_agent_state().position
-        return pos.tolist() if hasattr(pos, "tolist") else list(pos)
 

--- a/src/shared/wandb_utils.py
+++ b/src/shared/wandb_utils.py
@@ -22,7 +22,7 @@ def init_run(
 class EpisodeTracker:
     """Track per-episode metrics with rolling averages and per-category breakdown."""
 
-    def __init__(self, window: int = 100):
+    def __init__(self, window: int = 100, track_collision_rate: bool = False):
         self._window = window
         self._rewards: deque[float] = deque(maxlen=window)
         self._successes: deque[float] = deque(maxlen=window)
@@ -35,6 +35,11 @@ class EpisodeTracker:
         self._cat_rewards: dict[str, deque[float]] = defaultdict(
             lambda: deque(maxlen=window)
         )
+        # Collision rate is val-only by default: train rollouts already log
+        # per-step action statistics, so a per-episode aggregate is more
+        # informative in the deterministic val setting.
+        self._track_collision_rate = track_collision_rate
+        self._collision_rates: deque[float] = deque(maxlen=window)
         self._episode_count = 0
 
     def record(
@@ -46,6 +51,7 @@ class EpisodeTracker:
         scene_id: str,
         softspl: float = 0.0,
         dtg: float = 0.0,
+        collision_rate: float = 0.0,
     ) -> dict[str, Any]:
         """Record a completed episode, return dict of all metrics to log."""
         self._episode_count += 1
@@ -74,6 +80,10 @@ class EpisodeTracker:
             "metrics/dtg": float(np.mean(self._dtgs)),
             "metrics/reward": float(np.mean(self._rewards)),
         }
+        if self._track_collision_rate:
+            self._collision_rates.append(collision_rate)
+            metrics["episode/collision_rate"] = collision_rate
+            metrics["metrics/collision_rate"] = float(np.mean(self._collision_rates))
         for cat, succ_deque in self._cat_successes.items():
             metrics[f"goal/{cat}/sr"] = float(np.mean(succ_deque))
         for cat, rew_deque in self._cat_rewards.items():

--- a/src/shared/wandb_utils.py
+++ b/src/shared/wandb_utils.py
@@ -32,6 +32,9 @@ class EpisodeTracker:
         self._cat_successes: dict[str, deque[float]] = defaultdict(
             lambda: deque(maxlen=window)
         )
+        self._cat_spls: dict[str, deque[float]] = defaultdict(
+            lambda: deque(maxlen=window)
+        )
         self._cat_rewards: dict[str, deque[float]] = defaultdict(
             lambda: deque(maxlen=window)
         )
@@ -61,6 +64,7 @@ class EpisodeTracker:
         self._softspls.append(softspl)
         self._dtgs.append(dtg)
         self._cat_successes[category].append(success)
+        self._cat_spls[category].append(spl)
         self._cat_rewards[category].append(reward)
 
         scene = scene_id.split("/")[-1].replace(".basis.glb", "")
@@ -86,6 +90,8 @@ class EpisodeTracker:
             metrics["metrics/collision_rate"] = float(np.mean(self._collision_rates))
         for cat, succ_deque in self._cat_successes.items():
             metrics[f"goal/{cat}/sr"] = float(np.mean(succ_deque))
+        for cat, spl_deque in self._cat_spls.items():
+            metrics[f"goal/{cat}/spl"] = float(np.mean(spl_deque))
         for cat, rew_deque in self._cat_rewards.items():
             metrics[f"goal/{cat}/reward"] = float(np.mean(rew_deque))
         return metrics

--- a/src/shared/wandb_utils.py
+++ b/src/shared/wandb_utils.py
@@ -22,28 +22,27 @@ def init_run(
 class EpisodeTracker:
     """Track per-episode metrics with rolling averages and per-category breakdown."""
 
+    # Per-category metric streams. Adding a new one is a one-line change here.
+    _PER_CAT_KEYS: tuple[str, ...] = ("success", "spl", "reward")
+
+    # Rename rule for output keys (`metrics/sr` / `goal/{cat}/sr` keep the
+    # historical "sr" label even though the internal stream is named "success").
+    _OUTPUT_RENAME: dict[str, str] = {"success": "sr"}
+
     def __init__(self, window: int = 100, track_collision_rate: bool = False):
         self._window = window
-        self._rewards: deque[float] = deque(maxlen=window)
-        self._successes: deque[float] = deque(maxlen=window)
-        self._spls: deque[float] = deque(maxlen=window)
-        self._softspls: deque[float] = deque(maxlen=window)
-        self._dtgs: deque[float] = deque(maxlen=window)
-        self._cat_successes: dict[str, deque[float]] = defaultdict(
-            lambda: deque(maxlen=window)
-        )
-        self._cat_spls: dict[str, deque[float]] = defaultdict(
-            lambda: deque(maxlen=window)
-        )
-        self._cat_rewards: dict[str, deque[float]] = defaultdict(
-            lambda: deque(maxlen=window)
-        )
         # Collision rate is val-only by default: train rollouts already log
         # per-step action statistics, so a per-episode aggregate is more
         # informative in the deterministic val setting.
         self._track_collision_rate = track_collision_rate
-        self._collision_rates: deque[float] = deque(maxlen=window)
+        self._global: dict[str, deque[float]] = defaultdict(self._new_window)
+        self._per_cat: dict[str, dict[str, deque[float]]] = defaultdict(
+            lambda: defaultdict(self._new_window)
+        )
         self._episode_count = 0
+
+    def _new_window(self) -> deque[float]:
+        return deque(maxlen=self._window)
 
     def record(
         self,
@@ -58,42 +57,36 @@ class EpisodeTracker:
     ) -> dict[str, Any]:
         """Record a completed episode, return dict of all metrics to log."""
         self._episode_count += 1
-        self._rewards.append(reward)
-        self._successes.append(success)
-        self._spls.append(spl)
-        self._softspls.append(softspl)
-        self._dtgs.append(dtg)
-        self._cat_successes[category].append(success)
-        self._cat_spls[category].append(spl)
-        self._cat_rewards[category].append(reward)
+
+        samples: dict[str, float] = {
+            "reward": reward,
+            "success": success,
+            "spl": spl,
+            "softspl": softspl,
+            "dtg": dtg,
+        }
+        if self._track_collision_rate:
+            samples["collision_rate"] = collision_rate
+
+        for k, v in samples.items():
+            self._global[k].append(v)
+        for k in self._PER_CAT_KEYS:
+            self._per_cat[category][k].append(samples[k])
 
         scene = scene_id.split("/")[-1].replace(".basis.glb", "")
 
         metrics: dict[str, Any] = {
-            "episode/reward": reward,
-            "episode/success": success,
-            "episode/spl": spl,
-            "episode/softspl": softspl,
-            "episode/dtg": dtg,
             "episode/count": self._episode_count,
             "episode/goal": category,
             "episode/scene": scene,
-            "metrics/sr": float(np.mean(self._successes)),
-            "metrics/spl": float(np.mean(self._spls)),
-            "metrics/softspl": float(np.mean(self._softspls)),
-            "metrics/dtg": float(np.mean(self._dtgs)),
-            "metrics/reward": float(np.mean(self._rewards)),
         }
-        if self._track_collision_rate:
-            self._collision_rates.append(collision_rate)
-            metrics["episode/collision_rate"] = collision_rate
-            metrics["metrics/collision_rate"] = float(np.mean(self._collision_rates))
-        for cat, succ_deque in self._cat_successes.items():
-            metrics[f"goal/{cat}/sr"] = float(np.mean(succ_deque))
-        for cat, spl_deque in self._cat_spls.items():
-            metrics[f"goal/{cat}/spl"] = float(np.mean(spl_deque))
-        for cat, rew_deque in self._cat_rewards.items():
-            metrics[f"goal/{cat}/reward"] = float(np.mean(rew_deque))
+        for k, v in samples.items():
+            metrics[f"episode/{k}"] = v
+        for k, dq in self._global.items():
+            metrics[f"metrics/{self._OUTPUT_RENAME.get(k, k)}"] = float(np.mean(dq))
+        for cat, per in self._per_cat.items():
+            for k, dq in per.items():
+                metrics[f"goal/{cat}/{self._OUTPUT_RENAME.get(k, k)}"] = float(np.mean(dq))
         return metrics
 
 

--- a/src/shared/wandb_utils.py
+++ b/src/shared/wandb_utils.py
@@ -27,6 +27,8 @@ class EpisodeTracker:
         self._rewards: deque[float] = deque(maxlen=window)
         self._successes: deque[float] = deque(maxlen=window)
         self._spls: deque[float] = deque(maxlen=window)
+        self._softspls: deque[float] = deque(maxlen=window)
+        self._dtgs: deque[float] = deque(maxlen=window)
         self._cat_successes: dict[str, deque[float]] = defaultdict(
             lambda: deque(maxlen=window)
         )
@@ -42,12 +44,16 @@ class EpisodeTracker:
         spl: float,
         category: str,
         scene_id: str,
+        softspl: float = 0.0,
+        dtg: float = 0.0,
     ) -> dict[str, Any]:
         """Record a completed episode, return dict of all metrics to log."""
         self._episode_count += 1
         self._rewards.append(reward)
         self._successes.append(success)
         self._spls.append(spl)
+        self._softspls.append(softspl)
+        self._dtgs.append(dtg)
         self._cat_successes[category].append(success)
         self._cat_rewards[category].append(reward)
 
@@ -57,11 +63,15 @@ class EpisodeTracker:
             "episode/reward": reward,
             "episode/success": success,
             "episode/spl": spl,
+            "episode/softspl": softspl,
+            "episode/dtg": dtg,
             "episode/count": self._episode_count,
             "episode/goal": category,
             "episode/scene": scene,
             "metrics/sr": float(np.mean(self._successes)),
             "metrics/spl": float(np.mean(self._spls)),
+            "metrics/softspl": float(np.mean(self._softspls)),
+            "metrics/dtg": float(np.mean(self._dtgs)),
             "metrics/reward": float(np.mean(self._rewards)),
         }
         for cat, succ_deque in self._cat_successes.items():

--- a/tests/environments/test_collision_rate.py
+++ b/tests/environments/test_collision_rate.py
@@ -1,0 +1,174 @@
+"""Unit tests for the collision_rate workaround in HabitatObjectNavEnv.
+
+Habitat exposes no direct collision API. We approximate it by detecting
+FORWARD steps whose position delta falls under 0.01 m (vs nominal 0.25 m).
+"""
+
+import numpy as np
+import pytest
+
+from src.shared.configs import DreamerConfig
+from src.environments.habitat import HabitatObjectNavEnv
+
+
+class _FakeAgentState:
+    def __init__(self, position):
+        self.position = np.array(position)
+
+
+class _FakeSim:
+    """Simulates a position the test can advance step-by-step."""
+
+    def __init__(self):
+        self._position = [0.0, 0.0, 0.0]
+
+    def set_position(self, position):
+        self._position = list(position)
+
+    def get_agent_state(self):
+        return _FakeAgentState(self._position)
+
+
+class _FakeHabitatEnv:
+    """Drives _FakeSim from a fixed list of post-step positions."""
+
+    def __init__(self, post_step_positions, distance: float = 5.0):
+        self.sim = _FakeSim()
+        self._post_step_positions = list(post_step_positions)
+        self._idx = 0
+        self._distance = distance
+
+    def step(self, action):
+        # Each step advances the sim to the next pre-loaded position
+        if self._idx < len(self._post_step_positions):
+            self.sim.set_position(self._post_step_positions[self._idx])
+            self._idx += 1
+        return {"rgb": np.zeros((1, 1, 3), dtype=np.uint8)}
+
+    def get_metrics(self):
+        return {"distance_to_goal": self._distance}
+
+
+def _make_env(post_step_positions, max_steps: int = 100) -> HabitatObjectNavEnv:
+    env = object.__new__(HabitatObjectNavEnv)
+    env._cfg = DreamerConfig(
+        obs_shape=(3, 1, 1),
+        max_episode_steps=max_steps,
+        reward_type="sparse",
+        step_penalty=0.0,
+        success_bonus=1.0,
+    )
+    env._env = _FakeHabitatEnv(post_step_positions, distance=5.0)
+    env._last_obs = {"rgb": np.zeros((1, 1, 3), dtype=np.uint8)}
+    env._prev_dist = 5.0
+    env._start_geodesic = 5.0
+    env._step_count = 0
+    env._path_length = 0.0
+    env._prev_position = np.array([0.0, 0.0, 0.0])
+    env._collisions = 0
+    env._forward_steps = 0
+    return env
+
+
+def test_collision_rate_zero_when_no_forward_steps():
+    """Pure rotations and STOPs leave collision_rate at 0 (no forward attempts)."""
+    env = _make_env(post_step_positions=[(0.0, 0.0, 0.0)] * 5, max_steps=5)
+    env.step(2)  # TURN_LEFT — position unchanged but not counted
+    env.step(3)  # TURN_RIGHT — same
+    env.step(2)
+    env.step(3)
+    obs = env.step(0)  # STOP at max_steps -> done=True
+    assert obs["done"] is True
+    assert obs["collision_rate"] == 0.0
+
+
+def test_collision_rate_all_collisions():
+    """Every FORWARD step blocked at < 0.01 m -> collision_rate = 1.0."""
+    # 5 forward steps, all moving < 0.01 m
+    blocked = [(0.005, 0.0, 0.0)] * 5  # 5 mm increment, < 1 cm threshold
+    env = _make_env(post_step_positions=blocked, max_steps=5)
+    for _ in range(4):
+        env.step(1)
+    obs = env.step(1)  # 5th forward triggers done at max_steps
+    assert obs["done"] is True
+    assert obs["collision_rate"] == pytest.approx(1.0)
+
+
+def test_collision_rate_no_collisions():
+    """All FORWARD steps moving ~0.25 m -> collision_rate = 0.0."""
+    free = [(0.25 * (i + 1), 0.0, 0.0) for i in range(5)]
+    env = _make_env(post_step_positions=free, max_steps=5)
+    for _ in range(4):
+        env.step(1)
+    obs = env.step(1)
+    assert obs["done"] is True
+    assert obs["collision_rate"] == 0.0
+
+
+def test_collision_rate_mixed():
+    """3 collisions out of 5 forward steps -> 0.6."""
+    # Forward steps 1, 3, 5 move freely; 2 and 4 collide.
+    positions = [
+        (0.25, 0.0, 0.0),    # move
+        (0.255, 0.0, 0.0),   # collision (0.005 m delta)
+        (0.50, 0.0, 0.0),    # move
+        (0.505, 0.0, 0.0),   # collision
+        (0.75, 0.0, 0.0),    # move
+    ]
+    env = _make_env(post_step_positions=positions, max_steps=5)
+    for _ in range(4):
+        env.step(1)
+    obs = env.step(1)
+    assert obs["done"] is True
+    # 2 collisions / 5 forward steps = 0.4
+    assert obs["collision_rate"] == pytest.approx(0.4)
+
+
+def test_collision_rate_only_counts_forward_actions():
+    """TURN actions don't move and must NOT be classified as collisions."""
+    # 1 forward (moves freely), 4 turns (no movement)
+    positions = [
+        (0.25, 0.0, 0.0),
+        (0.25, 0.0, 0.0),
+        (0.25, 0.0, 0.0),
+        (0.25, 0.0, 0.0),
+        (0.25, 0.0, 0.0),
+    ]
+    env = _make_env(post_step_positions=positions, max_steps=5)
+    env.step(1)  # forward (free)
+    env.step(2)  # turn left
+    env.step(3)  # turn right
+    env.step(2)
+    obs = env.step(3)  # final turn triggers done at max_steps
+    assert obs["done"] is True
+    # Only 1 forward step, 0 collisions -> 0.0
+    assert obs["collision_rate"] == 0.0
+
+
+def test_collision_rate_resets_between_episodes():
+    """A fresh episode starts with collision_rate=0 (state reset)."""
+    blocked = [(0.005, 0.0, 0.0)] * 3
+    env = _make_env(post_step_positions=blocked, max_steps=3)
+    env.step(1)
+    env.step(1)
+    obs = env.step(1)
+    assert obs["collision_rate"] == pytest.approx(1.0)
+    # Simulate reset state
+    env._collisions = 0
+    env._forward_steps = 0
+    assert env._compute_collision_rate() == 0.0
+
+
+def test_collision_rate_in_unit_interval():
+    """Property: collision_rate ∈ [0, 1] for any combination of moves."""
+    rng = np.random.default_rng(0)
+    for _ in range(20):
+        n = int(rng.integers(1, 10))
+        positions = [
+            (float(rng.uniform(0, 0.3)), 0.0, 0.0) for _ in range(n)
+        ]
+        env = _make_env(post_step_positions=positions, max_steps=n)
+        for _ in range(n - 1):
+            env.step(1)
+        obs = env.step(1)
+        assert 0.0 <= obs["collision_rate"] <= 1.0

--- a/tests/environments/test_reward.py
+++ b/tests/environments/test_reward.py
@@ -67,6 +67,8 @@ def _make_step_test_env(distance: float) -> HabitatObjectNavEnv:
     env._step_count = 0
     env._path_length = 0.0
     env._prev_position = [0.0, 0.0, 0.0]
+    env._collisions = 0
+    env._forward_steps = 0
     return env
 
 

--- a/tests/environments/test_softspl.py
+++ b/tests/environments/test_softspl.py
@@ -57,6 +57,8 @@ def _make_env(distance: float, *, start_geodesic: float, path_length: float,
     env._step_count = max_steps - 1
     env._path_length = path_length
     env._prev_position = np.array(prev_position)
+    env._collisions = 0
+    env._forward_steps = 0
     return env
 
 

--- a/tests/environments/test_softspl.py
+++ b/tests/environments/test_softspl.py
@@ -1,0 +1,150 @@
+"""Unit tests for SoftSPL + DTG in HabitatObjectNavEnv.step().
+
+Mocks habitat sim so the math can be exercised without a GPU. Sibling
+test_spl.py is the GPU-only integration test that validates SPL end-to-end.
+"""
+
+import numpy as np
+import pytest
+
+from src.shared.configs import DreamerConfig
+from src.environments.habitat import (
+    GOAL_RADIUS,
+    HabitatObjectNavEnv,
+)
+
+
+class _FakeAgentState:
+    def __init__(self, position):
+        self.position = position
+
+
+class _FakeSim:
+    def __init__(self, position):
+        self._position = position
+
+    def get_agent_state(self):
+        return _FakeAgentState(self._position)
+
+
+class _FakeHabitatEnv:
+    def __init__(self, distance, position=(0.0, 0.0, 0.0)):
+        self._distance = distance
+        self.sim = _FakeSim(list(position))
+
+    def step(self, action):
+        return {"rgb": np.zeros((1, 1, 3), dtype=np.uint8)}
+
+    def get_metrics(self):
+        return {"distance_to_goal": self._distance}
+
+
+def _make_env(distance: float, *, start_geodesic: float, path_length: float,
+              prev_position=(0.0, 0.0, 0.0), max_steps: int = 100) -> HabitatObjectNavEnv:
+    env = object.__new__(HabitatObjectNavEnv)
+    env._cfg = DreamerConfig(
+        obs_shape=(3, 1, 1),
+        max_episode_steps=max_steps,
+        reward_type="sparse",
+        step_penalty=0.0,
+        success_bonus=1.0,
+    )
+    env._env = _FakeHabitatEnv(distance, position=prev_position)
+    env._last_obs = {"rgb": np.zeros((1, 1, 3), dtype=np.uint8)}
+    env._prev_dist = start_geodesic
+    env._start_geodesic = start_geodesic
+    # Step count chosen so the upcoming step() lands at max_steps -> done=True
+    env._step_count = max_steps - 1
+    env._path_length = path_length
+    env._prev_position = np.array(prev_position)
+    return env
+
+
+def test_softspl_on_success_uses_residual_distance():
+    """On success SoftSPL = (1 - d_final/d_init) * length_ratio — never quite SPL.
+
+    d_final inside GOAL_RADIUS triggers success=1 but softspl reflects the
+    fact that the agent stopped 0.1m from the goal, not exactly on it.
+    """
+    env = _make_env(distance=0.1, start_geodesic=5.0, path_length=5.0)
+    obs = env.step(1)
+    assert obs["success"] == 1.0
+    assert obs["spl"] == pytest.approx(1.0)
+    # progress = 1 - 0.1/5.0 = 0.98 ; length_ratio = 1.0 -> softspl 0.98
+    assert obs["softspl"] == pytest.approx(0.98)
+    assert obs["dtg"] == pytest.approx(0.1)
+
+
+def test_softspl_partial_progress_no_success():
+    """Failed episode that made progress: SoftSPL > 0, SPL = 0."""
+    # d_init = 10.0, d_final = 3.0 -> progress = 0.7
+    # path_length = 10.0, shortest = 10.0 -> length_ratio = 1.0
+    # softspl = 0.7
+    env = _make_env(distance=3.0, start_geodesic=10.0, path_length=10.0)
+    obs = env.step(1)
+    assert obs["success"] == 0.0
+    assert obs["spl"] == 0.0
+    assert obs["softspl"] == pytest.approx(0.7)
+    assert obs["dtg"] == pytest.approx(3.0)
+
+
+def test_softspl_clipped_when_agent_moves_away():
+    """If d_final > d_init, the progress term is clipped to 0."""
+    env = _make_env(distance=12.0, start_geodesic=10.0, path_length=15.0)
+    obs = env.step(1)
+    assert obs["success"] == 0.0
+    assert obs["softspl"] == 0.0
+    assert obs["dtg"] == pytest.approx(12.0)
+
+
+def test_softspl_length_ratio_penalises_long_paths():
+    """A long wandering path reduces SoftSPL even when progress is full."""
+    # progress = 1 - 1/10 = 0.9
+    # path_length = 30, shortest = 10 -> length_ratio = 10/30 = 1/3
+    # softspl = 0.9 / 3 = 0.3
+    env = _make_env(distance=1.0, start_geodesic=10.0, path_length=30.0)
+    obs = env.step(1)
+    assert obs["softspl"] == pytest.approx(0.3)
+
+
+def test_softspl_zero_when_start_geodesic_zero():
+    """Defensive: if start_geodesic is 0 (degenerate), SoftSPL must be 0."""
+    env = _make_env(distance=0.5, start_geodesic=0.0, path_length=0.0)
+    obs = env.step(1)
+    assert obs["softspl"] == 0.0
+
+
+def test_softspl_zero_mid_episode():
+    """SoftSPL/DTG are 0 mid-episode (only meaningful at done)."""
+    env = _make_env(distance=5.0, start_geodesic=10.0, path_length=2.0, max_steps=100)
+    env._step_count = 0  # step() takes us to 1, far below max
+    obs = env.step(1)
+    assert obs["done"] is False
+    assert obs["softspl"] == 0.0
+    assert obs["dtg"] == 0.0
+
+
+def test_softspl_stop_action_timeout_uses_prev_dist():
+    """STOP at max_steps still surfaces SoftSPL/DTG using _prev_dist."""
+    env = _make_env(distance=999.0, start_geodesic=10.0, path_length=8.0)
+    env._prev_dist = 4.0  # last known distance before STOP
+    obs = env.step(0)
+    assert obs["done"] is True
+    # progress = 1 - 4/10 = 0.6, length_ratio = 10/10 = 1.0 -> softspl 0.6
+    assert obs["softspl"] == pytest.approx(0.6)
+    assert obs["dtg"] == pytest.approx(4.0)
+
+
+def test_softspl_in_unit_interval():
+    """Property: softspl ∈ [0, 1] for all reasonable inputs."""
+    for d_init in (1.0, 5.0, 20.0):
+        for d_final in (0.0, 0.5, 1.0, d_init, d_init * 2):
+            for path in (d_init, d_init * 1.5, d_init * 3):
+                env = _make_env(
+                    distance=d_final, start_geodesic=d_init, path_length=path,
+                )
+                obs = env.step(1)
+                assert 0.0 <= obs["softspl"] <= 1.0, (
+                    f"d_init={d_init} d_final={d_final} path={path} "
+                    f"softspl={obs['softspl']}"
+                )

--- a/tests/shared/test_episode_tracker.py
+++ b/tests/shared/test_episode_tracker.py
@@ -1,0 +1,76 @@
+"""Unit tests for EpisodeTracker — per-category accumulators + collision-rate flag."""
+
+import pytest
+
+from src.shared.wandb_utils import EpisodeTracker
+
+
+def _make_episode(category, spl, success=0.0, reward=0.0):
+    return dict(
+        reward=reward, success=success, spl=spl,
+        category=category, scene_id="some/scene.basis.glb",
+    )
+
+
+def test_per_category_spl_emitted_alongside_per_category_sr():
+    tracker = EpisodeTracker(window=100)
+    out = tracker.record(**_make_episode("chair", spl=0.8, success=1.0))
+    assert out["goal/chair/sr"] == pytest.approx(1.0)
+    assert out["goal/chair/spl"] == pytest.approx(0.8)
+    assert out["goal/chair/reward"] == pytest.approx(0.0)
+
+
+def test_per_category_spl_isolated_across_categories():
+    tracker = EpisodeTracker(window=100)
+    tracker.record(**_make_episode("chair", spl=1.0, success=1.0))
+    tracker.record(**_make_episode("chair", spl=0.0, success=0.0))
+    out = tracker.record(**_make_episode("plant", spl=0.5, success=1.0))
+    # chair: mean(1.0, 0.0) = 0.5
+    assert out["goal/chair/spl"] == pytest.approx(0.5)
+    # plant: single entry
+    assert out["goal/plant/spl"] == pytest.approx(0.5)
+
+
+def test_per_category_spl_uses_rolling_window():
+    tracker = EpisodeTracker(window=3)
+    tracker.record(**_make_episode("chair", spl=0.0))
+    tracker.record(**_make_episode("chair", spl=0.0))
+    tracker.record(**_make_episode("chair", spl=0.0))
+    # 4th entry pushes the oldest 0.0 out of the rolling window
+    out = tracker.record(**_make_episode("chair", spl=1.0))
+    # window now: [0.0, 0.0, 1.0] -> mean = 1/3
+    assert out["goal/chair/spl"] == pytest.approx(1.0 / 3.0)
+
+
+def test_collision_rate_only_emitted_when_flag_enabled():
+    train_tracker = EpisodeTracker(window=100, track_collision_rate=False)
+    val_tracker = EpisodeTracker(window=100, track_collision_rate=True)
+
+    train_out = train_tracker.record(
+        reward=0.0, success=0.0, spl=0.0,
+        category="chair", scene_id="x.basis.glb",
+        collision_rate=0.3,
+    )
+    val_out = val_tracker.record(
+        reward=0.0, success=0.0, spl=0.0,
+        category="chair", scene_id="x.basis.glb",
+        collision_rate=0.3,
+    )
+
+    assert "episode/collision_rate" not in train_out
+    assert "metrics/collision_rate" not in train_out
+    assert val_out["episode/collision_rate"] == pytest.approx(0.3)
+    assert val_out["metrics/collision_rate"] == pytest.approx(0.3)
+
+
+def test_softspl_and_dtg_emitted_for_every_episode():
+    tracker = EpisodeTracker(window=100)
+    out = tracker.record(
+        reward=1.0, success=1.0, spl=1.0,
+        category="bed", scene_id="x.basis.glb",
+        softspl=0.7, dtg=0.1,
+    )
+    assert out["episode/softspl"] == pytest.approx(0.7)
+    assert out["episode/dtg"] == pytest.approx(0.1)
+    assert out["metrics/softspl"] == pytest.approx(0.7)
+    assert out["metrics/dtg"] == pytest.approx(0.1)


### PR DESCRIPTION
## Summary

Closes the [3D-35 metrics-logging overhaul](https://linear.app/3d-wm-objectnav/issue/3D-35/metrics-logging-overhaul-deterministic-val-episode-loop-objectnav) and its 8 subissues (3D-36 .. 3D-43).

- **Real validation signal**: deterministic Val-Episode-Loop runs every 50k steps (configurable) on the pinned eval episode IDs from the curriculum JSON. Greedy policy (`agent.act(..., training=False)`), separate `HabitatObjectNavEnv` + obs adapter so the train VGGT video buffer is untouched.
- **New metrics in the env + tracker**: SoftSPL + DTG (habitat-lab clipping), per-FORWARD-step collision detection (`< 0.01 m` heuristic), per-category SPL alongside the existing per-category SR.
- **Cleanup**: removed the misleading offline `val_loss` path (replay-buffer loss under a `val/*` prefix) including `agent.eval_loss`, `--val_data`, `--val_loss_every`, and the `_val_dataset` plumbing. The `kl_prior` / `kl_post` duplicate-key cleanup (3D-42) was a no-op — grep confirmed the keys are already absent in current code.
- **Verification sbatch**: `scripts/verify_3d_35_metrics.sbatch` — CNN + L1 + 15k steps + val every 5k on `dev_gpu_h100` (28 min wallclock).

## Linear issues

| Issue | What it touches |
|---|---|
| [3D-36](https://linear.app/3d-wm-objectnav/issue/3D-36) | `Trainer._run_val_loop`, `TrainerConfig.val_*`, launcher wiring |
| [3D-37](https://linear.app/3d-wm-objectnav/issue/3D-37) | strip `_log_val_loss`, `eval_loss`, val-loss CLI flags |
| [3D-38](https://linear.app/3d-wm-objectnav/issue/3D-38) | verification-only — generator is deterministic (seed=42), JSONs present |
| [3D-39](https://linear.app/3d-wm-objectnav/issue/3D-39) | `HabitatObjectNavEnv` collision counter + `EpisodeTracker.track_collision_rate` |
| [3D-40](https://linear.app/3d-wm-objectnav/issue/3D-40) | per-category SPL in `EpisodeTracker` |
| [3D-41](https://linear.app/3d-wm-objectnav/issue/3D-41) | `val/episode_video` (deterministic playback via pinned episode order) |
| [3D-42](https://linear.app/3d-wm-objectnav/issue/3D-42) | no-op — premise stale (grep confirms no `kl_prior`/`kl_post` in tree) |
| [3D-43](https://linear.app/3d-wm-objectnav/issue/3D-43) | SoftSPL + DTG in `HabitatObjectNavEnv.step()` |

## New W&B keys (under `val/`)

`metrics/sr`, `metrics/spl`, `metrics/softspl`, `metrics/dtg`, `metrics/collision_rate`, `metrics/reward`, `goal/{cat}/sr`, `goal/{cat}/spl`, `goal/{cat}/reward`, `episode/softspl`, `episode/dtg`, `episode/collision_rate`, `episode_video`.

## Risk

- Two Habitat sims now live during training (train + val) — ~10s warm-up and ~1 GB RAM overhead per run.
- The val loop is gated by `val_every>0 && val_env is not None`; existing runs that pass `--val_every 0` or don't construct a val env keep the old behavior.
- `agent.eval_loss` is gone. Only the trainer called it; grep across `src/`, `tests/`, `scripts/` confirms no other callers.

## How to test

1. Submit the verification run:
   ```
   sbatch scripts/verify_3d_35_metrics.sbatch
   ```
2. In W&B (project `3d-vla-objectnav`, tag `3D-35`):
   - Confirm `val/metrics/*` appear at steps 5k, 10k, 15k.
   - Confirm `val/episode_video` shows 3 deterministic clips.
   - Confirm no `val/total_loss` / `val/loss/*` keys.
3. Local unit tests:
   ```
   .venv/bin/python -m pytest tests/environments/ tests/shared/ tests/buffer/
   ```
   should report `71 passed, 1 skipped` (the skip is the GPU-only `test_spl.py` integration test).

## What was intentionally not done

- No multi-level transfer probes — out of scope per parent's "Level scope: A — MVP".
- `ValReplayDataset` class kept in `src/buffer` because `scripts/collect_val_data.py` still references it; only the trainer's usage was removed.
- No Linear comments posted on each subissue — the Claude Code auto-mode classifier blocked `mcp__claude_ai_Linear__save_comment` on issues this session didn't create. Status updates went through. If you want comments enabled, allowlist the tool in `~/.claude/settings.json`.

## Agent involvement

Drafted by Claude Opus 4.7 (1M context) in a `.claude/worktrees/3d-35-metrics-overhaul` worktree. 7 commits, one per closed subissue plus the sbatch script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)