### PR TITLE
feat(r2dreamer): add 3D-27 online eval sweep

### DIFF
--- a/scripts/r2dreamer/slurm/evaluate_offline_ablation.sbatch
+++ b/scripts/r2dreamer/slurm/evaluate_offline_ablation.sbatch
@@ -1,0 +1,114 @@
+#!/bin/bash
+#SBATCH --job-name=3d27-online-eval
+#SBATCH --partition=gpu_h100_il
+#SBATCH --gres=gpu:1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=160G
+#SBATCH --time=04:00:00
+#SBATCH --output=output/3d27-online-eval/slurm-%j.out
+#SBATCH --error=output/3d27-online-eval/slurm-%j.err
+
+# 3D-27 Online navigation evaluation for one 3D-26 offline-ablation checkpoint.
+#
+# Args (via env vars):
+#   ENCODER          wp_cp | aggregator                 (required)
+#   SEED             0 | 1 | 2                          (required)
+#   CHECKPOINT       explicit checkpoint path           (optional)
+#   CHECKPOINT_ROOT  root containing 3D-26 run outputs   (default output/3d26-offline-ablation)
+#   EPISODES         HM3D val episodes to evaluate      (default 50)
+#   EVAL_SEED        evaluation RNG seed                (default SEED)
+#   SPLIT            Habitat split                      (default val)
+#   WANDB_PROJECT    W&B project for eval videos        (default empty/off)
+#   EXTRA_ARGS       extra CLI for src.main evaluate    (default empty)
+
+set -euo pipefail
+
+: "${ENCODER:?ENCODER must be set (wp_cp|aggregator)}"
+: "${SEED:?SEED must be set (0|1|2)}"
+case "${ENCODER}" in wp_cp|aggregator) ;; *) echo "bad ENCODER=${ENCODER}" >&2; exit 2 ;; esac
+case "${SEED}" in 0|1|2) ;; *) echo "bad SEED=${SEED}" >&2; exit 2 ;; esac
+
+export CHECKPOINT_ROOT="${CHECKPOINT_ROOT:-output/3d26-offline-ablation}"
+EPISODES="${EPISODES:-50}"
+EVAL_SEED="${EVAL_SEED:-${SEED}}"
+SPLIT="${SPLIT:-val}"
+WANDB_PROJECT="${WANDB_PROJECT:-}"
+EXTRA_ARGS="${EXTRA_ARGS:-}"
+
+case "${ENCODER}" in
+    wp_cp) EVAL_ENCODER="vggt" ;;
+    aggregator) EVAL_ENCODER="vggt_aggregator_mlp" ;;
+esac
+
+mkdir -p output/3d27-online-eval
+./scripts/setup_worktree.sh
+
+git_common_dir="$(git rev-parse --git-common-dir)"
+main_root="$(realpath "${git_common_dir}/..")"
+
+# Mirror the VGGT external-repo links needed by the online feature extractor.
+mkdir -p external
+for name in InfiniteVGGT StreamVGGT VGGT; do
+    target="${main_root}/external/${name}"
+    link="external/${name}"
+    if [ ! -e "${link}" ] && [ -e "${target}" ]; then
+        ln -s "$(realpath --relative-to external "${target}")" "${link}"
+    fi
+done
+
+if [ -z "${CHECKPOINT:-}" ]; then
+    CHECKPOINT="$(python - <<'PY'
+import os
+from pathlib import Path
+root = Path(os.environ["CHECKPOINT_ROOT"])
+encoder = os.environ["ENCODER"]
+seed = os.environ["SEED"]
+base = root / f"{encoder}-seed{seed}"
+ckpts = sorted(base.glob("run-*/checkpoints/step_*.pkl"))
+if not ckpts:
+    raise SystemExit(f"no checkpoints found under {base}/run-*/checkpoints/step_*.pkl")
+# Prefer the numerically largest training step; tie-break by mtime for reruns.
+def key(path: Path):
+    step = int(path.stem.split("_")[-1])
+    return (step, path.stat().st_mtime)
+print(max(ckpts, key=key))
+PY
+)"
+fi
+
+OUTPUT_DIR="output/3d27-online-eval/${ENCODER}-seed${SEED}/run-${SLURM_JOB_ID}"
+mkdir -p "${OUTPUT_DIR}"
+
+WANDB_ARGS=()
+if [ -n "${WANDB_PROJECT}" ]; then
+    WANDB_ARGS=(--wandb_project "${WANDB_PROJECT}" --wandb_name "3d27-${ENCODER}-seed${SEED}-${SLURM_JOB_ID}")
+fi
+
+cat <<EOF
+Job ${SLURM_JOB_ID} on $(hostname) at $(date)
+GPU: $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || echo N/A)
+Encoder:          ${ENCODER} (${EVAL_ENCODER})
+Train seed:       ${SEED}
+Eval seed:        ${EVAL_SEED}
+Episodes:         ${EPISODES}
+Split:            ${SPLIT}
+Checkpoint:       ${CHECKPOINT}
+Output:           ${OUTPUT_DIR}
+Commit:           $(git rev-parse HEAD)
+Dirty files:      $(git status --porcelain | wc -l)
+EOF
+
+# shellcheck disable=SC2086
+.venv/bin/python -m src.main evaluate \
+    --env habitat \
+    --encoder "${EVAL_ENCODER}" \
+    --checkpoint "${CHECKPOINT}" \
+    --episodes "${EPISODES}" \
+    --seed "${EVAL_SEED}" \
+    --split "${SPLIT}" \
+    --output_dir "${OUTPUT_DIR}" \
+    "${WANDB_ARGS[@]}" \
+    ${EXTRA_ARGS}
+
+echo "Done at $(date)"

--- a/scripts/r2dreamer/slurm/submit_online_eval.sh
+++ b/scripts/r2dreamer/slurm/submit_online_eval.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Submit a single 3D-27 online navigation evaluation run for a 3D-26 checkpoint.
+#
+# Usage:
+#   ./submit_online_eval.sh dev  <encoder> <seed> [--dry-run]
+#   ./submit_online_eval.sh prod <encoder> <seed> [--dry-run]
+#
+# encoder ∈ {wp_cp, aggregator}; seed ∈ {0, 1, 2}
+#
+# Env passthrough:
+#   CHECKPOINT       explicit checkpoint path for this run (optional)
+#   CHECKPOINT_ROOT  default output/3d26-offline-ablation
+#   EPISODES         dev default 2, prod default 50
+#   EVAL_SEED        default SEED
+#   SPLIT            default val
+#   WANDB_PROJECT    optional W&B project for eval videos
+#   EXTRA_ARGS       extra CLI flags for src.main evaluate
+
+set -euo pipefail
+
+usage() {
+    echo "usage: $0 {dev|prod} <encoder> <seed> [--dry-run]" >&2
+    echo "       encoder ∈ {wp_cp, aggregator}; seed ∈ {0, 1, 2}" >&2
+    exit 2
+}
+
+mode="${1:-}"
+encoder="${2:-}"
+seed="${3:-}"
+shift 3 2>/dev/null || usage
+[ -z "${mode}" ] || [ -z "${encoder}" ] || [ -z "${seed}" ] && usage
+case "${encoder}" in wp_cp|aggregator) ;; *) usage ;; esac
+case "${seed}" in 0|1|2) ;; *) usage ;; esac
+
+dry_run=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run) dry_run=1 ;;
+        *) usage ;;
+    esac
+    shift
+done
+
+case "${mode}" in
+    dev)
+        partition=gpu_h100_short
+        time_limit=00:25:00
+        export EPISODES="${EPISODES:-2}"
+        export EXTRA_ARGS="${EXTRA_ARGS:---log_video_episodes 0}"
+        job_name="3d27-dev-${encoder}-s${seed}"
+        ;;
+    prod)
+        partition=gpu_h100_il
+        time_limit=04:00:00
+        export EPISODES="${EPISODES:-50}"
+        export EXTRA_ARGS="${EXTRA_ARGS:-}"
+        job_name="3d27-prod-${encoder}-s${seed}"
+        ;;
+    *)
+        usage
+        ;;
+esac
+
+export ENCODER="${encoder}"
+export SEED="${seed}"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+sbatch_file="${script_dir}/evaluate_offline_ablation.sbatch"
+
+echo "Mode=${mode}  Partition=${partition}  Time=${time_limit}"
+echo "Encoder=${encoder}  Seed=${seed}  Episodes=${EPISODES}"
+echo "Sbatch=${sbatch_file}"
+
+sbatch_args=(
+    --partition="${partition}"
+    --time="${time_limit}"
+    --job-name="${job_name}"
+    --export=ALL
+)
+if [ -n "${WAIT_FOR:-}" ]; then
+    sbatch_args+=(--dependency="afterok:${WAIT_FOR}")
+fi
+sbatch_args+=("${sbatch_file}")
+
+sbatch --test-only "${sbatch_args[@]}"
+echo "Pre-flight OK."
+
+if [ "${dry_run}" -eq 1 ]; then
+    echo "--dry-run: not submitting."
+    exit 0
+fi
+
+submit_out="$(sbatch "${sbatch_args[@]}")"
+echo "${submit_out}"
+jobid="$(echo "${submit_out}" | awk '{print $NF}')"
+echo "Log: output/3d27-online-eval/slurm-${jobid}.out"

--- a/scripts/r2dreamer/slurm/submit_online_eval_sweep.sh
+++ b/scripts/r2dreamer/slurm/submit_online_eval_sweep.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Submit the full 3D-27 online navigation eval sweep: 2 encoders × 3 seeds = 6 jobs.
+#
+# Usage:
+#   ./submit_online_eval_sweep.sh prod [--dry-run]
+#
+# Reads CHECKPOINT_ROOT / EPISODES / SPLIT / WANDB_PROJECT / EXTRA_ARGS from env
+# and passes them through to each underlying ./submit_online_eval.sh call.
+#
+# Optional env: WAIT_FOR=<jobid>  -- adds --dependency=afterok:<jobid> to every
+# submission, e.g. to chain behind a final 3D-26 training job.
+
+set -euo pipefail
+
+mode="${1:-}"
+extra_flag="${2:-}"
+
+if [ "${mode}" != "prod" ]; then
+    echo "usage: $0 prod [--dry-run]" >&2
+    echo "(use submit_online_eval.sh directly for dev smoke tests)" >&2
+    exit 2
+fi
+if [ -n "${extra_flag}" ] && [ "${extra_flag}" != "--dry-run" ]; then
+    echo "usage: $0 prod [--dry-run]" >&2
+    exit 2
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+single_submit="${script_dir}/submit_online_eval.sh"
+
+ids=()
+for encoder in wp_cp aggregator; do
+    for seed in 0 1 2; do
+        echo "================================================================"
+        echo "Submitting ${encoder} seed=${seed}"
+        echo "================================================================"
+        out="$("${single_submit}" "${mode}" "${encoder}" "${seed}" ${extra_flag})"
+        echo "${out}"
+        if [ "${extra_flag}" != "--dry-run" ]; then
+            jobid="$(echo "${out}" | awk '/Submitted batch job/ {print $NF}')"
+            if [ -n "${jobid}" ]; then ids+=("${encoder}-s${seed}:${jobid}"); fi
+        fi
+    done
+done
+
+if [ "${extra_flag}" != "--dry-run" ]; then
+    echo ""
+    echo "================================================================"
+    echo "Submitted 6 jobs:"
+    for id in "${ids[@]}"; do echo "  ${id}"; done
+    echo "================================================================"
+fi

--- a/src/r2dreamer/launch/evaluate.py
+++ b/src/r2dreamer/launch/evaluate.py
@@ -70,7 +70,6 @@ def evaluate(
     Returns metrics dict with 'results' and 'meta' keys.
     """
     from src.r2dreamer.launch.registries import encoder_registry
-    from src.r2dreamer.adapters import VGGT_FEATURE_DIM
     from src.shared.configs import DreamerConfig
     from src.environments.habitat import HabitatObjectNavEnv
 
@@ -117,7 +116,7 @@ def evaluate(
     if env not in env_registry:
         raise KeyError(f"Unknown env {env!r}. Available: {list(env_registry)}")
 
-    if eff_encoder == "vggt":
+    if eff_encoder in {"vggt", "vggt_aggregator_mlp"}:
         render_resolution = args.render_resolution if args.render_resolution is not None else 518
     else:
         render_resolution = args.render_resolution if args.render_resolution is not None else 64
@@ -136,7 +135,7 @@ def evaluate(
 
     # --- Build encoder + adapter ---
     encoder_cls = encoder_registry[eff_encoder]
-    if eff_encoder == "vggt":
+    if eff_encoder in {"vggt", "vggt_aggregator_mlp"}:
         enc = encoder_cls(resolution=render_resolution)
     else:
         enc = encoder_cls()
@@ -144,18 +143,11 @@ def evaluate(
 
     # --- Build agent ---
     encoder_spec = enc.spec()
-    if eff_encoder == "vggt":
-        from src.r2dreamer.adapters import VGGT_FEATURE_DIM
-        agent_config_kwargs: dict = {
-            "encoder_type": "vggt",
-            "encoder_module_cls": encoder_spec.module_cls,
-            "obs_shape": (VGGT_FEATURE_DIM,),
-        }
-    else:
-        agent_config_kwargs = {
-            "encoder_module_cls": encoder_spec.module_cls,
-            "obs_shape": (3, 64, 64),
-        }
+    agent_config_kwargs: dict = {
+        "encoder_type": encoder_spec.encoder_type,
+        "encoder_module_cls": encoder_spec.module_cls,
+        "obs_shape": encoder_spec.obs_shape,
+    }
     config = R2DreamerConfig(num_actions=4, **agent_config_kwargs)
     rng_key = jax.random.PRNGKey(args.seed)
 

--- a/src/r2dreamer/launch/parser.py
+++ b/src/r2dreamer/launch/parser.py
@@ -84,7 +84,10 @@ def _build_parser_eval() -> argparse.ArgumentParser:
     """Build CLI parser for evaluate()."""
     p = argparse.ArgumentParser(add_help=True)
     p.add_argument("--checkpoint", type=str, default=None)
-    p.add_argument("--encoder", type=str, default=None, choices=["cnn", "vggt"])
+    p.add_argument(
+        "--encoder", type=str, default=None,
+        choices=["cnn", "vggt", "vggt_aggregator_mlp"],
+    )
     p.add_argument("--random", action="store_true",
                    help="Use random agent instead of a checkpoint")
     p.add_argument("--episodes", type=int, default=10)

--- a/tests/r2dreamer/launch/test_parser.py
+++ b/tests/r2dreamer/launch/test_parser.py
@@ -1,6 +1,6 @@
-"""Parser behavior tests for r2dreamer train launch flags."""
+"""Parser behavior tests for r2dreamer launch flags."""
 
-from src.r2dreamer.launch.parser import _build_parser_train
+from src.r2dreamer.launch.parser import _build_parser_eval, _build_parser_train
 
 
 def test_train_parser_does_not_expose_wandb_notes_file():
@@ -9,3 +9,10 @@ def test_train_parser_does_not_expose_wandb_notes_file():
 
     assert not hasattr(args, "wandb_notes_file")
     assert "--wandb_notes_file" not in parser.format_help()
+
+
+def test_eval_parser_accepts_3d27_aggregator_encoder():
+    parser = _build_parser_eval()
+    args = parser.parse_args(["--encoder", "vggt_aggregator_mlp"])
+
+    assert args.encoder == "vggt_aggregator_mlp"


### PR DESCRIPTION
## What changed
- Adds 3D-27 SLURM entrypoints for HM3D online navigation evaluation of the 3D-26 offline-ablation checkpoints:
  - `evaluate_offline_ablation.sbatch` for one encoder/seed checkpoint.
  - `submit_online_eval.sh` for dev/prod single-run submission.
  - `submit_online_eval_sweep.sh` for the full 2 encoder × 3 seed sweep.
- Extends `src.main evaluate --encoder ...` to support `vggt_aggregator_mlp` in addition to `vggt` and `cnn`.
- Makes evaluation build agent config from the resolved `EncoderSpec` instead of hard-coded VGGT/CNN shapes, so aggregator checkpoints load with the matching `(3072,)` observation shape and encoder module.
- Adds parser coverage for the 3D-27 aggregator eval encoder.

## Why
3D-27 needs online HM3D navigation evaluation for all six offline-ablation runs. The existing eval launcher only accepted `cnn`/`vggt` and hard-coded the VGGT `(4116,)` `wp_cp` path, so the aggregator variant could not be evaluated online.

## Linear issue
- https://linear.app/3d-wm-objectnav/issue/3D-27/offline-ablation-3-online-navigation-evaluation-6-runs-in-hm3d

## Acceptance criteria checked
- [x] Single-run SLURM submission wrapper for one encoder/seed.
- [x] Full six-run sweep wrapper for `wp_cp` and `aggregator`, seeds 0/1/2.
- [x] Online eval maps `wp_cp -> --encoder vggt` and `aggregator -> --encoder vggt_aggregator_mlp`.
- [x] Aggregator eval parser accepts `vggt_aggregator_mlp`.
- [x] Aggregator eval agent config uses the registry/encoder spec instead of the old hard-coded VGGT feature shape.
- [ ] Actual 6 HM3D eval runs submitted/completed. Blocked locally because the completed 3D-26 SLURM jobs point to a removed worktree and I could not find the produced checkpoints on disk.

## Screenshots, Loom, or preview URL
N/A.

## W&B run link or run ID
Not available yet. The eval jobs can log videos by setting `WANDB_PROJECT`, but no 3D-27 production eval jobs were submitted in this pass because checkpoints were not discoverable locally.

## Risk
- Low-to-medium: the launcher change generalizes eval config construction to use the existing encoder registry/spec. This is the same abstraction used by training, but it changes the code path for CNN/VGGT eval too.
- The new scripts assume 3D-26 checkpoints live under `output/3d26-offline-ablation/<encoder>-seed<seed>/run-*/checkpoints/step_*.pkl` unless `CHECKPOINT` or `CHECKPOINT_ROOT` is supplied.

## How to test
```bash
.venv/bin/python -m pytest tests/r2dreamer/launch/test_parser.py tests/r2dreamer/launch/test_registries.py
bash -n scripts/r2dreamer/slurm/evaluate_offline_ablation.sbatch scripts/r2dreamer/slurm/submit_online_eval.sh scripts/r2dreamer/slurm/submit_online_eval_sweep.sh
scripts/r2dreamer/slurm/submit_online_eval.sh dev wp_cp 0 --dry-run
scripts/r2dreamer/slurm/submit_online_eval.sh dev aggregator 0 --dry-run
```

Observed:
- `10 passed`
- `sbatch --test-only` passed for both `wp_cp` and `aggregator` dev dry runs on `gpu_h100_short`.

## What was intentionally not done
- Did not submit the six production HM3D eval jobs yet: `sacct` shows the 3D-26 jobs completed, but their recorded worktree path no longer exists and no `3d26-offline-ablation` checkpoints were found under the main checkout/action-runner paths. Once checkpoint paths are restored, run:

```bash
CHECKPOINT_ROOT=/path/to/3d26-offline-ablation \
  scripts/r2dreamer/slurm/submit_online_eval_sweep.sh prod
```

or pass per-run `CHECKPOINT=/path/to/step_000500000.pkl` with `submit_online_eval.sh`.

## Agent involvement
Implemented by Hermes Agent in a clean git worktree from `origin/main` because the main checkout had unrelated local modifications.

## Follow-up issues created
None.
