### PR TITLE
feat(r2dreamer): external PyTorch R2Dreamer offline adapter (3D-45)

### DIFF
--- a/docs/notes/external-offline-r2dreamer.md
+++ b/docs/notes/external-offline-r2dreamer.md
@@ -1,0 +1,108 @@
+# External (PyTorch) R2Dreamer — offline adapter
+
+Adapter that trains the **original PyTorch R2Dreamer** (`external/r2dreamer/`)
+offline from the canonical replay buffer, to produce a baseline that is
+apples-to-apples with the JAX offline numbers.
+
+- Linear: **3D-45** (this adapter) → **3D-46** (the 3 baseline runs + comparison).
+- Parent ablation: **3D-24** (VGGT WP/CP vs Aggregator MLP as R2Dreamer input).
+- Entry point: `scripts/r2dreamer/train_external_offline.py`.
+
+## Why an adapter
+
+The stock external entry point (`external/r2dreamer/train.py`) is **env-driven**
+(`make_envs` → `OnlineTrainer`, torchrl `LazyTensorStorage` filled by live
+rollouts) and logs only to TensorBoard/jsonl. To replay the fixed offline buffer
+on a precomputed vector and land in the same W&B project as the JAX runs, the
+adapter adds three things without touching the vendored repo:
+
+1. **Vector input** — declares an obs space `{"vector": Box(4116,)}` and sets
+   `encoder.mlp_keys='vector'`, `cnn_keys='$^'`. `MultiEncoder` already routes a
+   `len(shape)==1` obs matched by `mlp_keys` to its MLP branch; `$^` is the
+   match-nothing regex that disables the CNN. No new modeling.
+2. **Offline replay** (`OfflineVectorBuffer`) — drop-in for the external
+   `Buffer`'s `sample()/update()/count()` interface, so `agent.update()` is
+   reused verbatim (identical LaProp/GradScaler/AGC/scheduler behaviour).
+3. **W&B** — a thin `tools.Logger` subclass that mirrors scalars to W&B, gated
+   behind `--wandb`.
+
+## Fairness: identical to the JAX `OfflineBufferDataset`
+
+The buffer reproduces the JAX sampling contract exactly, so the external sees the
+same `(obs, action, reward, flags)` windows the JAX runs saw:
+
+- contiguous windows that **may straddle episode boundaries**;
+- `is_first[:, 0] = True`, and `is_first[:, t] = done[t-1]` (reset on `done`);
+- `is_terminal == is_last == done` (the buffer records only env `done`);
+- actions aligned with obs at the same index (no torchrl one-step shift), one-hot
+  over the 4 Habitat actions;
+- **zeroed initial latent each batch** — episode reset is driven entirely by
+  `is_first`. The external R2-Dreamer replay-buffer latent write-back
+  (`replay_buffer.update`) is a **no-op** offline, matching the JAX path which
+  carries no cross-batch latent state.
+
+Train/heldout split = `collection_metadata.json["heldout_split"]`
+(last 10% of episodes by `episode_id`), same as 3D-25/3D-26.
+
+## Decoder-free on both sides
+
+Default `rep_loss="r2dreamer"` (Barlow-Twins redundancy reduction) carries **no
+decoder** — same as the decoder-free JAX R2Dreamer — so there is **no
+reconstruction NLL on either side**. Comparable held-out metrics are dynamics KL,
+representation KL, reward MSE, and k-step latent rollout error (k ∈ {1,5,15}).
+(`rep_loss="dreamer"` would add a `MultiDecoder` and a recon NLL; we do **not**
+use it for the baseline.)
+
+## Environment
+
+Run under the **external** venv — it has torchrl/tensordict/gymnasium; the main
+`.venv` does not:
+
+```
+external/r2dreamer/.venv/bin/python scripts/r2dreamer/train_external_offline.py ...
+```
+
+## Commands
+
+Smoke (NaN-free, no W&B; CPU is fine — `torch.compile` is auto-disabled and
+`GradScaler` auto-disables without CUDA):
+
+```
+external/r2dreamer/.venv/bin/python scripts/r2dreamer/train_external_offline.py \
+    --encoder wp_cp --seed 0 --steps 100 \
+    --buffer-dir data/offline_buffer_smoke --output-dir /tmp/ext_smoke \
+    --device cpu --batch-size 4 --seq-len 16
+```
+
+Real run (GPU) — one per seed for 3D-46:
+
+```
+external/r2dreamer/.venv/bin/python scripts/r2dreamer/train_external_offline.py \
+    --encoder wp_cp --seed 0 --steps 500000 \
+    --buffer-dir data/offline_buffer --output-dir output/3d46/ext-wp_cp-seed0 \
+    --device cuda:0 --wandb --wandb-name ext-wp_cp-seed0
+```
+
+W&B (when `--wandb`): project `3d-vla-objectnav-offline-ablation`, tags
+`offline-ablation, 3d-24, framework:pytorch-external, variant:wp_cp`, run name
+`ext-<encoder>-seed<n>` — so the runs filter beside the JAX `wp_cp-seed{0,1,2}`.
+
+`run_config.json` (written to `--output-dir`) records both repo and
+`external/r2dreamer` code SHAs plus the buffer metadata for reproducibility.
+
+## Handoff to 3D-46
+
+- Launch `--seed {0,1,2}`, `--steps 500000`, `--device cuda:0`, `--wandb`. Runs
+  are independent → parallelizable across nodes (mirror the SLURM pattern in
+  `scripts/slurm/`).
+- Held-out metrics: reuse the train/heldout split above; report dynamics KL,
+  representation KL, reward MSE, k-step rollout error (k ∈ {1,5,15}) — **not**
+  reconstruction NLL (decoder-free on both sides).
+- The only field that may differ across the 3 runs is `--seed`.
+
+## Tests
+
+`tests/r2dreamer/test_external_offline_buffer.py` validates the split, window
+sampling, `is_first` done-shift, one-hot actions, and zeroed initial latent on a
+synthetic buffer. Skipped under the main venv (no tensordict); runs under the
+external venv.

--- a/scripts/r2dreamer/train_external_offline.py
+++ b/scripts/r2dreamer/train_external_offline.py
@@ -1,0 +1,563 @@
+#!/usr/bin/env python
+"""Offline training of the *external* (PyTorch) R2Dreamer — 3D-45 adapter.
+
+Trains the ORIGINAL PyTorch R2Dreamer (``external/r2dreamer/``) offline from the
+canonical replay buffer (``data/offline_buffer/``) on the WP/CP vector readout
+(``z_wp_cp.npz``, 4116-d), with no live env and no VGGT forward pass. This is the
+infra that the 3D-46 baseline runs depend on: it produces a PyTorch number that
+is apples-to-apples with the JAX 3D-26 offline results.
+
+Why a wrapper instead of ``external/r2dreamer/train.py``
+-------------------------------------------------------
+The stock external entry point is env-driven (``make_envs`` -> ``OnlineTrainer``,
+torchrl ``LazyTensorStorage`` filled by live rollouts) and logs only to
+TensorBoard/jsonl. This wrapper instead:
+
+  * feeds the 4116-d WP/CP vector through the MLP encoder branch by declaring an
+    obs space ``{"vector": Box(4116,)}`` and setting ``encoder.mlp_keys='vector'``
+    / ``cnn_keys='$^'`` (the match-nothing regex that disables the CNN);
+  * replays the fixed offline buffer with the SAME sampling semantics as the JAX
+    ``OfflineBufferDataset`` — contiguous windows that may straddle episode
+    boundaries, ``is_first`` reset wherever ``done`` flipped, ``is_terminal=done``,
+    and a zeroed initial latent each batch (the external R2-Dreamer latent
+    write-back is a no-op offline, matching the JAX path which carries no
+    cross-batch latent state);
+  * reuses ``agent.update()`` verbatim, so the optimizer / GradScaler / AGC /
+    scheduler behaviour is identical to the online external trainer;
+  * optionally mirrors scalars to W&B in the same project as the JAX runs.
+
+The default ``rep_loss="r2dreamer"`` (Barlow-Twins redundancy reduction) carries
+NO decoder — matching the decoder-free JAX R2Dreamer — so there is no
+reconstruction NLL on either side. See 3D-45 / 3D-46.
+
+IMPORTANT — run under the external venv (it has torchrl/tensordict/gymnasium):
+
+    external/r2dreamer/.venv/bin/python scripts/r2dreamer/train_external_offline.py ...
+
+Smoke (NaN-free 100 steps on CPU, no W&B):
+
+    external/r2dreamer/.venv/bin/python scripts/r2dreamer/train_external_offline.py \\
+        --encoder wp_cp --seed 0 --steps 100 \\
+        --buffer-dir data/offline_buffer_smoke --output-dir /tmp/ext_smoke \\
+        --device cpu --batch-size 4 --seq-len 16
+
+Real run (GPU, one of seeds {0,1,2} for 3D-46):
+
+    external/r2dreamer/.venv/bin/python scripts/r2dreamer/train_external_offline.py \\
+        --encoder wp_cp --seed 0 --steps 500000 \\
+        --buffer-dir data/offline_buffer --output-dir output/3d46/ext-wp_cp-seed0 \\
+        --device cuda:0 --wandb --wandb-name ext-wp_cp-seed0
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXT = REPO_ROOT / "external" / "r2dreamer"
+
+# Fairness-contract defaults — must match 3D-26 (the JAX offline runs).
+SHARED = {
+    "batch_size": 16,
+    "seq_len": 64,
+    "imag_horizon": 15,
+}
+
+# z_*.npz file + flat feature dim per readout. Aggregator is wired but out of
+# scope for 3D-45/3D-46 (WP/CP only); kept so a future readout is a one-liner.
+ENCODER_SPECS = {
+    "wp_cp": {"z_file": "z_wp_cp.npz", "obs_dim": 4116},
+    "aggregator": {"z_file": "z_aggregator.npz", "obs_dim": 3072},
+}
+
+NUM_ACTIONS = 4  # Habitat objectnav: stop / forward / left / right
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--encoder", choices=list(ENCODER_SPECS), default="wp_cp")
+    p.add_argument("--seed", type=int, required=True)
+    p.add_argument("--steps", type=int, default=500_000, help="Total grad steps.")
+    p.add_argument("--buffer-dir", default="data/offline_buffer")
+    p.add_argument("--output-dir", required=True)
+    p.add_argument("--device", default="cuda:0")
+    p.add_argument("--model-size", default="size12M")
+    p.add_argument("--batch-size", type=int, default=SHARED["batch_size"])
+    p.add_argument("--seq-len", type=int, default=SHARED["seq_len"])
+    p.add_argument("--log-every", type=int, default=250)
+    p.add_argument("--checkpoint-every", type=int, default=50_000)
+    # compile defaults to the model config (True); forced off on CPU.
+    p.add_argument("--compile", dest="compile", action="store_true", default=None)
+    p.add_argument("--no-compile", dest="compile", action="store_false")
+    p.add_argument("--wandb", action="store_true", help="Enable W&B (off by default).")
+    p.add_argument("--wandb-project", default="3d-vla-objectnav-offline-ablation")
+    p.add_argument("--wandb-name", default=None)
+    p.add_argument(
+        "--wandb-tags",
+        default="offline-ablation,3d-24,framework:pytorch-external",
+        help="Comma-separated. `variant:<encoder>` is appended automatically.",
+    )
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Config / spaces
+# ---------------------------------------------------------------------------
+def build_model_config(model_size: str, device: str, compile_flag: bool | None):
+    """Compose the external model config without hydra's env layer.
+
+    The shipped ``configs/model/_base_.yaml`` interpolates ``${env.encoder.*}``
+    and ``${device}``; we supply those nodes here and point the encoder/decoder
+    at the single ``vector`` obs key (CNN disabled via the ``$^`` regex).
+    """
+    from omegaconf import OmegaConf
+
+    base = OmegaConf.load(EXT / "configs" / "model" / "_base_.yaml")
+    size = OmegaConf.load(EXT / "configs" / "model" / f"{model_size}.yaml")
+    if "defaults" in size:
+        del size["defaults"]  # hydra-only key; we merge _base_ explicitly
+    model = OmegaConf.merge(base, size)
+
+    top = OmegaConf.create(
+        {
+            "device": device,
+            "env": {
+                "encoder": {"mlp_keys": "vector", "cnn_keys": "$^"},
+                "decoder": {"mlp_keys": "vector", "cnn_keys": "$^"},
+            },
+            "model": model,
+        }
+    )
+    OmegaConf.resolve(top)
+    model_cfg = top.model
+    if compile_flag is not None:
+        model_cfg.compile = bool(compile_flag)
+    # Dreamer mutates a few config fields in place (actor.shape, actor.dist, ...).
+    OmegaConf.set_struct(model_cfg, False)
+    return model_cfg
+
+
+def make_spaces(obs_dim: int, num_actions: int):
+    """Build a gymnasium obs Dict + a discrete (one-hot) action Box.
+
+    Mirrors ``envs/wrappers.OneHotAction``: a Box with a ``.discrete`` marker so
+    ``Dreamer`` selects the one-hot actor head. Only the ``vector`` key is
+    declared, so ``MultiEncoder`` routes it (and nothing else) to the MLP encoder.
+    """
+    import gymnasium as gym
+
+    obs_space = gym.spaces.Dict(
+        {"vector": gym.spaces.Box(-np.inf, np.inf, shape=(obs_dim,), dtype=np.float32)}
+    )
+    act_space = gym.spaces.Box(low=0.0, high=1.0, shape=(num_actions,), dtype=np.float32)
+    act_space.discrete = True
+    return obs_space, act_space
+
+
+# ---------------------------------------------------------------------------
+# Offline replay buffer (drop-in for external Buffer's sample/update/count)
+# ---------------------------------------------------------------------------
+class OfflineVectorBuffer:
+    """Replays ``data/offline_buffer`` windows with JAX-identical semantics.
+
+    Exposes the ``(data, index, initial) = sample()`` / ``update(index, stoch,
+    deter)`` / ``count()`` interface that ``Dreamer.update`` calls, so the agent's
+    training step is reused unchanged. Sampling matches
+    ``src/buffer/offline_buffer_dataset.OfflineBufferDataset``: contiguous windows
+    over a single split's index range, ``is_first[:,0]=True`` plus wherever
+    ``done`` flipped, ``is_terminal=is_last=done``, and a zeroed initial latent
+    (episode reset is driven entirely by ``is_first``).
+    """
+
+    def __init__(
+        self,
+        buffer_dir: Path,
+        encoder: str,
+        split: str,
+        *,
+        batch_size: int,
+        seq_len: int,
+        device,
+        seed: int,
+        deter_size: int,
+        stoch_classes: int,
+        stoch_discrete: int,
+    ) -> None:
+        import torch
+
+        self._torch = torch
+        self.device = torch.device(device)
+        self.B = int(batch_size)
+        self.L = int(seq_len)
+        self._init_dims = (int(stoch_classes), int(stoch_discrete), int(deter_size))
+
+        spec = ENCODER_SPECS[encoder]
+        meta = _load_metadata(buffer_dir)
+        self.metadata = meta
+        n = meta["n_completed_steps"]
+        heldout_start = meta["heldout_start_episode"]
+
+        skeleton = np.load(buffer_dir / "trajectory_skeleton.npz")
+        try:
+            actions = skeleton["action"][:n]
+            rewards = skeleton["reward"][:n]
+            dones = skeleton["done"][:n]
+            episode_ids = skeleton["episode_id"][:n]
+        finally:
+            skeleton.close()
+
+        z = _load_features(buffer_dir / spec["z_file"])[:n]
+
+        if split == "train":
+            mask = episode_ids < heldout_start
+        elif split == "heldout":
+            mask = episode_ids >= heldout_start
+        else:
+            raise ValueError(f"unknown split: {split!r}")
+        if not mask.any():
+            raise ValueError(
+                f"split={split!r} empty (heldout_start={heldout_start}, "
+                f"episodes={meta['num_episodes']})"
+            )
+        idx = np.where(mask)[0]
+        if not np.all(np.diff(idx) == 1):
+            raise ValueError(
+                f"split={split!r} is not a contiguous transition range — the "
+                f"collector reordered episodes? Aborting to avoid wrap-around."
+            )
+        start, end = int(idx[0]), int(idx[-1]) + 1
+
+        self.obs = z[start:end]  # kept float16 in RAM; cast per-batch
+        self.actions = actions[start:end]
+        self.rewards = rewards[start:end]
+        self.dones = dones[start:end]
+        self.size = int(self.obs.shape[0])
+        self.obs_dim = int(self.obs.shape[1])
+        if self.size < self.L:
+            raise ValueError(f"split has {self.size} steps < seq_len {self.L}")
+        self._rng = np.random.default_rng(seed)
+
+        print(
+            f"OfflineVectorBuffer[{split}]: {self.size} steps, obs={self.obs.shape} "
+            f"{self.obs.dtype}, {encoder} from {buffer_dir}"
+        )
+
+    def sample(self):
+        torch = self._torch
+        n_valid = self.size - self.L + 1
+        starts = self._rng.integers(0, n_valid, size=self.B)
+        win = starts[:, None] + np.arange(self.L)[None, :]  # (B, L)
+
+        dev = self.device
+        obs = torch.as_tensor(self.obs[win].astype(np.float32), device=dev)
+        act_idx = torch.as_tensor(self.actions[win].astype(np.int64), device=dev)
+        action = torch.nn.functional.one_hot(act_idx, NUM_ACTIONS).to(torch.float32)
+        reward = torch.as_tensor(
+            self.rewards[win].astype(np.float32), device=dev
+        ).unsqueeze(-1)
+
+        dones = self.dones[win]  # (B, L) bool
+        is_first = np.zeros_like(dones)
+        is_first[:, 0] = True
+        is_first[:, 1:] = dones[:, :-1]
+        is_first_t = torch.as_tensor(is_first, device=dev).unsqueeze(-1)
+        done_t = torch.as_tensor(dones.astype(np.float32), device=dev).unsqueeze(-1)
+
+        from tensordict import TensorDict
+
+        data = TensorDict(
+            {
+                "vector": obs,
+                "action": action,
+                "reward": reward,
+                "is_first": is_first_t,
+                "is_last": done_t,
+                "is_terminal": done_t,
+            },
+            batch_size=(self.B, self.L),
+            device=dev,
+        )
+        s_classes, s_discrete, deter = self._init_dims
+        initial = (
+            torch.zeros(self.B, s_classes, s_discrete, device=dev),
+            torch.zeros(self.B, deter, device=dev),
+        )
+        return data, win, initial
+
+    def update(self, index, stoch, deter):  # noqa: D401 - offline no-op
+        """No-op: offline replay carries no cross-batch latent state (matches JAX)."""
+
+    def count(self):
+        return self.size
+
+
+def _load_metadata(buffer_dir: Path) -> dict:
+    """Read collection_metadata.json; tolerate a missing file (all-train)."""
+    skeleton = np.load(buffer_dir / "trajectory_skeleton.npz")
+    try:
+        episode_ids = skeleton["episode_id"]
+        n_rows = int(episode_ids.shape[0])
+    finally:
+        skeleton.close()
+
+    meta_path = buffer_dir / "collection_metadata.json"
+    raw = json.loads(meta_path.read_text()) if meta_path.exists() else {}
+    n_completed = int(raw.get("n_completed_steps", n_rows))
+    if n_completed > n_rows:
+        raise ValueError(
+            f"metadata n_completed_steps={n_completed} > skeleton rows {n_rows}"
+        )
+    num_episodes = int(episode_ids[:n_completed].max()) + 1 if n_completed else 0
+    heldout = raw.get("heldout_split", {})
+    return {
+        "n_completed_steps": n_completed,
+        "num_episodes": num_episodes,
+        "heldout_start_episode": int(
+            heldout.get("episode_id_start_inclusive", num_episodes)
+        ),
+        "code_sha": raw.get("code_sha"),
+        "checkpoint_sha256": raw.get("checkpoint_sha256"),
+        "collect_seed": int(raw.get("collect_seed", -1)),
+    }
+
+
+def _load_features(path: Path) -> np.ndarray:
+    data = np.load(path)
+    try:
+        key = "features" if "features" in data.files else data.files[0]
+        return data[key]
+    finally:
+        data.close()
+
+
+# ---------------------------------------------------------------------------
+# Logger (TensorBoard/jsonl via tools.Logger, + optional W&B mirror)
+# ---------------------------------------------------------------------------
+def make_logger(output_dir: Path, wandb_run):
+    import tools  # external/r2dreamer/tools.py (EXT is on sys.path)
+
+    if wandb_run is None:
+        return tools.Logger(output_dir)
+
+    class _WandbLogger(tools.Logger):
+        def write(self, step, fps=False):
+            scalars = dict(self._scalars)  # snapshot before super() clears
+            super().write(step, fps=fps)
+            wandb_run.log(scalars, step=int(step))
+
+    return _WandbLogger(output_dir)
+
+
+# ---------------------------------------------------------------------------
+# Offline trainer
+# ---------------------------------------------------------------------------
+class OfflineTrainer:
+    """Pure offline loop: ``steps`` grad updates, no env, no eval episodes."""
+
+    def __init__(self, agent, buffer, logger, *, steps, log_every, checkpoint_every, output_dir):
+        self.agent = agent
+        self.buffer = buffer
+        self.logger = logger
+        self.steps = int(steps)
+        self.log_every = int(log_every)
+        self.checkpoint_every = int(checkpoint_every)
+        self.output_dir = Path(output_dir)
+
+    def run(self):
+        import torch
+
+        import tools
+
+        self.agent.train()
+        t0 = time.time()
+        last = t0
+        for step in range(self.steps):
+            metrics = self.agent.update(self.buffer)
+            scalars = {k: _to_float(v) for k, v in metrics.items()}
+
+            bad = [k for k, v in scalars.items() if not math.isfinite(v)]
+            if bad:
+                raise RuntimeError(f"non-finite metric(s) at step {step}: {bad}")
+
+            if step % self.log_every == 0:
+                now = time.time()
+                for k, v in scalars.items():
+                    self.logger.scalar(f"train/{k}", v)
+                self.logger.scalar("perf/sps", self.log_every / max(now - last, 1e-6))
+                self.logger.scalar("perf/elapsed_min", (now - t0) / 60.0)
+                self.logger.write(step, fps=True)
+                last = now
+
+            if self.checkpoint_every and step > 0 and step % self.checkpoint_every == 0:
+                self._save(step)
+
+        self._save(self.steps, latest=True)
+        print(f"Done: {self.steps} grad steps in {(time.time() - t0) / 60:.1f} min")
+
+    def _save(self, step, latest=False):
+        import torch
+
+        import tools
+
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "step": step,
+            "agent_state_dict": self.agent.state_dict(),
+            "optims_state_dict": tools.recursively_collect_optim_state_dict(self.agent),
+        }
+        torch.save(payload, self.output_dir / f"checkpoint_{step:09d}.pt")
+        if latest:
+            torch.save(payload, self.output_dir / "latest.pt")
+        print(f"  saved checkpoint @ step {step}")
+
+
+def _to_float(v) -> float:
+    try:
+        return float(v.item()) if hasattr(v, "item") else float(v)
+    except Exception:
+        return float("nan")
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+def _git_sha(path: Path) -> str | None:
+    try:
+        return subprocess.check_output(
+            ["git", "-C", str(path), "rev-parse", "HEAD"], text=True
+        ).strip()
+    except Exception:
+        return None
+
+
+def _resolve(path_str: str) -> Path:
+    p = Path(path_str)
+    return p if p.is_absolute() else (REPO_ROOT / p)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _build_parser().parse_args(argv)
+
+    # Make the external package importable (it imports siblings by bare name).
+    if str(EXT) not in sys.path:
+        sys.path.insert(0, str(EXT))
+
+    import torch
+
+    import tools
+    from dreamer import Dreamer
+
+    buffer_dir = _resolve(args.buffer_dir)
+    output_dir = _resolve(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    device = args.device
+    compile_flag = args.compile
+    if device.startswith("cpu"):
+        compile_flag = False  # reduce-overhead/cudagraphs require CUDA
+
+    tools.set_seed_everywhere(args.seed)
+    if device.startswith("cuda"):
+        torch.set_float32_matmul_precision("high")
+
+    spec = ENCODER_SPECS[args.encoder]
+    model_cfg = build_model_config(args.model_size, device, compile_flag)
+    obs_space, act_space = make_spaces(spec["obs_dim"], NUM_ACTIONS)
+
+    print(
+        f"3D-45 external offline: encoder={args.encoder} seed={args.seed} "
+        f"steps={args.steps} device={device} compile={bool(model_cfg.compile)}"
+    )
+    agent = Dreamer(model_cfg, obs_space, act_space).to(device)
+
+    train_buf = OfflineVectorBuffer(
+        buffer_dir,
+        args.encoder,
+        split="train",
+        batch_size=args.batch_size,
+        seq_len=args.seq_len,
+        device=device,
+        seed=args.seed,
+        deter_size=int(model_cfg.rssm.deter),
+        stoch_classes=int(model_cfg.rssm.stoch),
+        stoch_discrete=int(model_cfg.rssm.discrete),
+    )
+    if train_buf.obs_dim != spec["obs_dim"]:
+        raise ValueError(
+            f"buffer obs_dim={train_buf.obs_dim} != encoder {args.encoder} "
+            f"expected {spec['obs_dim']}"
+        )
+
+    # W&B (off by default; real 3D-46 runs pass --wandb).
+    wandb_run = None
+    if args.wandb:
+        import wandb
+        from omegaconf import OmegaConf
+
+        tags = [t.strip() for t in args.wandb_tags.split(",") if t.strip()]
+        tags.append(f"variant:{args.encoder}")
+        wandb_run = wandb.init(
+            project=args.wandb_project,
+            name=args.wandb_name or f"ext-{args.encoder}-seed{args.seed}",
+            tags=tags,
+            config=OmegaConf.to_container(model_cfg, resolve=True),
+        )
+
+    # Reproducibility record.
+    from omegaconf import OmegaConf
+
+    run_config = {
+        "issue": "3D-45/3D-46",
+        "framework": "pytorch-external",
+        "encoder": args.encoder,
+        "obs_dim": spec["obs_dim"],
+        "num_actions": NUM_ACTIONS,
+        "seed": args.seed,
+        "steps": args.steps,
+        "batch_size": args.batch_size,
+        "seq_len": args.seq_len,
+        "device": device,
+        "model_size": args.model_size,
+        "rep_loss": str(model_cfg.rep_loss),
+        "compile": bool(model_cfg.compile),
+        "buffer_dir": str(buffer_dir),
+        "train_split_size": train_buf.size,
+        "buffer_metadata": train_buf.metadata,
+        "code_sha_main": _git_sha(REPO_ROOT),
+        "code_sha_external": _git_sha(EXT),
+        "wandb_run_id": wandb_run.id if wandb_run is not None else None,
+        "wandb_run_url": wandb_run.url if wandb_run is not None else None,
+        "model_config": OmegaConf.to_container(model_cfg, resolve=True),
+    }
+    (output_dir / "run_config.json").write_text(json.dumps(run_config, indent=2, default=str))
+
+    logger = make_logger(output_dir, wandb_run)
+    OfflineTrainer(
+        agent,
+        train_buf,
+        logger,
+        steps=args.steps,
+        log_every=args.log_every,
+        checkpoint_every=args.checkpoint_every,
+        output_dir=output_dir,
+    ).run()
+
+    if wandb_run is not None:
+        wandb_run.finish()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/r2dreamer/test_external_offline_buffer.py
+++ b/tests/r2dreamer/test_external_offline_buffer.py
@@ -1,0 +1,135 @@
+"""Semantics of the external-R2Dreamer offline buffer adapter (3D-45).
+
+Validates that `OfflineVectorBuffer` (scripts/r2dreamer/train_external_offline.py)
+reproduces the JAX `OfflineBufferDataset` sampling contract: the train/heldout
+split, contiguous windows, `is_first` reset on `done`, `is_terminal == is_last ==
+done`, one-hot actions, and a zeroed initial latent.
+
+These run under the *external* venv (torch + tensordict + gymnasium). Under the
+main venv they are skipped — tensordict is not installed there.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("tensordict")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "r2dreamer" / "train_external_offline.py"
+
+
+def _load_module():
+    # The external package imports siblings by bare name; put it on the path so
+    # the module's lazy `from dreamer import Dreamer` etc. could resolve too.
+    sys.path.insert(0, str(REPO_ROOT / "external" / "r2dreamer"))
+    spec = importlib.util.spec_from_file_location("train_external_offline", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _make_buffer(tmp: Path, *, ep_lengths, obs_dim=8, heldout_start=None, seed=0):
+    """Write a tiny offline buffer (skeleton + z_wp_cp + metadata) to `tmp`."""
+    rng = np.random.default_rng(seed)
+    actions, rewards, dones, episode_ids = [], [], [], []
+    for ep, length in enumerate(ep_lengths):
+        actions.append(rng.integers(0, 4, size=length).astype(np.int32))
+        rewards.append(rng.standard_normal(length).astype(np.float32))
+        d = np.zeros(length, dtype=bool)
+        d[-1] = True  # episode terminates on its last step
+        dones.append(d)
+        episode_ids.append(np.full(length, ep, dtype=np.int32))
+    action = np.concatenate(actions)
+    reward = np.concatenate(rewards)
+    done = np.concatenate(dones)
+    episode_id = np.concatenate(episode_ids)
+    n = action.shape[0]
+
+    np.savez(tmp / "trajectory_skeleton.npz", action=action, reward=reward, done=done, episode_id=episode_id)
+    np.savez(tmp / "z_wp_cp.npz", features=rng.standard_normal((n, obs_dim)).astype(np.float16))
+
+    meta = {"n_completed_steps": n, "num_episodes": len(ep_lengths)}
+    if heldout_start is not None:
+        meta["heldout_split"] = {"episode_id_start_inclusive": heldout_start}
+    (tmp / "collection_metadata.json").write_text(json.dumps(meta))
+    return n
+
+
+def _buf(mod, tmp, *, split, batch_size=4, seq_len=5, obs_dim=8):
+    return mod.OfflineVectorBuffer(
+        tmp, "wp_cp", split=split,
+        batch_size=batch_size, seq_len=seq_len, device="cpu", seed=0,
+        deter_size=16, stoch_classes=6, stoch_discrete=3,
+    )
+
+
+def test_split_partitions_episodes(tmp_path):
+    mod = _load_module()
+    # 5 episodes of 10 steps = 50; heldout = episodes >= 4 (last episode, 10 steps).
+    _make_buffer(tmp_path, ep_lengths=[10] * 5, heldout_start=4)
+    train = _buf(mod, tmp_path, split="train")
+    heldout = _buf(mod, tmp_path, split="heldout")
+    assert train.size == 40
+    assert heldout.size == 10
+    assert train.size + heldout.size == 50
+
+
+def test_sample_shapes_and_flags(tmp_path):
+    import torch
+
+    mod = _load_module()
+    _make_buffer(tmp_path, ep_lengths=[10] * 5, heldout_start=4, obs_dim=8)
+    buf = _buf(mod, tmp_path, split="train", batch_size=4, seq_len=5, obs_dim=8)
+    data, index, initial = buf.sample()
+
+    assert tuple(data.batch_size) == (4, 5)
+    assert data["vector"].shape == (4, 5, 8)
+    assert data["action"].shape == (4, 5, mod.NUM_ACTIONS)
+    assert data["reward"].shape == (4, 5, 1)
+    for k in ("is_first", "is_last", "is_terminal"):
+        assert data[k].shape == (4, 5, 1)
+
+    # Actions are one-hot.
+    assert torch.allclose(data["action"].sum(-1), torch.ones(4, 5))
+    # First column of every window is a reset.
+    assert bool(data["is_first"][:, 0].all())
+    # is_terminal == is_last == done.
+    assert torch.equal(data["is_terminal"], data["is_last"])
+    # Zeroed initial latent of the right shape.
+    s, d = initial
+    assert s.shape == (4, 6, 3) and d.shape == (4, 16)
+    assert float(s.abs().sum()) == 0.0 and float(d.abs().sum()) == 0.0
+    assert index.shape == (4, 5)
+
+
+def test_is_first_tracks_done_shift(tmp_path):
+    mod = _load_module()
+    # Two episodes of 8 in a single (all-train) split, so windows straddle the
+    # boundary and exercise the interior is_first reset.
+    _make_buffer(tmp_path, ep_lengths=[8, 8], heldout_start=99)
+    buf = _buf(mod, tmp_path, split="train", batch_size=8, seq_len=5)
+    data, index, _ = buf.sample()
+    isf = data["is_first"][..., 0].bool().numpy()  # (B, L)
+
+    # Invariant (matches JAX OfflineBufferDataset): is_first[:,0]=True, and
+    # is_first[:,t] = done at the previous global step.
+    expected = np.zeros_like(isf)
+    expected[:, 0] = True
+    expected[:, 1:] = buf.dones[index[:, :-1]]
+    assert np.array_equal(isf, expected)
+    # The boundary at global index 7 must show up as a reset somewhere.
+    assert isf[:, 1:].any() or not (index[:, :-1] == 7).any()
+
+
+def test_missing_metadata_is_all_train(tmp_path):
+    mod = _load_module()
+    # No heldout_split / no metadata file beyond n_completed -> everything is train.
+    n = _make_buffer(tmp_path, ep_lengths=[6, 6, 6], heldout_start=None)
+    train = _buf(mod, tmp_path, split="train", seq_len=4)
+    assert train.size == n


### PR DESCRIPTION
## What changed
Adds an offline training adapter for the **original PyTorch R2Dreamer** (`external/r2dreamer/`) so it can be trained from the canonical `data/offline_buffer/` on the WP/CP vector readout — the infra that the 3D-46 baseline runs depend on.

- **`scripts/r2dreamer/train_external_offline.py`** — self-contained CLI (runs under `external/r2dreamer/.venv`, which has torchrl/tensordict/gymnasium; the main `.venv` does not).
  - **Vector input** via the existing `MultiEncoder` MLP branch: obs space `{"vector": Box(4116,)}`, `encoder.mlp_keys='vector'`, `cnn_keys='$^'` (match-nothing regex disables the CNN). No new modeling.
  - **`OfflineVectorBuffer`** mirrors the JAX `OfflineBufferDataset` exactly: contiguous windows that may straddle episodes, `is_first[:,0]=True` + wherever `done` flipped, `is_terminal=is_last=done`, zeroed initial latent each batch. The external R2-Dreamer latent write-back is a **no-op** offline (matches the JAX path, which carries no cross-batch latent state).
  - Reuses `agent.update()` verbatim → identical LaProp/GradScaler/AGC/scheduler behaviour to the online external trainer.
  - **W&B** gated behind `--wandb`: project `3d-vla-objectnav-offline-ablation`, tags `offline-ablation, 3d-24, framework:pytorch-external, variant:wp_cp`, name `ext-<encoder>-seed<n>`. Main + `external/r2dreamer` code SHAs recorded in `run_config.json`.
- **`tests/r2dreamer/test_external_offline_buffer.py`** — buffer-semantics tests (split, window shapes, `is_first` done-shift, one-hot actions, zero initial); skipped under the main venv (no tensordict).
- **`docs/notes/external-offline-r2dreamer.md`** — usage + design + 3D-46 handoff.

## Why
To produce an apples-to-apples PyTorch baseline against the JAX 3D-26 offline numbers. The stock external entry point is env-driven and has no W&B; this adapter adds offline replay + vector input + W&B without touching the vendored repo.

## Linear
3D-45 (this PR) → feeds 3D-46. Parent ablation: 3D-24.

## Acceptance criteria checked
- [x] NaN-free 100 grad steps on a buffer slice, no W&B — CPU smoke `Done: 100 grad steps`, exit 0 (trainer raises on any non-finite metric).
- [x] 4116-d vector consumed via the MLP encoder — `Encoder MLP shapes: {'vector': (4116,)}`, `Encoder CNN shapes: {}`.
- [x] Code SHA of both the main repo and `external/r2dreamer` recorded in `run_config.json`.
- [~] One real seed logs to the W&B project with the agreed tags/name — code in place and gated behind `--wandb`; **not live-tested** (no GPU on login node + no W&B from CI). Will be exercised by the first 3D-46 run.

## Decoder-free note
Default `rep_loss="r2dreamer"` (Barlow-Twins) carries **no decoder**, same as the JAX side — so there is no reconstruction NLL on either side. The issue's caveat (external decoder → recon NLL) only applies under `rep_loss="dreamer"`, which we do not use for the baseline.

## How to test
```
external/r2dreamer/.venv/bin/python scripts/r2dreamer/train_external_offline.py \
    --encoder wp_cp --seed 0 --steps 100 \
    --buffer-dir data/offline_buffer_smoke --output-dir /tmp/ext_smoke \
    --device cpu --batch-size 4 --seq-len 16
```

## Verification run
- **CPU smoke** (login node, no GPU): NaN-free 100 steps, exit 0; real fairness dims (batch=16, seq=64) validated for 2 steps; buffer-semantics tests pass under the external venv.
- **GPU `srun` smoke** (validates the CUDA-only path: `torch.compile` reduce-overhead, fp16 autocast, enabled `GradScaler`): **srun job 4809046**, `gpu_h100_short`, queued on resources at time of PR. Result will be appended here when it lands.
- No W&B run yet (gated behind `--wandb`; first real run is 3D-46).

## Risk
Low. New files only; no change to the vendored `external/r2dreamer/` or the JAX side. The adapter is additive and only runs when invoked.

## What was intentionally not done
- The 3 full baseline runs + comparison table (→ 3D-46).
- The Aggregator variant (WP/CP only per 3D-24 scope decision).
- A SLURM launcher for the 3 seeds (belongs with the 3D-46 runs).

## Agent involvement
Implemented by Claude Code (Opus 4.7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)