### PR TITLE
feat(r2dreamer): external R2Dreamer held-out metrics + launcher + comparison (3D-46)

### DIFF
--- a/docs/notes/external-offline-r2dreamer.md
+++ b/docs/notes/external-offline-r2dreamer.md
@@ -90,15 +90,57 @@ W&B (when `--wandb`): project `3d-vla-objectnav-offline-ablation`, tags
 `run_config.json` (written to `--output-dir`) records both repo and
 `external/r2dreamer` code SHAs plus the buffer metadata for reproducibility.
 
-## Handoff to 3D-46
+## 3D-46 — the 3 baseline runs + comparison
 
-- Launch `--seed {0,1,2}`, `--steps 500000`, `--device cuda:0`, `--wandb`. Runs
-  are independent → parallelizable across nodes (mirror the SLURM pattern in
-  `scripts/slurm/`).
-- Held-out metrics: reuse the train/heldout split above; report dynamics KL,
-  representation KL, reward MSE, k-step rollout error (k ∈ {1,5,15}) — **not**
-  reconstruction NLL (decoder-free on both sides).
-- The only field that may differ across the 3 runs is `--seed`.
+### Held-out metrics (built into the training script)
+
+After training, the script computes held-out WM metrics on the last 10% of
+episodes and writes `heldout_final.json` + `heldout_table_row.json` to the
+output dir (and logs `final/heldout/*` to W&B). Definitions mirror the JAX
+`src/r2dreamer/heldout_eval.py` exactly:
+
+- **dynamics_kl / representation_kl** — `rssm.kl_loss(post, prior, kl_free)`
+  means (same free-bits clipping as training `loss/dyn` / `loss/rep`). The two
+  share a forward value — the `.detach()` only changes which side gets gradient.
+- **reward_mse** — MSE of the twohot reward head's expected value
+  (`reward(feat).mode()`, real reward space) vs the GT reward.
+- **k_step_rollout_mse[k]**, k ∈ {1,5,15} — from the posterior at t=0, run
+  `rssm.img_step` with GT actions for k steps, MSE on `get_feat` vs the GT
+  posterior feature at step k. (Needs `seq_len ≥ 16`.)
+- **reconstruction_nll = NaN** — decoder-free on both sides.
+
+Disable with `--skip-heldout-eval`; tune batches with `--heldout-eval-batches`
+(default 64, matching the JAX final eval).
+
+### Launching the runs (SLURM)
+
+```
+# smoke (gpu_h100_short, 200 steps, validates GPU + buffer + eval + W&B)
+scripts/r2dreamer/slurm/submit_external_offline.sh smoke 0
+
+# the 3 prod runs (gpu_h100_il, 500k steps, ~5 h each, parallelizable)
+for s in 0 1 2; do scripts/r2dreamer/slurm/submit_external_offline.sh prod "$s"; done
+```
+
+Only `--seed` differs across the 3 prod runs (verifiable from each
+`run_config.json`). Throughput ~29 steps/s on one H100 ⇒ ~5 h/seed.
+
+### Comparison table (after the runs finish)
+
+```
+python scripts/r2dreamer/build_offline_comparison.py \
+    --external-glob 'output/3d46-external-offline/wp_cp-seed*/run-*/heldout_table_row.json' \
+    --jax-glob      'output/3d26-offline-ablation/wp_cp-seed*/run-*/heldout_table_row.json' \
+    --out-md  docs/notes/offline-ablation-comparison.md \
+    --out-csv docs/notes/offline-ablation-comparison.csv
+```
+
+If the JAX 3D-26 output dirs aren't on disk, pass `--jax-wandb` instead — it
+reads each JAX run's `final/heldout/*` summary from the
+`3d-vla-objectnav-offline-ablation` W&B project (tags `3d-26,wp_cp`). The
+builder emits a markdown table (JAX vs PyTorch, mean ± std over 3 seeds) and a
+per-seed CSV; **reconstruction NLL is excluded** from the head-to-head (N/A on
+both sides).
 
 ## Tests
 

--- a/scripts/r2dreamer/build_offline_comparison.py
+++ b/scripts/r2dreamer/build_offline_comparison.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python
+"""Build the 3D-46 JAX-vs-external(PyTorch) WP/CP comparison table.
+
+Aggregates held-out world-model metrics (mean ± std over the 3 seeds) for the
+JAX R2Dreamer (3D-26) and the external PyTorch R2Dreamer (3D-46) into a single
+markdown table + a per-seed CSV.
+
+Sources per framework (each a per-seed `heldout_table_row.json`):
+  * external: produced by `train_external_offline.py` (this PR), e.g.
+      output/3d46-external-offline/wp_cp-seed*/run-*/heldout_table_row.json
+  * JAX: produced by `train_offline_ablation.py` (3D-26), e.g.
+      output/3d26-offline-ablation/wp_cp-seed*/run-*/heldout_table_row.json
+    If those dirs are not on disk, pull the JAX numbers from W&B with
+    `--jax-wandb` (reads each run's `final/heldout/*` summary by tag).
+
+Comparable columns (decoder-free on both sides → reconstruction NLL is N/A and
+is NOT a head-to-head row):
+    dynamics_kl, representation_kl, reward_mse,
+    k_step_rollout_k1, k_step_rollout_k5, k_step_rollout_k15
+
+Usage:
+    python scripts/r2dreamer/build_offline_comparison.py \\
+        --external-glob 'output/3d46-external-offline/wp_cp-seed*/run-*/heldout_table_row.json' \\
+        --jax-glob      'output/3d26-offline-ablation/wp_cp-seed*/run-*/heldout_table_row.json' \\
+        --out-md   docs/notes/offline-ablation-comparison.md \\
+        --out-csv  docs/notes/offline-ablation-comparison.csv
+
+    # JAX numbers from W&B instead of disk:
+    python scripts/r2dreamer/build_offline_comparison.py \\
+        --external-glob '...heldout_table_row.json' --jax-wandb \\
+        --wandb-entity sailer-luca-university-ulm \\
+        --wandb-project 3d-vla-objectnav-offline-ablation
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import glob
+import json
+import re
+import statistics
+from pathlib import Path
+
+# Head-to-head columns (recon NLL excluded — decoder-free on both sides).
+COMPARABLE = [
+    "dynamics_kl",
+    "representation_kl",
+    "reward_mse",
+    "k_step_rollout_k1",
+    "k_step_rollout_k5",
+    "k_step_rollout_k15",
+]
+
+PRETTY = {
+    "dynamics_kl": "Dynamics KL",
+    "representation_kl": "Representation KL",
+    "reward_mse": "Reward MSE",
+    "k_step_rollout_k1": "k-step rollout MSE (k=1)",
+    "k_step_rollout_k5": "k-step rollout MSE (k=5)",
+    "k_step_rollout_k15": "k-step rollout MSE (k=15)",
+}
+
+# W&B summary keys -> table columns (the JAX trainer logs `final/heldout/*`).
+WANDB_KEYMAP = {
+    "dynamics_kl": "final/heldout/loss/dyn",
+    "representation_kl": "final/heldout/loss/rep",
+    "reward_mse": "final/heldout/reward_mse",
+    "k_step_rollout_k1": "final/heldout/k_step_rollout_mse/k1",
+    "k_step_rollout_k5": "final/heldout/k_step_rollout_mse/k5",
+    "k_step_rollout_k15": "final/heldout/k_step_rollout_mse/k15",
+}
+
+_SEED_RE = re.compile(r"seed[-_]?(\d+)")
+
+
+def _seed_from_path(path: str) -> str:
+    m = _SEED_RE.search(path)
+    return m.group(1) if m else path
+
+
+def load_rows_from_glob(pattern: str) -> dict[str, dict]:
+    """Map seed -> table-row dict from heldout_table_row.json files."""
+    rows: dict[str, dict] = {}
+    for p in sorted(glob.glob(pattern)):
+        seed = _seed_from_path(p)
+        rows[seed] = json.loads(Path(p).read_text())
+    return rows
+
+
+def load_jax_from_wandb(entity: str, project: str, tags: list[str]) -> dict[str, dict]:
+    """Pull JAX per-seed rows from W&B run summaries (`final/heldout/*`)."""
+    import wandb
+
+    api = wandb.Api()
+    filt = {"tags": {"$all": tags}} if tags else {}
+    rows: dict[str, dict] = {}
+    for run in api.runs(f"{entity}/{project}", filters=filt):
+        summary = run.summary
+        row = {col: _to_float(summary.get(key)) for col, key in WANDB_KEYMAP.items()}
+        if all(v is None for v in row.values()):
+            continue  # not a finished offline run
+        seed = _seed_from_path(run.name or run.id)
+        rows[seed] = row
+    return rows
+
+
+def _to_float(v):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def aggregate(rows_by_seed: dict[str, dict]) -> dict[str, dict]:
+    """seed->row  ->  metric -> {mean, std, n, per_seed:{seed:val}}."""
+    out: dict[str, dict] = {}
+    for col in COMPARABLE:
+        per_seed = {
+            seed: float(row[col])
+            for seed, row in rows_by_seed.items()
+            if col in row and row[col] is not None and _is_finite(row[col])
+        }
+        vals = list(per_seed.values())
+        out[col] = {
+            "mean": statistics.mean(vals) if vals else float("nan"),
+            "std": statistics.stdev(vals) if len(vals) >= 2 else 0.0,
+            "n": len(vals),
+            "per_seed": per_seed,
+        }
+    return out
+
+
+def _is_finite(x) -> bool:
+    try:
+        x = float(x)
+        return x == x and x not in (float("inf"), float("-inf"))
+    except (TypeError, ValueError):
+        return False
+
+
+def render_markdown(jax_agg: dict, ext_agg: dict, *, meta: dict) -> str:
+    lines = [
+        "# Offline ablation — JAX vs external (PyTorch) R2Dreamer (WP/CP)",
+        "",
+        "Held-out world-model metrics on the last 10% of episodes "
+        "(mean ± std over seeds {0,1,2}). Lower is better for every column.",
+        "",
+        "Both frameworks run the decoder-free R2-Dreamer objective "
+        "(`rep_loss=\"r2dreamer\"`), so **reconstruction NLL is N/A on both** "
+        "and is omitted from the head-to-head.",
+        "",
+        "| Metric | JAX (3D-26) | external PyTorch (3D-46) |",
+        "| -- | -- | -- |",
+    ]
+    for col in COMPARABLE:
+        j, e = jax_agg.get(col, {}), ext_agg.get(col, {})
+        lines.append(f"| {PRETTY[col]} | {_cell(j)} | {_cell(e)} |")
+    lines += [
+        "",
+        f"- JAX seeds found: {meta.get('jax_seeds', [])}",
+        f"- external seeds found: {meta.get('ext_seeds', [])}",
+        f"- JAX source: {meta.get('jax_source', '?')}",
+    ]
+    if meta.get("wandb_runs"):
+        lines.append(f"- W&B runs: {', '.join(meta['wandb_runs'])}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _cell(agg: dict) -> str:
+    if not agg or agg.get("n", 0) == 0:
+        return "_pending_"
+    return f"{agg['mean']:.4f} ± {agg['std']:.4f} (n={agg['n']})"
+
+
+def write_csv(path: Path, jax_rows: dict, ext_rows: dict) -> None:
+    with path.open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["framework", "seed", "metric", "value"])
+        for fw, rows in (("jax", jax_rows), ("pytorch_external", ext_rows)):
+            for seed, row in sorted(rows.items()):
+                for col in COMPARABLE:
+                    if col in row and row[col] is not None:
+                        w.writerow([fw, seed, col, row[col]])
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument(
+        "--external-glob", required=True,
+        help="Glob to external heldout_table_row.json files (one per seed).",
+    )
+    p.add_argument("--jax-glob", help="Glob to JAX heldout_table_row.json files.")
+    p.add_argument("--jax-wandb", action="store_true", help="Fetch JAX rows from W&B.")
+    p.add_argument("--wandb-entity", default="sailer-luca-university-ulm")
+    p.add_argument("--wandb-project", default="3d-vla-objectnav-offline-ablation")
+    p.add_argument("--wandb-tags", default="3d-26,wp_cp")
+    p.add_argument("--out-md", default="docs/notes/offline-ablation-comparison.md")
+    p.add_argument("--out-csv", default="docs/notes/offline-ablation-comparison.csv")
+    return p
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _build_parser().parse_args(argv)
+
+    ext_rows = load_rows_from_glob(args.external_glob)
+
+    jax_rows: dict[str, dict] = {}
+    jax_source = "none"
+    if args.jax_glob:
+        jax_rows = load_rows_from_glob(args.jax_glob)
+        jax_source = f"glob:{args.jax_glob}"
+    if not jax_rows and args.jax_wandb:
+        tags = [t.strip() for t in args.wandb_tags.split(",") if t.strip()]
+        jax_rows = load_jax_from_wandb(args.wandb_entity, args.wandb_project, tags)
+        jax_source = f"wandb:{args.wandb_entity}/{args.wandb_project} tags={tags}"
+
+    jax_agg, ext_agg = aggregate(jax_rows), aggregate(ext_rows)
+    meta = {
+        "jax_seeds": sorted(jax_rows),
+        "ext_seeds": sorted(ext_rows),
+        "jax_source": jax_source,
+    }
+    md = render_markdown(jax_agg, ext_agg, meta=meta)
+
+    out_md = Path(args.out_md)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    out_md.write_text(md)
+    write_csv(Path(args.out_csv), jax_rows, ext_rows)
+
+    print(md)
+    print(f"\nWrote {out_md} and {args.out_csv}")
+    if not ext_rows:
+        print("WARNING: no external rows found — runs not finished yet?")
+    if not jax_rows:
+        print("WARNING: no JAX rows found — pass --jax-glob or --jax-wandb once available.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/r2dreamer/slurm/submit_external_offline.sh
+++ b/scripts/r2dreamer/slurm/submit_external_offline.sh
@@ -54,7 +54,10 @@ case "${mode}" in
         job_name="3d46-${mode}-${encoder}-s${seed}"
         ;;
     prod)
-        partition=gpu_h100_il
+        # Multi-partition: Slurm starts on whichever H100 partition frees first.
+        # Keeps gpu_h100_il (5 nodes) and adds the larger gpu_h100 (12 nodes);
+        # both are H100, same account/billing — pure upside on queue time.
+        partition=gpu_h100_il,gpu_h100
         # ~29 steps/s on H100 -> ~5h for 500k; budget 8h for the final held-out
         # eval (non-compiled forward over up to 64 batches).
         time_limit=08:00:00

--- a/scripts/r2dreamer/slurm/submit_external_offline.sh
+++ b/scripts/r2dreamer/slurm/submit_external_offline.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Submit one 3D-46 external (PyTorch) R2Dreamer offline run.
+#
+# Usage:
+#   ./submit_external_offline.sh {dev|prod|smoke} <seed> [encoder] [--dry-run]
+#
+# dev/smoke -> gpu_h100_short (<=30 min), STEPS=200 — sanity / smoke.
+# prod      -> gpu_h100_il 8h, STEPS=500000 — the actual 3D-46 baseline runs.
+#
+# seed    in {0, 1, 2}; encoder defaults wp_cp (3D-46 is WP/CP only).
+#
+# Launch all three prod seeds:
+#   for s in 0 1 2; do ./submit_external_offline.sh prod "$s"; done
+
+set -euo pipefail
+
+usage() {
+    echo "usage: $0 {dev|prod|smoke} <seed> [encoder] [--dry-run]" >&2
+    echo "       seed in {0,1,2}; encoder in {wp_cp,aggregator} (default wp_cp)" >&2
+    exit 2
+}
+
+mode="${1:-}"
+seed="${2:-}"
+[ -z "${mode}" ] || [ -z "${seed}" ] && usage
+shift 2 || usage
+
+# Remaining args (any order): optional encoder + optional --dry-run.
+encoder="wp_cp"
+dry_run=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run)        dry_run=1 ;;
+        wp_cp|aggregator) encoder="$1" ;;
+        *)                usage ;;
+    esac
+    shift
+done
+
+case "${seed}"    in 0|1|2)            ;; *) usage ;; esac
+case "${encoder}" in wp_cp|aggregator) ;; *) usage ;; esac
+
+case "${mode}" in
+    dev|smoke)
+        # gpu_h100_short: fast queue, 30-min cap — best fit for smoke. Trim the
+        # held-out eval to a few batches so the short window is enough.
+        partition=gpu_h100_short
+        time_limit=00:25:00
+        export STEPS="${STEPS:-200}"
+        export EXTRA_ARGS="${EXTRA_ARGS:---checkpoint-every 100 --log-every 10 --heldout-eval-batches 4}"
+        # Namespace smoke runs (output + W&B name + tag) so they never collide
+        # with the prod runs the comparison globs over.
+        export RUN_TAG="${RUN_TAG:-smoke}"
+        job_name="3d46-${mode}-${encoder}-s${seed}"
+        ;;
+    prod)
+        partition=gpu_h100_il
+        # ~29 steps/s on H100 -> ~5h for 500k; budget 8h for the final held-out
+        # eval (non-compiled forward over up to 64 batches).
+        time_limit=08:00:00
+        export STEPS="${STEPS:-500000}"
+        export EXTRA_ARGS="${EXTRA_ARGS:-}"
+        job_name="3d46-prod-${encoder}-s${seed}"
+        ;;
+    *)
+        usage
+        ;;
+esac
+
+export ENCODER="${encoder}"
+export SEED="${seed}"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+sbatch_file="${script_dir}/train_external_offline.sbatch"
+
+echo "Mode=${mode}  Partition=${partition}  Time=${time_limit}"
+echo "Encoder=${encoder}  Seed=${seed}  Steps=${STEPS}"
+echo "Sbatch=${sbatch_file}"
+
+sbatch_args=(
+    --partition="${partition}"
+    --time="${time_limit}"
+    --job-name="${job_name}"
+    --export=ALL
+)
+# Optional: launch only after this job ID completes successfully.
+if [ -n "${WAIT_FOR:-}" ]; then
+    sbatch_args+=(--dependency="afterok:${WAIT_FOR}")
+fi
+sbatch_args+=("${sbatch_file}")
+
+# Pre-flight — catches partition / resource mistakes before queueing.
+sbatch --test-only "${sbatch_args[@]}"
+echo "Pre-flight OK."
+
+if [ "${dry_run}" -eq 1 ]; then
+    echo "--dry-run: not submitting."
+    exit 0
+fi
+
+submit_out="$(sbatch "${sbatch_args[@]}")"
+echo "${submit_out}"
+jobid="$(echo "${submit_out}" | awk '{print $NF}')"
+echo "Log: output/3d46-external-offline/slurm-${jobid}.out"

--- a/scripts/r2dreamer/slurm/train_external_offline.sbatch
+++ b/scripts/r2dreamer/slurm/train_external_offline.sbatch
@@ -1,6 +1,6 @@
 #!/bin/bash
 #SBATCH --job-name=3d46-external-offline
-#SBATCH --partition=gpu_h100_il
+#SBATCH --partition=gpu_h100_il,gpu_h100
 #SBATCH --gres=gpu:1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=8

--- a/scripts/r2dreamer/slurm/train_external_offline.sbatch
+++ b/scripts/r2dreamer/slurm/train_external_offline.sbatch
@@ -1,0 +1,66 @@
+#!/bin/bash
+#SBATCH --job-name=3d46-external-offline
+#SBATCH --partition=gpu_h100_il
+#SBATCH --gres=gpu:1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=160G
+#SBATCH --time=08:00:00
+#SBATCH --output=output/3d46-external-offline/slurm-%j.out
+#SBATCH --error=output/3d46-external-offline/slurm-%j.err
+
+# 3D-46 external (PyTorch) R2Dreamer offline baseline — one of the 3 WP/CP runs.
+#
+# Trains the original PyTorch R2Dreamer (external/r2dreamer/) offline on the
+# WP/CP vector readout, then logs held-out WM metrics directly comparable to the
+# JAX 3D-26 numbers. Runs under the EXTERNAL venv (torchrl/tensordict/gymnasium).
+#
+# Args (via env vars):
+#   ENCODER       wp_cp | aggregator   (default wp_cp; 3D-46 is WP/CP only)
+#   SEED          0 | 1 | 2            (required)
+#   STEPS         total grad steps     (default 500_000)
+#   BUFFER_DIR    offline buffer path  (default data/offline_buffer)
+#   WANDB_PROJECT W&B project          (default 3d-vla-objectnav-offline-ablation)
+#   EXTRA_ARGS    extra CLI for train_external_offline.py (default empty)
+
+set -euo pipefail
+
+: "${SEED:?SEED must be set (0|1|2)}"
+ENCODER="${ENCODER:-wp_cp}"
+STEPS="${STEPS:-500000}"
+BUFFER_DIR="${BUFFER_DIR:-data/offline_buffer}"
+WANDB_PROJECT="${WANDB_PROJECT:-3d-vla-objectnav-offline-ablation}"
+EXTRA_ARGS="${EXTRA_ARGS:-}"
+
+# RUN_TAG lets smoke runs land in a separate namespace (output + W&B name) so
+# they never collide with the prod runs the comparison globs over.
+RUN_TAG="${RUN_TAG:-}"
+OUTPUT_DIR="output/3d46-external-offline${RUN_TAG:+/$RUN_TAG}/${ENCODER}-seed${SEED}/run-${SLURM_JOB_ID}"
+WANDB_NAME="ext-${ENCODER}-seed${SEED}${RUN_TAG:+-$RUN_TAG}"
+mkdir -p "${OUTPUT_DIR}"
+
+PY="external/r2dreamer/.venv/bin/python"
+
+echo "Job ${SLURM_JOB_ID} on $(hostname) at $(date)"
+echo "GPU: $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || echo N/A)"
+echo "Encoder: ${ENCODER}   Seed: ${SEED}   Steps: ${STEPS}"
+echo "Buffer:  ${BUFFER_DIR}"
+echo "Output:  ${OUTPUT_DIR}"
+echo "WANDB:   ${WANDB_PROJECT}"
+echo "Commit:  $(git rev-parse HEAD)   external: $(git -C external/r2dreamer rev-parse HEAD 2>/dev/null || echo N/A)"
+
+# shellcheck disable=SC2086
+"${PY}" scripts/r2dreamer/train_external_offline.py \
+    --encoder "${ENCODER}" \
+    --seed "${SEED}" \
+    --steps "${STEPS}" \
+    --buffer-dir "${BUFFER_DIR}" \
+    --output-dir "${OUTPUT_DIR}" \
+    --device cuda:0 \
+    --wandb \
+    --wandb-project "${WANDB_PROJECT}" \
+    --wandb-name "${WANDB_NAME}" \
+    --wandb-tags "offline-ablation,3d-24,framework:pytorch-external,seed${SEED}${RUN_TAG:+,$RUN_TAG}" \
+    ${EXTRA_ARGS}
+
+echo "Done at $(date)"

--- a/scripts/r2dreamer/train_external_offline.py
+++ b/scripts/r2dreamer/train_external_offline.py
@@ -99,6 +99,14 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--seq-len", type=int, default=SHARED["seq_len"])
     p.add_argument("--log-every", type=int, default=250)
     p.add_argument("--checkpoint-every", type=int, default=50_000)
+    p.add_argument(
+        "--skip-heldout-eval", action="store_true",
+        help="Skip the final held-out WM metrics (smoke testing).",
+    )
+    p.add_argument(
+        "--heldout-eval-batches", type=int, default=64,
+        help="Max non-overlapping held-out batches averaged for the metrics.",
+    )
     # compile defaults to the model config (True); forced off on CPU.
     p.add_argument("--compile", dest="compile", action="store_true", default=None)
     p.add_argument("--no-compile", dest="compile", action="store_false")
@@ -303,6 +311,53 @@ class OfflineVectorBuffer:
     def count(self):
         return self.size
 
+    def iter_eval_batches(self, max_batches: int | None = None):
+        """Deterministic non-overlapping windows for held-out eval.
+
+        Mirrors `OfflineBufferDataset.iter_heldout_batches`: stride = seq_len, so
+        windows never overlap; chunked into groups of `batch_size`. Yields the
+        same TensorDict schema as `sample()` (no `initial` — the eval caller
+        rebuilds a zeroed initial per batch). The last chunk may be smaller.
+        """
+        torch = self._torch
+        from tensordict import TensorDict
+
+        dev = self.device
+        starts_all = np.arange(0, self.size - self.L + 1, self.L)
+        n_total = len(starts_all)
+        if max_batches is not None:
+            n_total = min(n_total, max_batches * self.B)
+        for chunk in range(0, n_total, self.B):
+            starts = starts_all[chunk : chunk + self.B]
+            if len(starts) == 0:
+                break
+            win = starts[:, None] + np.arange(self.L)[None, :]
+            b = win.shape[0]
+            obs = torch.as_tensor(self.obs[win].astype(np.float32), device=dev)
+            act_idx = torch.as_tensor(self.actions[win].astype(np.int64), device=dev)
+            action = torch.nn.functional.one_hot(act_idx, NUM_ACTIONS).to(torch.float32)
+            reward = torch.as_tensor(
+                self.rewards[win].astype(np.float32), device=dev
+            ).unsqueeze(-1)
+            dones = self.dones[win]
+            is_first = np.zeros_like(dones)
+            is_first[:, 0] = True
+            is_first[:, 1:] = dones[:, :-1]
+            is_first_t = torch.as_tensor(is_first, device=dev).unsqueeze(-1)
+            done_t = torch.as_tensor(dones.astype(np.float32), device=dev).unsqueeze(-1)
+            yield TensorDict(
+                {
+                    "vector": obs,
+                    "action": action,
+                    "reward": reward,
+                    "is_first": is_first_t,
+                    "is_last": done_t,
+                    "is_terminal": done_t,
+                },
+                batch_size=(b, self.L),
+                device=dev,
+            )
+
 
 def _load_metadata(buffer_dir: Path) -> dict:
     """Read collection_metadata.json; tolerate a missing file (all-train)."""
@@ -341,6 +396,87 @@ def _load_features(path: Path) -> np.ndarray:
         return data[key]
     finally:
         data.close()
+
+
+# ---------------------------------------------------------------------------
+# Held-out world-model metrics (mirrors src/r2dreamer/heldout_eval.py)
+# ---------------------------------------------------------------------------
+def compute_heldout_metrics(agent, buffer, *, max_batches=64, k_values=(1, 5, 15)):
+    """Held-out WM metrics with the SAME definitions as the JAX 3D-26 eval.
+
+    Per batch (no grad, full fp32):
+      * dynamics_kl / representation_kl = `rssm.kl_loss(post, prior, kl_free)`
+        means — identical free-bits clipping to training `loss/dyn` `loss/rep`.
+      * reward_mse = MSE of the twohot reward head's expected value
+        (`reward(feat).mode()`, in real reward space) vs the GT reward.
+      * k_step_rollout_mse[k] = start from the posterior at t=0, run
+        `rssm.img_step` with GT actions for k steps, MSE on `get_feat` vs the
+        GT posterior feature at step k.
+      * reconstruction_nll = NaN — decoder-free `rep_loss="r2dreamer"`, same as
+        the JAX side.
+    """
+    import torch
+
+    max_k = max(k_values)
+    if buffer.L < max_k + 1:
+        raise ValueError(f"seq_len {buffer.L} too short for max k_rollout {max_k}")
+
+    rssm = agent.rssm
+    sums = {"loss/dyn": 0.0, "loss/rep": 0.0, "reward_mse": 0.0}
+    rollout_sums = {k: 0.0 for k in k_values}
+    n = 0
+
+    agent.eval()
+    with torch.no_grad():
+        for data in buffer.iter_eval_batches(max_batches=max_batches):
+            b = int(data.batch_size[0])
+            initial = rssm.initial(b)
+            embed = agent.encoder(data)
+            post_stoch, post_deter, post_logit = rssm.observe(
+                embed, data["action"], initial, data["is_first"]
+            )
+            _, prior_logit = rssm.prior(post_deter)
+            dyn, rep = rssm.kl_loss(post_logit, prior_logit, agent.kl_free)
+            sums["loss/dyn"] += float(dyn.mean())
+            sums["loss/rep"] += float(rep.mean())
+
+            feat = rssm.get_feat(post_stoch, post_deter)
+            pred = agent.reward(feat).mode()  # (B, T, 1), expected reward
+            err = pred - data["reward"].to(pred.dtype)
+            sums["reward_mse"] += float(torch.mean(err * err))
+
+            stoch, deter = post_stoch[:, 0], post_deter[:, 0]
+            for step in range(1, max_k + 1):
+                stoch, deter = rssm.img_step(stoch, deter, data["action"][:, step - 1])
+                if step in k_values:
+                    feat_pred = rssm.get_feat(stoch, deter)
+                    feat_gt = rssm.get_feat(post_stoch[:, step], post_deter[:, step])
+                    d = feat_pred - feat_gt
+                    rollout_sums[step] += float(torch.mean(d * d))
+            n += 1
+    agent.train()
+
+    if n == 0:
+        return {}
+    out = {f"heldout/{k}": v / n for k, v in sums.items()}
+    for k, total in rollout_sums.items():
+        out[f"heldout/k_step_rollout_mse/k{k}"] = total / n
+    out["heldout/reconstruction_nll"] = float("nan")  # decoder-free, see docstring
+    out["heldout/num_batches"] = float(n)
+    return out
+
+
+def metrics_table_row(metrics: dict) -> dict:
+    """Translate held-out output into the 3D-26 comparison-table columns."""
+    return {
+        "reconstruction_nll": metrics.get("heldout/reconstruction_nll", float("nan")),
+        "dynamics_kl": metrics.get("heldout/loss/dyn", float("nan")),
+        "representation_kl": metrics.get("heldout/loss/rep", float("nan")),
+        "reward_mse": metrics.get("heldout/reward_mse", float("nan")),
+        "k_step_rollout_k1": metrics.get("heldout/k_step_rollout_mse/k1", float("nan")),
+        "k_step_rollout_k5": metrics.get("heldout/k_step_rollout_mse/k5", float("nan")),
+        "k_step_rollout_k15": metrics.get("heldout/k_step_rollout_mse/k15", float("nan")),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -554,6 +690,34 @@ def main(argv: list[str] | None = None) -> None:
         checkpoint_every=args.checkpoint_every,
         output_dir=output_dir,
     ).run()
+
+    # Final held-out world-model metrics (3D-46). Same definitions + columns as
+    # the JAX 3D-26 eval, so the two are directly comparable.
+    if not args.skip_heldout_eval:
+        heldout_buf = OfflineVectorBuffer(
+            buffer_dir,
+            args.encoder,
+            split="heldout",
+            batch_size=args.batch_size,
+            seq_len=args.seq_len,
+            device=device,
+            seed=args.seed,
+            deter_size=int(model_cfg.rssm.deter),
+            stoch_classes=int(model_cfg.rssm.stoch),
+            stoch_discrete=int(model_cfg.rssm.discrete),
+        )
+        heldout = compute_heldout_metrics(
+            agent, heldout_buf, max_batches=args.heldout_eval_batches
+        )
+        if heldout:
+            (output_dir / "heldout_final.json").write_text(json.dumps(heldout, indent=2))
+            table_row = metrics_table_row(heldout)
+            (output_dir / "heldout_table_row.json").write_text(json.dumps(table_row, indent=2))
+            if wandb_run is not None:
+                wandb_run.log({f"final/{k}": v for k, v in heldout.items()}, step=args.steps)
+            print("Final held-out metrics:")
+            for k, v in heldout.items():
+                print(f"  {k}={v:.6f}")
 
     if wandb_run is not None:
         wandb_run.finish()

--- a/tests/r2dreamer/test_offline_comparison.py
+++ b/tests/r2dreamer/test_offline_comparison.py
@@ -1,0 +1,94 @@
+"""Aggregation + rendering for the 3D-46 JAX-vs-external comparison builder.
+
+Pure-stdlib (no torch/jax), so it runs in any venv.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "r2dreamer" / "build_offline_comparison.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("build_offline_comparison", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _row(dyn, rep, rew, k1, k5, k15, recon=float("nan")):
+    return {
+        "reconstruction_nll": recon,
+        "dynamics_kl": dyn,
+        "representation_kl": rep,
+        "reward_mse": rew,
+        "k_step_rollout_k1": k1,
+        "k_step_rollout_k5": k5,
+        "k_step_rollout_k15": k15,
+    }
+
+
+def test_aggregate_mean_std():
+    mod = _load()
+    rows = {
+        "0": _row(10.0, 10.0, 1.0, 0.1, 0.5, 1.5),
+        "1": _row(12.0, 12.0, 2.0, 0.2, 0.6, 1.6),
+        "2": _row(14.0, 14.0, 3.0, 0.3, 0.7, 1.7),
+    }
+    agg = mod.aggregate(rows)
+    assert agg["dynamics_kl"]["mean"] == 12.0
+    assert agg["dynamics_kl"]["n"] == 3
+    assert abs(agg["dynamics_kl"]["std"] - 2.0) < 1e-9  # sample stdev of 10,12,14
+    assert abs(agg["reward_mse"]["mean"] - 2.0) < 1e-9
+    # recon NLL must not be a comparable column.
+    assert "reconstruction_nll" not in agg
+
+
+def test_aggregate_ignores_nan_and_missing():
+    mod = _load()
+    rows = {
+        "0": _row(10.0, 10.0, float("nan"), 0.1, 0.5, 1.5),
+        "1": _row(12.0, 12.0, 2.0, 0.2, 0.6, 1.6),
+    }
+    agg = mod.aggregate(rows)
+    # reward_mse has one finite value (seed 1); n=1, std=0.
+    assert agg["reward_mse"]["n"] == 1
+    assert agg["reward_mse"]["mean"] == 2.0
+    assert agg["reward_mse"]["std"] == 0.0
+
+
+def test_seed_from_path():
+    mod = _load()
+    assert mod._seed_from_path("output/3d46/wp_cp-seed2/run-99/heldout_table_row.json") == "2"
+    assert mod._seed_from_path("ext-wp_cp-seed0") == "0"
+
+
+def test_end_to_end_glob_and_outputs(tmp_path):
+    mod = _load()
+    # Synthesize 3 external seed dirs with table rows.
+    for s in range(3):
+        d = tmp_path / f"wp_cp-seed{s}" / "run-1"
+        d.mkdir(parents=True)
+        (d / "heldout_table_row.json").write_text(
+            json.dumps(_row(10.0 + s, 10.0 + s, 1.0 + s, 0.1, 0.5, 1.5))
+        )
+    ext_glob = str(tmp_path / "wp_cp-seed*" / "run-*" / "heldout_table_row.json")
+    out_md = tmp_path / "cmp.md"
+    out_csv = tmp_path / "cmp.csv"
+
+    mod.main([
+        "--external-glob", ext_glob,
+        "--out-md", str(out_md),
+        "--out-csv", str(out_csv),
+    ])
+
+    md = out_md.read_text()
+    assert "external PyTorch (3D-46)" in md
+    assert "11.0000 ± 1.0000 (n=3)" in md  # dynamics_kl mean of 10,11,12
+    assert "_pending_" in md  # JAX column has no data yet
+    # CSV has the external per-seed rows (3 seeds × 6 comparable metrics).
+    csv_lines = out_csv.read_text().strip().splitlines()
+    assert csv_lines[0] == "framework,seed,metric,value"
+    assert sum(1 for ln in csv_lines if ln.startswith("pytorch_external")) == 18


### PR DESCRIPTION
## Summary

Builds the 3D-46 external PyTorch R2Dreamer baseline on top of the merged 3D-45 offline adapter.

This PR adds:

- final diagnostic held-out world-model metrics for the external PyTorch run,
- SLURM launchers for smoke/prod external offline training,
- W&B logging for the external baseline,
- a comparison helper that can aggregate external PyTorch and JAX rows when both are available.

3D-46 is primarily a baseline/runtime parity milestone: prove that the original PyTorch R2Dreamer can train offline from the same WP/CP buffer under the same seed/step/fairness setup as the JAX pipeline.

## Why

The thesis comparison needs an independent external PyTorch baseline next to the JAX R2Dreamer implementation. 3D-45 provided the adapter; this PR provides the launcher, W&B/provenance, held-out diagnostic metrics, and completed 3-seed external training runs.

Held-out WM metrics are treated as **diagnostic**, not as the final decision metric for representation quality. The downstream comparison path remains fixed ObjectNav evaluation with SR/SPL on the same scenes/checkpoint steps.

## Changes

**External offline trainer**
- `scripts/r2dreamer/train_external_offline.py`
  - trains the original PyTorch R2Dreamer from `data/offline_buffer/`,
  - feeds the 4116-d WP/CP vector through the existing MLP encoder branch,
  - reuses `agent.update()` unchanged,
  - records main repo + `external/r2dreamer` SHAs in `run_config.json`,
  - optionally logs to W&B with stable tags/names.

**Held-out diagnostic metrics**
- Adds final held-out WM metrics mirroring the JAX metric definitions where practical:
  - dynamics KL / representation KL,
  - reward MSE,
  - k-step latent rollout MSE for k in `{1, 5, 15}`,
  - reconstruction NLL as `NaN` because the `rep_loss=\"r2dreamer\"` setup is decoder-free.
- Writes `heldout_final.json` and `heldout_table_row.json`.

**SLURM**
- `scripts/r2dreamer/slurm/train_external_offline.sbatch`
- `scripts/r2dreamer/slurm/submit_external_offline.sh`
- Supports smoke/dev/prod runs and names smoke outputs separately so they do not collide with prod comparison globs.

**Comparison helper**
- `scripts/r2dreamer/build_offline_comparison.py`
- Aggregates per-seed `heldout_table_row.json` files into markdown/CSV when external and JAX rows are available.
- Excludes reconstruction NLL from the head-to-head because both current setups are decoder-free.

**Tests/docs**
- `tests/r2dreamer/test_offline_comparison.py`
- Extended `docs/notes/external-offline-r2dreamer.md`

## Verification

Smoke:
- GPU dev smoke `4809136`: `COMPLETED`, exit 0, 5m35s on H100.
- Validated external venv, CUDA path, `torch.compile`, real buffer load, held-out eval, and W&B logging.
- Smoke W&B run: `fl9pq0jg`.

Prod external WP/CP runs:
- `4809371` — `ext-wp_cp-seed0`, `COMPLETED`, W&B run `thv90pbw`, elapsed 04:49:53.
- `4809373` — `ext-wp_cp-seed1`, `COMPLETED`, W&B run `roy9gcmc`, elapsed 06:07:09.
- `4809375` — `ext-wp_cp-seed2`, `COMPLETED`, W&B run `imuv7rrk`, elapsed 06:12:17.

Final held-out diagnostic rows were written under:

```text
output/3d46-external-offline/wp_cp-seed0/run-4809371/heldout_table_row.json
output/3d46-external-offline/wp_cp-seed1/run-4809373/heldout_table_row.json
output/3d46-external-offline/wp_cp-seed2/run-4809375/heldout_table_row.json
```

Per-seed held-out diagnostic metrics:

| Seed | Dynamics KL | Representation KL | Reward MSE | k1 rollout MSE | k5 rollout MSE | k15 rollout MSE |
| -- | --: | --: | --: | --: | --: | --: |
| 0 | 6.8288 | 6.8288 | 0.3762 | 0.0336 | 0.0945 | 0.1188 |
| 1 | 6.4178 | 6.4178 | 0.3469 | 0.0377 | 0.0915 | 0.1105 |
| 2 | 6.5481 | 6.5481 | 0.3224 | 0.0318 | 0.0902 | 0.1139 |

Other checks:
- CPU eval smoke writes both JSON outputs with finite comparable metrics.
- Comparison aggregation tests: `4/4` pass.
- Shell scripts pass `bash -n` and `sbatch --test-only` preflight.
- GitGuardian check passes.

## How to Test

```bash
# CPU eval path
external/r2dreamer/.venv/bin/python scripts/r2dreamer/train_external_offline.py \
  --encoder wp_cp --seed 0 --steps 2 --buffer-dir data/offline_buffer_smoke \
  --output-dir /tmp/ext_eval --device cpu --batch-size 4 --seq-len 16 \
  --heldout-eval-batches 2

# comparison aggregation
.venv/bin/python -m pytest tests/r2dreamer/test_offline_comparison.py -q
```

## Risk

Low. The PR is additive:

- no vendored `external/r2dreamer/` source changes,
- no changes to JAX training behavior,
- launcher only runs when invoked,
- held-out metrics are diagnostic and do not gate downstream policy comparison.

## What Was Intentionally Not Done

- This PR does not decide which implementation is better for ObjectNav. That should be measured by fixed online eval with SR/SPL.
- This PR does not add aggregator external baseline runs; 3D-46 is WP/CP only per 3D-24 scope.
- The JAX-vs-external markdown table is only meaningful when matching JAX rows are available. The external rows are complete and ready.

## Agent Involvement

Implemented by Claude Code. PR story and verification notes updated by Codex after the prod runs completed and after #156 was merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
