### PR TITLE
chore(worktree): symlink output/ so worktree run artifacts survive removal

### DIFF
--- a/scripts/setup_worktree.sh
+++ b/scripts/setup_worktree.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # Bootstrap a git worktree for ML runs.
 #
-# Symlinks the heavy, gitignored shared dirs (`data/`, `.venv/`) from the
-# main checkout into the current worktree so that CWD-relative paths
+# Symlinks the heavy, gitignored shared dirs (`data/`, `.venv/`, `output/`)
+# from the main checkout into the current worktree so that CWD-relative paths
 # (e.g. Habitat dataset configs) and the shared Python env work without
-# re-downloading or re-installing.
+# re-downloading or re-installing, and run artifacts written under `output/`
+# survive the worktree being removed (they live in the main checkout).
 #
 # Idempotent: re-running on an already-bootstrapped worktree is a no-op
 # that prints the current state of each link.
@@ -65,7 +66,7 @@ echo "Bootstrapping worktree: $worktree_root"
 echo "Main checkout:          $main_root"
 echo
 
-for name in data .venv; do
+for name in data .venv output; do
     link_shared "$name"
 done
 


### PR DESCRIPTION
## What changed
`setup_worktree.sh` now symlinks **`output/`** (in addition to `data/` and `.venv/`) from the main checkout into a worktree.

## Why
The script symlinked only `data/` and `.venv/`, so a worktree's `output/` was a real per-worktree directory — **deleted along with the worktree**. That's how the JAX 3D-26 offline run artifacts (`heldout_table_row.json`, checkpoints, etc.) were lost when their worktree was removed, which is why the 3D-46 comparison has to pull the JAX numbers from W&B instead of disk. Adding `output` to the shared-symlink loop makes run artifacts land in the main checkout and persist after the worktree is gone.

There's prior precedent for this fix done by hand: `worktrees/3d26-rerun-checkpoints/output -> ../../output`.

## Risk
Very low. `link_shared` already no-ops when `output/` is a pre-existing real dir (`conflict ... leaving alone`), so existing worktrees are untouched; only freshly bootstrapped worktrees get the symlink. Idempotent.

## How to test
```
bash -n scripts/setup_worktree.sh           # syntax
# in a fresh worktree: ./scripts/setup_worktree.sh  -> "output: linked -> ../../output"
# in the main checkout: -> "Not inside a worktree. Nothing to do."
```

## Linear
Follow-up surfaced while working 3D-46 (lost JAX 3D-26 outputs traced to this gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)