### PR TITLE
feat(r2dreamer): aggregator frame+global readout + 3D-47 ablation (3D-47)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ Goal Condition
 
 # Personal documents
 antrag_masterarbeit_*.pdf
+worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ When working in a `git worktree` (any directory under `worktrees/`), run once pe
 
 This symlinks the shared `data/` and `.venv/` from the main checkout into the worktree. Habitat and other scripts resolve dataset paths relative to CWD, so a worktree without these links fails fast with `FileNotFoundError: data/datasets/...`. The script is idempotent and is a no-op in the main checkout.
 
+When creating or starting work in a worktree for a Linear issue, move the issue status from Backlog to In Progress before editing. If Linear write tools are not available, say so in the final response.
+
 ## Default Workflow
 
 Before editing:
@@ -43,6 +45,7 @@ Every PR should explain:
 - Linear issue
 - Acceptance criteria checked
 - Screenshots, Loom, or preview URL when relevant
+- W&B run link or run ID when training or eval was run
 - Risk
 - How to test
 - What was intentionally not done
@@ -73,5 +76,9 @@ Return review feedback in three groups:
 ## Verification
 
 Use the narrowest useful verification command for the task.
+
+Agents are allowed to confirm code with an interactive `srun` job on the dev H100 GPU for up to 30 minutes. Use this for short smoke tests, targeted training/eval checks, or debugging that needs GPU access.
+
+If verification needs more than 30 minutes, first confirm the code works with the short `srun` check, then submit the longer run with `sbatch`. Before creating a PR, include the `sbatch` job ID, the command/script submitted, the current or final job result, and the W&B run link or run ID in the PR notes.
 
 If a broad check is already known to have unrelated failures, say that plainly in the PR and include the targeted checks that passed.

--- a/docs/curriculum-overview.html
+++ b/docs/curriculum-overview.html
@@ -1,0 +1,818 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Curriculum Overview — 4 levels, houses × goals × episodes</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap');
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  :root {
+    --bg: #0f0f13;
+    --surface: #1a1a24;
+    --surface-2: #22222e;
+    --surface-3: #2d2d3d;
+    --accent: #6366f1;
+    --accent2: #818cf8;
+    --good: #34d399;
+    --warn: #fbbf24;
+    --bad: #f87171;
+    --text: #e2e8f0;
+    --text-dim: #94a3b8;
+    --text-dimmer: #64748b;
+    --border: #2d2d3d;
+  }
+
+  body {
+    font-family: 'Inter', -apple-system, sans-serif;
+    background: var(--bg); color: var(--text);
+    min-height: 100vh; padding: 48px 24px; line-height: 1.55;
+  }
+  .container { max-width: 1100px; margin: 0 auto; }
+
+  header.page { margin-bottom: 28px; }
+  h1 { font-size: 1.85rem; font-weight: 700; margin-bottom: 6px; }
+  .subtitle { color: var(--text-dim); font-size: 0.9rem; }
+  .tag {
+    display: inline-block; padding: 2px 8px; border-radius: 4px;
+    font-family: 'JetBrains Mono', monospace; font-size: 0.75rem;
+    background: var(--surface-3); color: var(--text-dim); margin-right: 6px;
+  }
+  code, .mono { font-family: 'JetBrains Mono', monospace; font-size: 0.85em; }
+  code {
+    background: var(--surface-2); padding: 1px 5px; border-radius: 3px;
+    color: #c4b5fd;
+  }
+
+  h2 {
+    font-size: 1.15rem; font-weight: 600; margin: 0 0 4px;
+  }
+  h3 {
+    font-size: 0.95rem; font-weight: 600; margin: 22px 0 10px;
+    color: var(--accent2); text-transform: uppercase; letter-spacing: 1px;
+  }
+  h4 {
+    font-size: 0.85rem; font-weight: 600; margin: 0 0 10px;
+    color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.8px;
+  }
+
+  .summary-card {
+    background: var(--surface); border: 1px solid var(--border);
+    border-left: 3px solid var(--accent); border-radius: 6px;
+    padding: 18px 22px; margin-bottom: 20px;
+  }
+  .summary-card p { color: var(--text-dim); }
+
+  table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+  th, td { padding: 8px 12px; border-bottom: 1px solid var(--border); }
+  th {
+    text-align: left; color: var(--accent2); font-weight: 600;
+    background: var(--surface); border-bottom: 2px solid var(--border);
+  }
+  td { color: var(--text-dim); }
+  td.r, th.r { text-align: right; font-variant-numeric: tabular-nums; }
+  tr:hover td { background: rgba(99,102,241,0.05); }
+
+  .level-card {
+    background: var(--surface); border: 1px solid var(--border);
+    border-radius: 10px; padding: 22px 26px; margin: 22px 0;
+  }
+  .level-head { margin-bottom: 16px; }
+  .level-tag {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.95rem; color: var(--accent2);
+  }
+  .level-desc { color: var(--text-dim); font-size: 0.88rem; margin-top: 4px; }
+
+  .stat-grid {
+    display: grid; gap: 10px;
+    grid-template-columns: repeat(5, 1fr);
+    margin: 8px 0 22px;
+  }
+  .stat {
+    background: var(--surface-2); border: 1px solid var(--border);
+    border-radius: 6px; padding: 12px 14px;
+  }
+  .stat-num {
+    font-family: 'JetBrains Mono', monospace; font-weight: 600;
+    font-size: 1.15rem; color: var(--text);
+  }
+  .stat-lbl {
+    color: var(--text-dimmer); font-size: 0.7rem;
+    text-transform: uppercase; letter-spacing: 1px; margin-top: 2px;
+  }
+
+  .dist-grid {
+    display: grid; gap: 22px;
+    grid-template-columns: 1fr 1fr;
+    margin-top: 4px;
+  }
+  .dist-block.dist-wide { grid-column: 1 / -1; margin-top: 18px; }
+
+  .bars { display: flex; flex-direction: column; gap: 6px; }
+  .bar-row {
+    display: grid;
+    grid-template-columns: 78px 1fr 132px;
+    gap: 10px; align-items: center;
+    font-size: 0.78rem;
+  }
+  .bar-label code { font-size: 0.75rem; }
+  .bar-track {
+    background: var(--surface-2); border-radius: 3px;
+    height: 14px; position: relative; overflow: hidden;
+    border: 1px solid var(--border);
+  }
+  .bar-fill {
+    height: 100%; display: inline-block;
+    transition: width 0.2s;
+  }
+  .bar-eval { /* sits next to train */ }
+  .bar-value {
+    text-align: right; font-family: 'JetBrains Mono', monospace;
+    font-size: 0.72rem; color: var(--text-dim);
+    display: flex; flex-direction: column; line-height: 1.25;
+  }
+  .v-total { color: var(--text); font-weight: 600; }
+  .v-split { font-size: 0.66rem; color: var(--text-dimmer); }
+
+  /* Heatmap */
+  .heatmap { table-layout: fixed; font-size: 0.78rem; }
+  .heatmap th, .heatmap td { text-align: center; padding: 6px 4px; }
+  .heatmap th { font-size: 0.72rem; }
+  .heat-corner { background: transparent !important; color: var(--text-dimmer); }
+  .heat-row-label {
+    text-align: left !important; background: var(--surface) !important;
+    border-right: 1px solid var(--border);
+  }
+  .heat-row-label code { font-size: 0.7rem; }
+  .heat-cell {
+    color: #0f0f13; font-weight: 600;
+    font-family: 'JetBrains Mono', monospace; font-size: 0.74rem;
+    border: 1px solid var(--border);
+  }
+  .heat-cell span {
+    mix-blend-mode: normal;
+    text-shadow: 0 1px 2px rgba(15,15,19,0.55);
+    color: #0f0f13;
+  }
+  .heat-total {
+    font-family: 'JetBrains Mono', monospace; font-weight: 600;
+    color: var(--text); background: var(--surface-2);
+  }
+  .heat-grand { color: var(--accent2); }
+  .heat-note { font-size: 0.72rem; color: var(--text-dimmer); margin-top: 8px; }
+
+  .legend {
+    display: flex; flex-wrap: wrap; gap: 8px; margin: 10px 0 22px;
+  }
+  .legend-pill {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 3px 10px; background: var(--surface);
+    border: 1px solid var(--border); border-radius: 999px;
+    font-size: 0.75rem;
+  }
+  .legend-pill .dot {
+    width: 9px; height: 9px; border-radius: 50%; background: var(--c);
+  }
+
+  footer.page {
+    margin-top: 36px; padding-top: 16px;
+    border-top: 1px solid var(--border);
+    font-size: 0.78rem; color: var(--text-dimmer);
+  }
+
+  @media (max-width: 720px) {
+    .stat-grid { grid-template-columns: repeat(2, 1fr); }
+    .dist-grid { grid-template-columns: 1fr; }
+    .bar-row { grid-template-columns: 70px 1fr 110px; }
+  }
+</style>
+</head>
+<body>
+<div class="container">
+
+<header class="page">
+  <span class="tag">curriculum</span><span class="tag">overview</span>
+  <h1>Curriculum overview — houses × goals × episodes</h1>
+  <p class="subtitle">
+    Auto-generated from <code>data/curriculum/level{1..4}_*.json</code>.
+    Each episode is a Habitat ObjectNav trajectory keyed by
+    <code>(episode_id, goal_category, scene_id)</code>.
+  </p>
+</header>
+
+<div class="summary-card">
+  <h2>Summary</h2>
+  <p style="margin-top:6px;">
+    The curriculum is a 2&times;2 design varying <em>scene diversity</em>
+    (1 vs 10 houses) and <em>goal diversity</em> (1 vs 6 object categories).
+    All splits use <code>seed=42</code> with <code>train_ratio=0.9</code>,
+    so the same trajectory always falls on the same side of the split
+    across ablations.
+  </p>
+</div>
+
+
+    <table class="summary-table">
+      <thead><tr>
+        <th>level</th><th class='r'>houses</th><th class='r'>goals</th>
+        <th class='r'>train</th><th class='r'>eval</th>
+        <th class='r'>total</th><th class='r'>≈ episodes / (house × goal)</th>
+      </tr></thead>
+      <tbody><tr><td><code>level1_1house_1goal</code></td><td class='r'>1</td><td class='r'>1</td><td class='r'>7,499</td><td class='r'>834</td><td class='r'><strong>8,333</strong></td><td class='r'>8,333</td></tr><tr><td><code>level2_1house_6goals</code></td><td class='r'>1</td><td class='r'>6</td><td class='r'>44,998</td><td class='r'>5,000</td><td class='r'><strong>49,998</strong></td><td class='r'>8,333</td></tr><tr><td><code>level3_10houses_1goal</code></td><td class='r'>10</td><td class='r'>1</td><td class='r'>74,997</td><td class='r'>8,333</td><td class='r'><strong>83,330</strong></td><td class='r'>8,333</td></tr><tr><td><code>level4_10houses_6goals</code></td><td class='r'>10</td><td class='r'>6</td><td class='r'>449,982</td><td class='r'>49,998</td><td class='r'><strong>499,980</strong></td><td class='r'>8,333</td></tr></tbody>
+    </table>
+
+<h3>Goal-category colour legend</h3>
+<div class="legend"><span class='legend-pill' style='--c:#6366f1'><span class='dot'></span><code>chair</code></span> <span class='legend-pill' style='--c:#22d3ee'><span class='dot'></span><code>bed</code></span> <span class='legend-pill' style='--c:#34d399'><span class='dot'></span><code>plant</code></span> <span class='legend-pill' style='--c:#fbbf24'><span class='dot'></span><code>sofa</code></span> <span class='legend-pill' style='--c:#f87171'><span class='dot'></span><code>toilet</code></span> <span class='legend-pill' style='--c:#a78bfa'><span class='dot'></span><code>tv_monitor</code></span></div>
+
+
+    <section class="level-card">
+      <header class="level-head">
+        <h2><span class="level-tag">level1_1house_1goal</span></h2>
+        <p class="level-desc">Single house (fK2vEV32Lag), chair only — proves WM learns</p>
+      </header>
+
+      <div class="stat-grid">
+        <div class="stat"><div class="stat-num">8,333</div>
+          <div class="stat-lbl">total episodes</div></div>
+        <div class="stat"><div class="stat-num">7,499</div>
+          <div class="stat-lbl">train</div></div>
+        <div class="stat"><div class="stat-num">834</div>
+          <div class="stat-lbl">eval (10.0%)</div></div>
+        <div class="stat"><div class="stat-num">1</div>
+          <div class="stat-lbl">house</div></div>
+        <div class="stat"><div class="stat-num">1</div>
+          <div class="stat-lbl">goal</div></div>
+      </div>
+
+      <div class="dist-grid">
+        
+    <div class="dist-block">
+      <h4>Goals × episodes</h4>
+      <div class="bars">
+    <div class="bar-row">
+      <div class="bar-label"><code>chair</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:89.99%; background:#6366f1;"
+             title="train: 7,499"></div>
+        <div class="bar-fill bar-eval"  style="width:10.01%; background:#6366f1;
+             opacity:0.45;" title="eval: 834"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">8,333</span>
+        <span class="v-split">7,499 train · 834 eval</span>
+      </div>
+    </div></div>
+    </div>
+        
+      </div>
+      
+    </section>
+
+    <section class="level-card">
+      <header class="level-head">
+        <h2><span class="level-tag">level2_1house_6goals</span></h2>
+        <p class="level-desc">Single house (fK2vEV32Lag), all 6 categories — tests multi-goal</p>
+      </header>
+
+      <div class="stat-grid">
+        <div class="stat"><div class="stat-num">49,998</div>
+          <div class="stat-lbl">total episodes</div></div>
+        <div class="stat"><div class="stat-num">44,998</div>
+          <div class="stat-lbl">train</div></div>
+        <div class="stat"><div class="stat-num">5,000</div>
+          <div class="stat-lbl">eval (10.0%)</div></div>
+        <div class="stat"><div class="stat-num">1</div>
+          <div class="stat-lbl">house</div></div>
+        <div class="stat"><div class="stat-num">6</div>
+          <div class="stat-lbl">goals</div></div>
+      </div>
+
+      <div class="dist-grid">
+        
+    <div class="dist-block">
+      <h4>Goals × episodes</h4>
+      <div class="bars">
+    <div class="bar-row">
+      <div class="bar-label"><code>bed</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:90.11%; background:#22d3ee;"
+             title="train: 7,509"></div>
+        <div class="bar-fill bar-eval"  style="width:9.89%; background:#22d3ee;
+             opacity:0.45;" title="eval: 824"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">8,333</span>
+        <span class="v-split">7,509 train · 824 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>chair</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:89.49%; background:#6366f1;"
+             title="train: 7,457"></div>
+        <div class="bar-fill bar-eval"  style="width:10.51%; background:#6366f1;
+             opacity:0.45;" title="eval: 876"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">8,333</span>
+        <span class="v-split">7,457 train · 876 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>plant</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:90.35%; background:#34d399;"
+             title="train: 7,529"></div>
+        <div class="bar-fill bar-eval"  style="width:9.65%; background:#34d399;
+             opacity:0.45;" title="eval: 804"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">8,333</span>
+        <span class="v-split">7,529 train · 804 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>sofa</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:89.92%; background:#fbbf24;"
+             title="train: 7,493"></div>
+        <div class="bar-fill bar-eval"  style="width:10.08%; background:#fbbf24;
+             opacity:0.45;" title="eval: 840"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">8,333</span>
+        <span class="v-split">7,493 train · 840 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>toilet</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:90.14%; background:#f87171;"
+             title="train: 7,511"></div>
+        <div class="bar-fill bar-eval"  style="width:9.86%; background:#f87171;
+             opacity:0.45;" title="eval: 822"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">8,333</span>
+        <span class="v-split">7,511 train · 822 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>tv_monitor</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:89.99%; background:#a78bfa;"
+             title="train: 7,499"></div>
+        <div class="bar-fill bar-eval"  style="width:10.01%; background:#a78bfa;
+             opacity:0.45;" title="eval: 834"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">8,333</span>
+        <span class="v-split">7,499 train · 834 eval</span>
+      </div>
+    </div></div>
+    </div>
+        
+      </div>
+      
+    </section>
+
+    <section class="level-card">
+      <header class="level-head">
+        <h2><span class="level-tag">level3_10houses_1goal</span></h2>
+        <p class="level-desc">10 houses (easy/medium/hard), chair only — tests generalization</p>
+      </header>
+
+      <div class="stat-grid">
+        <div class="stat"><div class="stat-num">83,330</div>
+          <div class="stat-lbl">total episodes</div></div>
+        <div class="stat"><div class="stat-num">74,997</div>
+          <div class="stat-lbl">train</div></div>
+        <div class="stat"><div class="stat-num">8,333</div>
+          <div class="stat-lbl">eval (10.0%)</div></div>
+        <div class="stat"><div class="stat-num">10</div>
+          <div class="stat-lbl">houses</div></div>
+        <div class="stat"><div class="stat-num">1</div>
+          <div class="stat-lbl">goal</div></div>
+      </div>
+
+      <div class="dist-grid">
+        
+    <div class="dist-block">
+      <h4>Goals × episodes</h4>
+      <div class="bars">
+    <div class="bar-row">
+      <div class="bar-label"><code>chair</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:90.00%; background:#6366f1;"
+             title="train: 74,997"></div>
+        <div class="bar-fill bar-eval"  style="width:10.00%; background:#6366f1;
+             opacity:0.45;" title="eval: 8,333"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">83,330</span>
+        <span class="v-split">74,997 train · 8,333 eval</span>
+      </div>
+    </div></div>
+    </div>
+        
+    <div class="dist-block">
+      <h4>Houses × episodes</h4>
+      <div class="bars">
+    <div class="bar-row">
+      <div class="bar-label"><code>fK2vEV32Lag</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:90.11%; background:#818cf8;"
+             title="train: 7,509"></div>
+        <div class="bar-fill bar-eval"  style="width:9.89%; background:#818cf8;
+             opacity:0.45;" title="eval: 824"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">8,333</span>
+        <span class="v-split">7,509 train · 824 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>W9YAR9qcuvN</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:89.72%; background:#818cf8;"
+             title="train: 7,476"></div>
+        <div class="bar-fill bar-eval"  style="width:10.28%; background:#818cf8;
+             opacity:0.45;" title="eval: 857"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">8,333</span>
+        <span class="v-split">7,476 train · 857 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>wPLokgvCnuk</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:90.10%; background:#818cf8;"
+             title="train: 7,508"></div>
+        <div class="bar-fill bar-eval"  style="width:9.90%; background:#818cf8;
+             opacity:0.45;" title="eval: 825"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">8,333</span>
+        <span class="v-split">7,508 train · 825 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>ACZZiU6BXLz</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:89.92%; background:#818cf8;"
+             title="train: 7,493"></div>
+        <div class="bar-fill bar-eval"  style="width:10.08%; background:#818cf8;
+             opacity:0.45;" title="eval: 840"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">8,333</span>
+        <span class="v-split">7,493 train · 840 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>XfUxBGTFQQb</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:89.66%; background:#818cf8;"
+             title="train: 7,471"></div>
+        <div class="bar-fill bar-eval"  style="width:10.34%; background:#818cf8;
+             opacity:0.45;" title="eval: 862"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">8,333</span>
+        <span class="v-split">7,471 train · 862 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>9h5JJxM6E5S</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:89.46%; background:#818cf8;"
+             title="train: 7,455"></div>
+        <div class="bar-fill bar-eval"  style="width:10.54%; background:#818cf8;
+             opacity:0.45;" title="eval: 878"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">8,333</span>
+        <span class="v-split">7,455 train · 878 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>qz3829g1Lzf</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:90.68%; background:#818cf8;"
+             title="train: 7,556"></div>
+        <div class="bar-fill bar-eval"  style="width:9.32%; background:#818cf8;
+             opacity:0.45;" title="eval: 777"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">8,333</span>
+        <span class="v-split">7,556 train · 777 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>oPj9qMxrDEa</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:90.28%; background:#818cf8;"
+             title="train: 7,523"></div>
+        <div class="bar-fill bar-eval"  style="width:9.72%; background:#818cf8;
+             opacity:0.45;" title="eval: 810"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">8,333</span>
+        <span class="v-split">7,523 train · 810 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>u5atqC7vRCY</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:90.23%; background:#818cf8;"
+             title="train: 7,519"></div>
+        <div class="bar-fill bar-eval"  style="width:9.77%; background:#818cf8;
+             opacity:0.45;" title="eval: 814"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">8,333</span>
+        <span class="v-split">7,519 train · 814 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>j2EJhFEQGCL</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:89.85%; background:#818cf8;"
+             title="train: 7,487"></div>
+        <div class="bar-fill bar-eval"  style="width:10.15%; background:#818cf8;
+             opacity:0.45;" title="eval: 846"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">8,333</span>
+        <span class="v-split">7,487 train · 846 eval</span>
+      </div>
+    </div></div>
+    </div>
+      </div>
+      
+    </section>
+
+    <section class="level-card">
+      <header class="level-head">
+        <h2><span class="level-tag">level4_10houses_6goals</span></h2>
+        <p class="level-desc">10 houses (easy/medium/hard), all 6 categories — full curriculum</p>
+      </header>
+
+      <div class="stat-grid">
+        <div class="stat"><div class="stat-num">499,980</div>
+          <div class="stat-lbl">total episodes</div></div>
+        <div class="stat"><div class="stat-num">449,982</div>
+          <div class="stat-lbl">train</div></div>
+        <div class="stat"><div class="stat-num">49,998</div>
+          <div class="stat-lbl">eval (10.0%)</div></div>
+        <div class="stat"><div class="stat-num">10</div>
+          <div class="stat-lbl">houses</div></div>
+        <div class="stat"><div class="stat-num">6</div>
+          <div class="stat-lbl">goals</div></div>
+      </div>
+
+      <div class="dist-grid">
+        
+    <div class="dist-block">
+      <h4>Goals × episodes</h4>
+      <div class="bars">
+    <div class="bar-row">
+      <div class="bar-label"><code>bed</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:89.97%; background:#22d3ee;"
+             title="train: 74,971"></div>
+        <div class="bar-fill bar-eval"  style="width:10.03%; background:#22d3ee;
+             opacity:0.45;" title="eval: 8,359"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">83,330</span>
+        <span class="v-split">74,971 train · 8,359 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>chair</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:90.01%; background:#6366f1;"
+             title="train: 75,006"></div>
+        <div class="bar-fill bar-eval"  style="width:9.99%; background:#6366f1;
+             opacity:0.45;" title="eval: 8,324"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">83,330</span>
+        <span class="v-split">75,006 train · 8,324 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>plant</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:90.07%; background:#34d399;"
+             title="train: 75,055"></div>
+        <div class="bar-fill bar-eval"  style="width:9.93%; background:#34d399;
+             opacity:0.45;" title="eval: 8,275"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">83,330</span>
+        <span class="v-split">75,055 train · 8,275 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>sofa</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:89.98%; background:#fbbf24;"
+             title="train: 74,983"></div>
+        <div class="bar-fill bar-eval"  style="width:10.02%; background:#fbbf24;
+             opacity:0.45;" title="eval: 8,347"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">83,330</span>
+        <span class="v-split">74,983 train · 8,347 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>toilet</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:89.98%; background:#f87171;"
+             title="train: 74,984"></div>
+        <div class="bar-fill bar-eval"  style="width:10.02%; background:#f87171;
+             opacity:0.45;" title="eval: 8,346"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">83,330</span>
+        <span class="v-split">74,984 train · 8,346 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>tv_monitor</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:89.98%; background:#a78bfa;"
+             title="train: 74,983"></div>
+        <div class="bar-fill bar-eval"  style="width:10.02%; background:#a78bfa;
+             opacity:0.45;" title="eval: 8,347"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">83,330</span>
+        <span class="v-split">74,983 train · 8,347 eval</span>
+      </div>
+    </div></div>
+    </div>
+        
+    <div class="dist-block">
+      <h4>Houses × episodes</h4>
+      <div class="bars">
+    <div class="bar-row">
+      <div class="bar-label"><code>fK2vEV32Lag</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:90.02%; background:#818cf8;"
+             title="train: 45,006"></div>
+        <div class="bar-fill bar-eval"  style="width:9.98%; background:#818cf8;
+             opacity:0.45;" title="eval: 4,992"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">49,998</span>
+        <span class="v-split">45,006 train · 4,992 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>W9YAR9qcuvN</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:89.86%; background:#818cf8;"
+             title="train: 44,926"></div>
+        <div class="bar-fill bar-eval"  style="width:10.14%; background:#818cf8;
+             opacity:0.45;" title="eval: 5,072"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">49,998</span>
+        <span class="v-split">44,926 train · 5,072 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>wPLokgvCnuk</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:90.08%; background:#818cf8;"
+             title="train: 45,039"></div>
+        <div class="bar-fill bar-eval"  style="width:9.92%; background:#818cf8;
+             opacity:0.45;" title="eval: 4,959"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">49,998</span>
+        <span class="v-split">45,039 train · 4,959 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>ACZZiU6BXLz</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:90.03%; background:#818cf8;"
+             title="train: 45,014"></div>
+        <div class="bar-fill bar-eval"  style="width:9.97%; background:#818cf8;
+             opacity:0.45;" title="eval: 4,984"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">49,998</span>
+        <span class="v-split">45,014 train · 4,984 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>XfUxBGTFQQb</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:90.07%; background:#818cf8;"
+             title="train: 45,031"></div>
+        <div class="bar-fill bar-eval"  style="width:9.93%; background:#818cf8;
+             opacity:0.45;" title="eval: 4,967"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">49,998</span>
+        <span class="v-split">45,031 train · 4,967 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>9h5JJxM6E5S</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:89.89%; background:#818cf8;"
+             title="train: 44,944"></div>
+        <div class="bar-fill bar-eval"  style="width:10.11%; background:#818cf8;
+             opacity:0.45;" title="eval: 5,054"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">49,998</span>
+        <span class="v-split">44,944 train · 5,054 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>qz3829g1Lzf</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:89.94%; background:#818cf8;"
+             title="train: 44,967"></div>
+        <div class="bar-fill bar-eval"  style="width:10.06%; background:#818cf8;
+             opacity:0.45;" title="eval: 5,031"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">49,998</span>
+        <span class="v-split">44,967 train · 5,031 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>oPj9qMxrDEa</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:90.15%; background:#818cf8;"
+             title="train: 45,074"></div>
+        <div class="bar-fill bar-eval"  style="width:9.85%; background:#818cf8;
+             opacity:0.45;" title="eval: 4,924"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">49,998</span>
+        <span class="v-split">45,074 train · 4,924 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>u5atqC7vRCY</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:90.18%; background:#818cf8;"
+             title="train: 45,089"></div>
+        <div class="bar-fill bar-eval"  style="width:9.82%; background:#818cf8;
+             opacity:0.45;" title="eval: 4,909"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">49,998</span>
+        <span class="v-split">45,089 train · 4,909 eval</span>
+      </div>
+    </div>
+    <div class="bar-row">
+      <div class="bar-label"><code>j2EJhFEQGCL</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:89.79%; background:#818cf8;"
+             title="train: 44,892"></div>
+        <div class="bar-fill bar-eval"  style="width:10.21%; background:#818cf8;
+             opacity:0.45;" title="eval: 5,106"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">49,998</span>
+        <span class="v-split">44,892 train · 5,106 eval</span>
+      </div>
+    </div></div>
+    </div>
+      </div>
+      
+    <div class="dist-block dist-wide">
+      <h4>House × goal heatmap (train + eval)</h4>
+      <table class="heatmap">
+        <thead><tr><th class='heat-corner'>house \ goal</th><th>bed</th><th>chair</th><th>plant</th><th>sofa</th><th>toilet</th><th>tv_monitor</th><th>total</th></tr></thead>
+        <tbody><tr><th class='heat-row-label'><code>fK2vEV32Lag</code></th><td class='heat-cell' style='background:#22d3ee;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#6366f1;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#34d399;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#fbbf24;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#f87171;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#a78bfa;opacity:0.88;'><span>8,333</span></td><td class='heat-total'>49,998</td></tr><tr><th class='heat-row-label'><code>W9YAR9qcuvN</code></th><td class='heat-cell' style='background:#22d3ee;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#6366f1;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#34d399;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#fbbf24;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#f87171;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#a78bfa;opacity:0.88;'><span>8,333</span></td><td class='heat-total'>49,998</td></tr><tr><th class='heat-row-label'><code>wPLokgvCnuk</code></th><td class='heat-cell' style='background:#22d3ee;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#6366f1;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#34d399;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#fbbf24;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#f87171;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#a78bfa;opacity:0.88;'><span>8,333</span></td><td class='heat-total'>49,998</td></tr><tr><th class='heat-row-label'><code>ACZZiU6BXLz</code></th><td class='heat-cell' style='background:#22d3ee;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#6366f1;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#34d399;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#fbbf24;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#f87171;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#a78bfa;opacity:0.88;'><span>8,333</span></td><td class='heat-total'>49,998</td></tr><tr><th class='heat-row-label'><code>XfUxBGTFQQb</code></th><td class='heat-cell' style='background:#22d3ee;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#6366f1;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#34d399;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#fbbf24;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#f87171;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#a78bfa;opacity:0.88;'><span>8,333</span></td><td class='heat-total'>49,998</td></tr><tr><th class='heat-row-label'><code>9h5JJxM6E5S</code></th><td class='heat-cell' style='background:#22d3ee;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#6366f1;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#34d399;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#fbbf24;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#f87171;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#a78bfa;opacity:0.88;'><span>8,333</span></td><td class='heat-total'>49,998</td></tr><tr><th class='heat-row-label'><code>qz3829g1Lzf</code></th><td class='heat-cell' style='background:#22d3ee;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#6366f1;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#34d399;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#fbbf24;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#f87171;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#a78bfa;opacity:0.88;'><span>8,333</span></td><td class='heat-total'>49,998</td></tr><tr><th class='heat-row-label'><code>oPj9qMxrDEa</code></th><td class='heat-cell' style='background:#22d3ee;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#6366f1;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#34d399;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#fbbf24;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#f87171;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#a78bfa;opacity:0.88;'><span>8,333</span></td><td class='heat-total'>49,998</td></tr><tr><th class='heat-row-label'><code>u5atqC7vRCY</code></th><td class='heat-cell' style='background:#22d3ee;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#6366f1;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#34d399;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#fbbf24;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#f87171;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#a78bfa;opacity:0.88;'><span>8,333</span></td><td class='heat-total'>49,998</td></tr><tr><th class='heat-row-label'><code>j2EJhFEQGCL</code></th><td class='heat-cell' style='background:#22d3ee;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#6366f1;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#34d399;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#fbbf24;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#f87171;opacity:0.88;'><span>8,333</span></td><td class='heat-cell' style='background:#a78bfa;opacity:0.88;'><span>8,333</span></td><td class='heat-total'>49,998</td></tr></tbody>
+        <tfoot><tr><th class='heat-row-label'>total</th><td class='heat-total'>83,330</td><td class='heat-total'>83,330</td><td class='heat-total'>83,330</td><td class='heat-total'>83,330</td><td class='heat-total'>83,330</td><td class='heat-total'>83,330</td><td class='heat-total heat-grand'>499,980</td></tr></tfoot>
+      </table>
+      <p class="heat-note">Cell shade scales with episode count
+        (min 8,333, max 8,333). Hue encodes goal category.</p>
+    </div>
+    </section>
+
+<footer class="page">
+  Generated 2026-05-28 by
+  <code>scripts/analysis/curriculum_overview.py</code>.
+  Bar tracks: solid = train, faded = eval (the two are concatenated, not stacked).
+</footer>
+
+</div>
+</body>
+</html>

--- a/docs/notes/external-offline-r2dreamer.md
+++ b/docs/notes/external-offline-r2dreamer.md
@@ -1,0 +1,108 @@
+# External (PyTorch) R2Dreamer — offline adapter
+
+Adapter that trains the **original PyTorch R2Dreamer** (`external/r2dreamer/`)
+offline from the canonical replay buffer, to produce a baseline that is
+apples-to-apples with the JAX offline numbers.
+
+- Linear: **3D-45** (this adapter) → **3D-46** (the 3 baseline runs + comparison).
+- Parent ablation: **3D-24** (VGGT WP/CP vs Aggregator MLP as R2Dreamer input).
+- Entry point: `scripts/r2dreamer/train_external_offline.py`.
+
+## Why an adapter
+
+The stock external entry point (`external/r2dreamer/train.py`) is **env-driven**
+(`make_envs` → `OnlineTrainer`, torchrl `LazyTensorStorage` filled by live
+rollouts) and logs only to TensorBoard/jsonl. To replay the fixed offline buffer
+on a precomputed vector and land in the same W&B project as the JAX runs, the
+adapter adds three things without touching the vendored repo:
+
+1. **Vector input** — declares an obs space `{"vector": Box(4116,)}` and sets
+   `encoder.mlp_keys='vector'`, `cnn_keys='$^'`. `MultiEncoder` already routes a
+   `len(shape)==1` obs matched by `mlp_keys` to its MLP branch; `$^` is the
+   match-nothing regex that disables the CNN. No new modeling.
+2. **Offline replay** (`OfflineVectorBuffer`) — drop-in for the external
+   `Buffer`'s `sample()/update()/count()` interface, so `agent.update()` is
+   reused verbatim (identical LaProp/GradScaler/AGC/scheduler behaviour).
+3. **W&B** — a thin `tools.Logger` subclass that mirrors scalars to W&B, gated
+   behind `--wandb`.
+
+## Fairness: identical to the JAX `OfflineBufferDataset`
+
+The buffer reproduces the JAX sampling contract exactly, so the external sees the
+same `(obs, action, reward, flags)` windows the JAX runs saw:
+
+- contiguous windows that **may straddle episode boundaries**;
+- `is_first[:, 0] = True`, and `is_first[:, t] = done[t-1]` (reset on `done`);
+- `is_terminal == is_last == done` (the buffer records only env `done`);
+- actions aligned with obs at the same index (no torchrl one-step shift), one-hot
+  over the 4 Habitat actions;
+- **zeroed initial latent each batch** — episode reset is driven entirely by
+  `is_first`. The external R2-Dreamer replay-buffer latent write-back
+  (`replay_buffer.update`) is a **no-op** offline, matching the JAX path which
+  carries no cross-batch latent state.
+
+Train/heldout split = `collection_metadata.json["heldout_split"]`
+(last 10% of episodes by `episode_id`), same as 3D-25/3D-26.
+
+## Decoder-free on both sides
+
+Default `rep_loss="r2dreamer"` (Barlow-Twins redundancy reduction) carries **no
+decoder** — same as the decoder-free JAX R2Dreamer — so there is **no
+reconstruction NLL on either side**. Comparable held-out metrics are dynamics KL,
+representation KL, reward MSE, and k-step latent rollout error (k ∈ {1,5,15}).
+(`rep_loss="dreamer"` would add a `MultiDecoder` and a recon NLL; we do **not**
+use it for the baseline.)
+
+## Environment
+
+Run under the **external** venv — it has torchrl/tensordict/gymnasium; the main
+`.venv` does not:
+
+```
+external/r2dreamer/.venv/bin/python scripts/r2dreamer/train_external_offline.py ...
+```
+
+## Commands
+
+Smoke (NaN-free, no W&B; CPU is fine — `torch.compile` is auto-disabled and
+`GradScaler` auto-disables without CUDA):
+
+```
+external/r2dreamer/.venv/bin/python scripts/r2dreamer/train_external_offline.py \
+    --encoder wp_cp --seed 0 --steps 100 \
+    --buffer-dir data/offline_buffer_smoke --output-dir /tmp/ext_smoke \
+    --device cpu --batch-size 4 --seq-len 16
+```
+
+Real run (GPU) — one per seed for 3D-46:
+
+```
+external/r2dreamer/.venv/bin/python scripts/r2dreamer/train_external_offline.py \
+    --encoder wp_cp --seed 0 --steps 500000 \
+    --buffer-dir data/offline_buffer --output-dir output/3d46/ext-wp_cp-seed0 \
+    --device cuda:0 --wandb --wandb-name ext-wp_cp-seed0
+```
+
+W&B (when `--wandb`): project `3d-vla-objectnav-offline-ablation`, tags
+`offline-ablation, 3d-24, framework:pytorch-external, variant:wp_cp`, run name
+`ext-<encoder>-seed<n>` — so the runs filter beside the JAX `wp_cp-seed{0,1,2}`.
+
+`run_config.json` (written to `--output-dir`) records both repo and
+`external/r2dreamer` code SHAs plus the buffer metadata for reproducibility.
+
+## Handoff to 3D-46
+
+- Launch `--seed {0,1,2}`, `--steps 500000`, `--device cuda:0`, `--wandb`. Runs
+  are independent → parallelizable across nodes (mirror the SLURM pattern in
+  `scripts/slurm/`).
+- Held-out metrics: reuse the train/heldout split above; report dynamics KL,
+  representation KL, reward MSE, k-step rollout error (k ∈ {1,5,15}) — **not**
+  reconstruction NLL (decoder-free on both sides).
+- The only field that may differ across the 3 runs is `--seed`.
+
+## Tests
+
+`tests/r2dreamer/test_external_offline_buffer.py` validates the split, window
+sampling, `is_first` done-shift, one-hot actions, and zeroed initial latent on a
+synthetic buffer. Skipped under the main venv (no tensordict); runs under the
+external venv.

--- a/docs/notes/external-offline-r2dreamer.md
+++ b/docs/notes/external-offline-r2dreamer.md
@@ -90,15 +90,57 @@ W&B (when `--wandb`): project `3d-vla-objectnav-offline-ablation`, tags
 `run_config.json` (written to `--output-dir`) records both repo and
 `external/r2dreamer` code SHAs plus the buffer metadata for reproducibility.
 
-## Handoff to 3D-46
+## 3D-46 — the 3 baseline runs + comparison
 
-- Launch `--seed {0,1,2}`, `--steps 500000`, `--device cuda:0`, `--wandb`. Runs
-  are independent → parallelizable across nodes (mirror the SLURM pattern in
-  `scripts/slurm/`).
-- Held-out metrics: reuse the train/heldout split above; report dynamics KL,
-  representation KL, reward MSE, k-step rollout error (k ∈ {1,5,15}) — **not**
-  reconstruction NLL (decoder-free on both sides).
-- The only field that may differ across the 3 runs is `--seed`.
+### Held-out metrics (built into the training script)
+
+After training, the script computes held-out WM metrics on the last 10% of
+episodes and writes `heldout_final.json` + `heldout_table_row.json` to the
+output dir (and logs `final/heldout/*` to W&B). Definitions mirror the JAX
+`src/r2dreamer/heldout_eval.py` exactly:
+
+- **dynamics_kl / representation_kl** — `rssm.kl_loss(post, prior, kl_free)`
+  means (same free-bits clipping as training `loss/dyn` / `loss/rep`). The two
+  share a forward value — the `.detach()` only changes which side gets gradient.
+- **reward_mse** — MSE of the twohot reward head's expected value
+  (`reward(feat).mode()`, real reward space) vs the GT reward.
+- **k_step_rollout_mse[k]**, k ∈ {1,5,15} — from the posterior at t=0, run
+  `rssm.img_step` with GT actions for k steps, MSE on `get_feat` vs the GT
+  posterior feature at step k. (Needs `seq_len ≥ 16`.)
+- **reconstruction_nll = NaN** — decoder-free on both sides.
+
+Disable with `--skip-heldout-eval`; tune batches with `--heldout-eval-batches`
+(default 64, matching the JAX final eval).
+
+### Launching the runs (SLURM)
+
+```
+# smoke (gpu_h100_short, 200 steps, validates GPU + buffer + eval + W&B)
+scripts/r2dreamer/slurm/submit_external_offline.sh smoke 0
+
+# the 3 prod runs (gpu_h100_il, 500k steps, ~5 h each, parallelizable)
+for s in 0 1 2; do scripts/r2dreamer/slurm/submit_external_offline.sh prod "$s"; done
+```
+
+Only `--seed` differs across the 3 prod runs (verifiable from each
+`run_config.json`). Throughput ~29 steps/s on one H100 ⇒ ~5 h/seed.
+
+### Comparison table (after the runs finish)
+
+```
+python scripts/r2dreamer/build_offline_comparison.py \
+    --external-glob 'output/3d46-external-offline/wp_cp-seed*/run-*/heldout_table_row.json' \
+    --jax-glob      'output/3d26-offline-ablation/wp_cp-seed*/run-*/heldout_table_row.json' \
+    --out-md  docs/notes/offline-ablation-comparison.md \
+    --out-csv docs/notes/offline-ablation-comparison.csv
+```
+
+If the JAX 3D-26 output dirs aren't on disk, pass `--jax-wandb` instead — it
+reads each JAX run's `final/heldout/*` summary from the
+`3d-vla-objectnav-offline-ablation` W&B project (tags `3d-26,wp_cp`). The
+builder emits a markdown table (JAX vs PyTorch, mean ± std over 3 seeds) and a
+per-seed CSV; **reconstruction NLL is excluded** from the head-to-head (N/A on
+both sides).
 
 ## Tests
 

--- a/scripts/analysis/curriculum_overview.py
+++ b/scripts/analysis/curriculum_overview.py
@@ -1,0 +1,520 @@
+"""Build a self-contained HTML overview of the 4 curriculum levels.
+
+Reads data/curriculum/level{1..4}*.json, counts train+eval episodes,
+breaks down per goal category and per house (scene), and writes the
+report to docs/curriculum-overview.html.
+
+Run from the repo root:
+    python scripts/analysis/curriculum_overview.py
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from datetime import date
+from html import escape
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+CURRICULUM_DIR = REPO / "data" / "curriculum"
+OUTPUT = REPO / "docs" / "curriculum-overview.html"
+
+LEVEL_FILES = [
+    "level1_1house_1goal.json",
+    "level2_1house_6goals.json",
+    "level3_10houses_1goal.json",
+    "level4_10houses_6goals.json",
+]
+
+# Distinct accent per goal category — chosen to stay readable on dark bg.
+GOAL_COLORS = {
+    "chair":      "#6366f1",
+    "bed":        "#22d3ee",
+    "plant":      "#34d399",
+    "sofa":       "#fbbf24",
+    "toilet":     "#f87171",
+    "tv_monitor": "#a78bfa",
+}
+FALLBACK_COLOR = "#94a3b8"
+
+
+def load_level(path: Path) -> dict:
+    data = json.loads(path.read_text())
+    train = data.get("train_episode_keys", [])
+    evalk = data.get("eval_episode_keys", [])
+    # tuples shaped (episode_id, goal, scene)
+    by_goal_train = Counter(t[1] for t in train)
+    by_goal_eval = Counter(t[1] for t in evalk)
+    by_scene_train = Counter(t[2] for t in train)
+    by_scene_eval = Counter(t[2] for t in evalk)
+    pair_train = Counter((t[2], t[1]) for t in train)
+    pair_eval = Counter((t[2], t[1]) for t in evalk)
+    return {
+        "name": data["name"],
+        "description": data.get("description", ""),
+        "scenes": data.get("scenes", []),
+        "categories": data.get("categories", []),
+        "train_total": len(train),
+        "eval_total": len(evalk),
+        "train_ratio": data.get("train_ratio"),
+        "seed": data.get("seed"),
+        "by_goal_train": by_goal_train,
+        "by_goal_eval": by_goal_eval,
+        "by_scene_train": by_scene_train,
+        "by_scene_eval": by_scene_eval,
+        "pair_train": pair_train,
+        "pair_eval": pair_eval,
+    }
+
+
+def color_for(goal: str) -> str:
+    return GOAL_COLORS.get(goal, FALLBACK_COLOR)
+
+
+def fmt_int(n: int) -> str:
+    return f"{n:,}"
+
+
+def bar_row(label: str, train: int, eval_: int, max_total: int, color: str) -> str:
+    total = train + eval_
+    pct_total = (total / max_total * 100) if max_total else 0
+    train_w = (train / max_total * 100) if max_total else 0
+    eval_w = (eval_ / max_total * 100) if max_total else 0
+    return f"""
+    <div class="bar-row">
+      <div class="bar-label"><code>{escape(label)}</code></div>
+      <div class="bar-track">
+        <div class="bar-fill bar-train" style="width:{train_w:.2f}%; background:{color};"
+             title="train: {fmt_int(train)}"></div>
+        <div class="bar-fill bar-eval"  style="width:{eval_w:.2f}%; background:{color};
+             opacity:0.45;" title="eval: {fmt_int(eval_)}"></div>
+      </div>
+      <div class="bar-value">
+        <span class="v-total">{fmt_int(total)}</span>
+        <span class="v-split">{fmt_int(train)} train · {fmt_int(eval_)} eval</span>
+      </div>
+    </div>"""
+
+
+def render_goal_distribution(level: dict) -> str:
+    cats = level["categories"]
+    if not cats:
+        return ""
+    totals = {c: level["by_goal_train"][c] + level["by_goal_eval"][c] for c in cats}
+    max_total = max(totals.values()) if totals else 1
+    rows = "".join(
+        bar_row(
+            c,
+            level["by_goal_train"][c],
+            level["by_goal_eval"][c],
+            max_total,
+            color_for(c),
+        )
+        for c in sorted(cats, key=lambda x: -totals[x])
+    )
+    return f"""
+    <div class="dist-block">
+      <h4>Goals × episodes</h4>
+      <div class="bars">{rows}</div>
+    </div>"""
+
+
+def render_scene_distribution(level: dict) -> str:
+    scenes = level["scenes"]
+    if not scenes:
+        return ""
+    totals = {
+        s: level["by_scene_train"][s] + level["by_scene_eval"][s] for s in scenes
+    }
+    max_total = max(totals.values()) if totals else 1
+    # Single house cases benefit less from this view.
+    if len(scenes) <= 1:
+        return ""
+    rows = "".join(
+        bar_row(
+            s,
+            level["by_scene_train"][s],
+            level["by_scene_eval"][s],
+            max_total,
+            "#818cf8",
+        )
+        for s in sorted(scenes, key=lambda x: -totals[x])
+    )
+    return f"""
+    <div class="dist-block">
+      <h4>Houses × episodes</h4>
+      <div class="bars">{rows}</div>
+    </div>"""
+
+
+def render_pair_heatmap(level: dict) -> str:
+    scenes = level["scenes"]
+    cats = level["categories"]
+    if len(scenes) <= 1 or len(cats) <= 1:
+        return ""
+    pair_total = {
+        (s, c): level["pair_train"][(s, c)] + level["pair_eval"][(s, c)]
+        for s in scenes
+        for c in cats
+    }
+    max_val = max(pair_total.values()) if pair_total else 1
+    min_val = min(v for v in pair_total.values() if v > 0) if pair_total else 0
+
+    header = (
+        "<thead><tr><th class='heat-corner'>house \\ goal</th>"
+        + "".join(f"<th>{escape(c)}</th>" for c in cats)
+        + "<th>total</th></tr></thead>"
+    )
+    rows = []
+    scene_order = sorted(scenes, key=lambda s: -sum(pair_total[(s, c)] for c in cats))
+    for s in scene_order:
+        row_cells = [f"<th class='heat-row-label'><code>{escape(s)}</code></th>"]
+        row_total = 0
+        for c in cats:
+            v = pair_total[(s, c)]
+            row_total += v
+            frac = v / max_val if max_val else 0
+            base = color_for(c)
+            row_cells.append(
+                f"<td class='heat-cell' style='background:{base};opacity:{0.18 + 0.7 * frac:.2f};'>"
+                f"<span>{fmt_int(v)}</span></td>"
+            )
+        row_cells.append(f"<td class='heat-total'>{fmt_int(row_total)}</td>")
+        rows.append(f"<tr>{''.join(row_cells)}</tr>")
+
+    # column totals
+    col_totals = [sum(pair_total[(s, c)] for s in scenes) for c in cats]
+    grand_total = sum(col_totals)
+    footer_cells = (
+        "<th class='heat-row-label'>total</th>"
+        + "".join(f"<td class='heat-total'>{fmt_int(v)}</td>" for v in col_totals)
+        + f"<td class='heat-total heat-grand'>{fmt_int(grand_total)}</td>"
+    )
+    return f"""
+    <div class="dist-block dist-wide">
+      <h4>House × goal heatmap (train + eval)</h4>
+      <table class="heatmap">
+        {header}
+        <tbody>{''.join(rows)}</tbody>
+        <tfoot><tr>{footer_cells}</tr></tfoot>
+      </table>
+      <p class="heat-note">Cell shade scales with episode count
+        (min {fmt_int(min_val)}, max {fmt_int(max_val)}). Hue encodes goal category.</p>
+    </div>"""
+
+
+def render_level(level: dict) -> str:
+    n_scenes = len(level["scenes"])
+    n_cats = len(level["categories"])
+    grand = level["train_total"] + level["eval_total"]
+    eval_frac = level["eval_total"] / grand * 100 if grand else 0
+    return f"""
+    <section class="level-card">
+      <header class="level-head">
+        <h2><span class="level-tag">{escape(level['name'])}</span></h2>
+        <p class="level-desc">{escape(level['description'])}</p>
+      </header>
+
+      <div class="stat-grid">
+        <div class="stat"><div class="stat-num">{fmt_int(grand)}</div>
+          <div class="stat-lbl">total episodes</div></div>
+        <div class="stat"><div class="stat-num">{fmt_int(level['train_total'])}</div>
+          <div class="stat-lbl">train</div></div>
+        <div class="stat"><div class="stat-num">{fmt_int(level['eval_total'])}</div>
+          <div class="stat-lbl">eval ({eval_frac:.1f}%)</div></div>
+        <div class="stat"><div class="stat-num">{n_scenes}</div>
+          <div class="stat-lbl">house{'s' if n_scenes != 1 else ''}</div></div>
+        <div class="stat"><div class="stat-num">{n_cats}</div>
+          <div class="stat-lbl">goal{'s' if n_cats != 1 else ''}</div></div>
+      </div>
+
+      <div class="dist-grid">
+        {render_goal_distribution(level)}
+        {render_scene_distribution(level)}
+      </div>
+      {render_pair_heatmap(level)}
+    </section>"""
+
+
+def render_summary_table(levels: list[dict]) -> str:
+    rows = []
+    for L in levels:
+        n_s = len(L["scenes"])
+        n_c = len(L["categories"])
+        total = L["train_total"] + L["eval_total"]
+        # how many train episodes per (house, goal) cell on average
+        per_cell = total / max(1, n_s * n_c)
+        rows.append(
+            f"<tr>"
+            f"<td><code>{escape(L['name'])}</code></td>"
+            f"<td class='r'>{n_s}</td>"
+            f"<td class='r'>{n_c}</td>"
+            f"<td class='r'>{fmt_int(L['train_total'])}</td>"
+            f"<td class='r'>{fmt_int(L['eval_total'])}</td>"
+            f"<td class='r'><strong>{fmt_int(total)}</strong></td>"
+            f"<td class='r'>{fmt_int(round(per_cell))}</td>"
+            f"</tr>"
+        )
+    return f"""
+    <table class="summary-table">
+      <thead><tr>
+        <th>level</th><th class='r'>houses</th><th class='r'>goals</th>
+        <th class='r'>train</th><th class='r'>eval</th>
+        <th class='r'>total</th><th class='r'>≈ episodes / (house × goal)</th>
+      </tr></thead>
+      <tbody>{''.join(rows)}</tbody>
+    </table>"""
+
+
+def render_html(levels: list[dict]) -> str:
+    today = date.today().isoformat()
+    sections = "\n".join(render_level(L) for L in levels)
+    summary = render_summary_table(levels)
+    legend = " ".join(
+        f"<span class='legend-pill' style='--c:{c}'><span class='dot'></span>"
+        f"<code>{escape(g)}</code></span>"
+        for g, c in GOAL_COLORS.items()
+    )
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Curriculum Overview — 4 levels, houses × goals × episodes</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap');
+  * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+
+  :root {{
+    --bg: #0f0f13;
+    --surface: #1a1a24;
+    --surface-2: #22222e;
+    --surface-3: #2d2d3d;
+    --accent: #6366f1;
+    --accent2: #818cf8;
+    --good: #34d399;
+    --warn: #fbbf24;
+    --bad: #f87171;
+    --text: #e2e8f0;
+    --text-dim: #94a3b8;
+    --text-dimmer: #64748b;
+    --border: #2d2d3d;
+  }}
+
+  body {{
+    font-family: 'Inter', -apple-system, sans-serif;
+    background: var(--bg); color: var(--text);
+    min-height: 100vh; padding: 48px 24px; line-height: 1.55;
+  }}
+  .container {{ max-width: 1100px; margin: 0 auto; }}
+
+  header.page {{ margin-bottom: 28px; }}
+  h1 {{ font-size: 1.85rem; font-weight: 700; margin-bottom: 6px; }}
+  .subtitle {{ color: var(--text-dim); font-size: 0.9rem; }}
+  .tag {{
+    display: inline-block; padding: 2px 8px; border-radius: 4px;
+    font-family: 'JetBrains Mono', monospace; font-size: 0.75rem;
+    background: var(--surface-3); color: var(--text-dim); margin-right: 6px;
+  }}
+  code, .mono {{ font-family: 'JetBrains Mono', monospace; font-size: 0.85em; }}
+  code {{
+    background: var(--surface-2); padding: 1px 5px; border-radius: 3px;
+    color: #c4b5fd;
+  }}
+
+  h2 {{
+    font-size: 1.15rem; font-weight: 600; margin: 0 0 4px;
+  }}
+  h3 {{
+    font-size: 0.95rem; font-weight: 600; margin: 22px 0 10px;
+    color: var(--accent2); text-transform: uppercase; letter-spacing: 1px;
+  }}
+  h4 {{
+    font-size: 0.85rem; font-weight: 600; margin: 0 0 10px;
+    color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.8px;
+  }}
+
+  .summary-card {{
+    background: var(--surface); border: 1px solid var(--border);
+    border-left: 3px solid var(--accent); border-radius: 6px;
+    padding: 18px 22px; margin-bottom: 20px;
+  }}
+  .summary-card p {{ color: var(--text-dim); }}
+
+  table {{ width: 100%; border-collapse: collapse; font-size: 0.85rem; }}
+  th, td {{ padding: 8px 12px; border-bottom: 1px solid var(--border); }}
+  th {{
+    text-align: left; color: var(--accent2); font-weight: 600;
+    background: var(--surface); border-bottom: 2px solid var(--border);
+  }}
+  td {{ color: var(--text-dim); }}
+  td.r, th.r {{ text-align: right; font-variant-numeric: tabular-nums; }}
+  tr:hover td {{ background: rgba(99,102,241,0.05); }}
+
+  .level-card {{
+    background: var(--surface); border: 1px solid var(--border);
+    border-radius: 10px; padding: 22px 26px; margin: 22px 0;
+  }}
+  .level-head {{ margin-bottom: 16px; }}
+  .level-tag {{
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.95rem; color: var(--accent2);
+  }}
+  .level-desc {{ color: var(--text-dim); font-size: 0.88rem; margin-top: 4px; }}
+
+  .stat-grid {{
+    display: grid; gap: 10px;
+    grid-template-columns: repeat(5, 1fr);
+    margin: 8px 0 22px;
+  }}
+  .stat {{
+    background: var(--surface-2); border: 1px solid var(--border);
+    border-radius: 6px; padding: 12px 14px;
+  }}
+  .stat-num {{
+    font-family: 'JetBrains Mono', monospace; font-weight: 600;
+    font-size: 1.15rem; color: var(--text);
+  }}
+  .stat-lbl {{
+    color: var(--text-dimmer); font-size: 0.7rem;
+    text-transform: uppercase; letter-spacing: 1px; margin-top: 2px;
+  }}
+
+  .dist-grid {{
+    display: grid; gap: 22px;
+    grid-template-columns: 1fr 1fr;
+    margin-top: 4px;
+  }}
+  .dist-block.dist-wide {{ grid-column: 1 / -1; margin-top: 18px; }}
+
+  .bars {{ display: flex; flex-direction: column; gap: 6px; }}
+  .bar-row {{
+    display: grid;
+    grid-template-columns: 78px 1fr 132px;
+    gap: 10px; align-items: center;
+    font-size: 0.78rem;
+  }}
+  .bar-label code {{ font-size: 0.75rem; }}
+  .bar-track {{
+    background: var(--surface-2); border-radius: 3px;
+    height: 14px; position: relative; overflow: hidden;
+    border: 1px solid var(--border);
+  }}
+  .bar-fill {{
+    height: 100%; display: inline-block;
+    transition: width 0.2s;
+  }}
+  .bar-eval {{ /* sits next to train */ }}
+  .bar-value {{
+    text-align: right; font-family: 'JetBrains Mono', monospace;
+    font-size: 0.72rem; color: var(--text-dim);
+    display: flex; flex-direction: column; line-height: 1.25;
+  }}
+  .v-total {{ color: var(--text); font-weight: 600; }}
+  .v-split {{ font-size: 0.66rem; color: var(--text-dimmer); }}
+
+  /* Heatmap */
+  .heatmap {{ table-layout: fixed; font-size: 0.78rem; }}
+  .heatmap th, .heatmap td {{ text-align: center; padding: 6px 4px; }}
+  .heatmap th {{ font-size: 0.72rem; }}
+  .heat-corner {{ background: transparent !important; color: var(--text-dimmer); }}
+  .heat-row-label {{
+    text-align: left !important; background: var(--surface) !important;
+    border-right: 1px solid var(--border);
+  }}
+  .heat-row-label code {{ font-size: 0.7rem; }}
+  .heat-cell {{
+    color: #0f0f13; font-weight: 600;
+    font-family: 'JetBrains Mono', monospace; font-size: 0.74rem;
+    border: 1px solid var(--border);
+  }}
+  .heat-cell span {{
+    mix-blend-mode: normal;
+    text-shadow: 0 1px 2px rgba(15,15,19,0.55);
+    color: #0f0f13;
+  }}
+  .heat-total {{
+    font-family: 'JetBrains Mono', monospace; font-weight: 600;
+    color: var(--text); background: var(--surface-2);
+  }}
+  .heat-grand {{ color: var(--accent2); }}
+  .heat-note {{ font-size: 0.72rem; color: var(--text-dimmer); margin-top: 8px; }}
+
+  .legend {{
+    display: flex; flex-wrap: wrap; gap: 8px; margin: 10px 0 22px;
+  }}
+  .legend-pill {{
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 3px 10px; background: var(--surface);
+    border: 1px solid var(--border); border-radius: 999px;
+    font-size: 0.75rem;
+  }}
+  .legend-pill .dot {{
+    width: 9px; height: 9px; border-radius: 50%; background: var(--c);
+  }}
+
+  footer.page {{
+    margin-top: 36px; padding-top: 16px;
+    border-top: 1px solid var(--border);
+    font-size: 0.78rem; color: var(--text-dimmer);
+  }}
+
+  @media (max-width: 720px) {{
+    .stat-grid {{ grid-template-columns: repeat(2, 1fr); }}
+    .dist-grid {{ grid-template-columns: 1fr; }}
+    .bar-row {{ grid-template-columns: 70px 1fr 110px; }}
+  }}
+</style>
+</head>
+<body>
+<div class="container">
+
+<header class="page">
+  <span class="tag">curriculum</span><span class="tag">overview</span>
+  <h1>Curriculum overview — houses × goals × episodes</h1>
+  <p class="subtitle">
+    Auto-generated from <code>data/curriculum/level{{1..4}}_*.json</code>.
+    Each episode is a Habitat ObjectNav trajectory keyed by
+    <code>(episode_id, goal_category, scene_id)</code>.
+  </p>
+</header>
+
+<div class="summary-card">
+  <h2>Summary</h2>
+  <p style="margin-top:6px;">
+    The curriculum is a 2&times;2 design varying <em>scene diversity</em>
+    (1 vs 10 houses) and <em>goal diversity</em> (1 vs 6 object categories).
+    All splits use <code>seed=42</code> with <code>train_ratio=0.9</code>,
+    so the same trajectory always falls on the same side of the split
+    across ablations.
+  </p>
+</div>
+
+{summary}
+
+<h3>Goal-category colour legend</h3>
+<div class="legend">{legend}</div>
+
+{sections}
+
+<footer class="page">
+  Generated {today} by
+  <code>scripts/analysis/curriculum_overview.py</code>.
+  Bar tracks: solid = train, faded = eval (the two are concatenated, not stacked).
+</footer>
+
+</div>
+</body>
+</html>"""
+
+
+def main() -> None:
+    levels = [load_level(CURRICULUM_DIR / fn) for fn in LEVEL_FILES]
+    html = render_html(levels)
+    OUTPUT.write_text(html)
+    print(f"wrote {OUTPUT.relative_to(REPO)}  ({OUTPUT.stat().st_size / 1024:.1f} KB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/r2dreamer/build_offline_comparison.py
+++ b/scripts/r2dreamer/build_offline_comparison.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python
+"""Build the 3D-46 JAX-vs-external(PyTorch) WP/CP comparison table.
+
+Aggregates held-out world-model metrics (mean ± std over the 3 seeds) for the
+JAX R2Dreamer (3D-26) and the external PyTorch R2Dreamer (3D-46) into a single
+markdown table + a per-seed CSV.
+
+Sources per framework (each a per-seed `heldout_table_row.json`):
+  * external: produced by `train_external_offline.py` (this PR), e.g.
+      output/3d46-external-offline/wp_cp-seed*/run-*/heldout_table_row.json
+  * JAX: produced by `train_offline_ablation.py` (3D-26), e.g.
+      output/3d26-offline-ablation/wp_cp-seed*/run-*/heldout_table_row.json
+    If those dirs are not on disk, pull the JAX numbers from W&B with
+    `--jax-wandb` (reads each run's `final/heldout/*` summary by tag).
+
+Comparable columns (decoder-free on both sides → reconstruction NLL is N/A and
+is NOT a head-to-head row):
+    dynamics_kl, representation_kl, reward_mse,
+    k_step_rollout_k1, k_step_rollout_k5, k_step_rollout_k15
+
+Usage:
+    python scripts/r2dreamer/build_offline_comparison.py \\
+        --external-glob 'output/3d46-external-offline/wp_cp-seed*/run-*/heldout_table_row.json' \\
+        --jax-glob      'output/3d26-offline-ablation/wp_cp-seed*/run-*/heldout_table_row.json' \\
+        --out-md   docs/notes/offline-ablation-comparison.md \\
+        --out-csv  docs/notes/offline-ablation-comparison.csv
+
+    # JAX numbers from W&B instead of disk:
+    python scripts/r2dreamer/build_offline_comparison.py \\
+        --external-glob '...heldout_table_row.json' --jax-wandb \\
+        --wandb-entity sailer-luca-university-ulm \\
+        --wandb-project 3d-vla-objectnav-offline-ablation
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import glob
+import json
+import re
+import statistics
+from pathlib import Path
+
+# Head-to-head columns (recon NLL excluded — decoder-free on both sides).
+COMPARABLE = [
+    "dynamics_kl",
+    "representation_kl",
+    "reward_mse",
+    "k_step_rollout_k1",
+    "k_step_rollout_k5",
+    "k_step_rollout_k15",
+]
+
+PRETTY = {
+    "dynamics_kl": "Dynamics KL",
+    "representation_kl": "Representation KL",
+    "reward_mse": "Reward MSE",
+    "k_step_rollout_k1": "k-step rollout MSE (k=1)",
+    "k_step_rollout_k5": "k-step rollout MSE (k=5)",
+    "k_step_rollout_k15": "k-step rollout MSE (k=15)",
+}
+
+# W&B summary keys -> table columns (the JAX trainer logs `final/heldout/*`).
+WANDB_KEYMAP = {
+    "dynamics_kl": "final/heldout/loss/dyn",
+    "representation_kl": "final/heldout/loss/rep",
+    "reward_mse": "final/heldout/reward_mse",
+    "k_step_rollout_k1": "final/heldout/k_step_rollout_mse/k1",
+    "k_step_rollout_k5": "final/heldout/k_step_rollout_mse/k5",
+    "k_step_rollout_k15": "final/heldout/k_step_rollout_mse/k15",
+}
+
+_SEED_RE = re.compile(r"seed[-_]?(\d+)")
+
+
+def _seed_from_path(path: str) -> str:
+    m = _SEED_RE.search(path)
+    return m.group(1) if m else path
+
+
+def load_rows_from_glob(pattern: str) -> dict[str, dict]:
+    """Map seed -> table-row dict from heldout_table_row.json files."""
+    rows: dict[str, dict] = {}
+    for p in sorted(glob.glob(pattern)):
+        seed = _seed_from_path(p)
+        rows[seed] = json.loads(Path(p).read_text())
+    return rows
+
+
+def load_jax_from_wandb(entity: str, project: str, tags: list[str]) -> dict[str, dict]:
+    """Pull JAX per-seed rows from W&B run summaries (`final/heldout/*`)."""
+    import wandb
+
+    api = wandb.Api()
+    filt = {"tags": {"$all": tags}} if tags else {}
+    rows: dict[str, dict] = {}
+    for run in api.runs(f"{entity}/{project}", filters=filt):
+        summary = run.summary
+        row = {col: _to_float(summary.get(key)) for col, key in WANDB_KEYMAP.items()}
+        if all(v is None for v in row.values()):
+            continue  # not a finished offline run
+        seed = _seed_from_path(run.name or run.id)
+        rows[seed] = row
+    return rows
+
+
+def _to_float(v):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def aggregate(rows_by_seed: dict[str, dict]) -> dict[str, dict]:
+    """seed->row  ->  metric -> {mean, std, n, per_seed:{seed:val}}."""
+    out: dict[str, dict] = {}
+    for col in COMPARABLE:
+        per_seed = {
+            seed: float(row[col])
+            for seed, row in rows_by_seed.items()
+            if col in row and row[col] is not None and _is_finite(row[col])
+        }
+        vals = list(per_seed.values())
+        out[col] = {
+            "mean": statistics.mean(vals) if vals else float("nan"),
+            "std": statistics.stdev(vals) if len(vals) >= 2 else 0.0,
+            "n": len(vals),
+            "per_seed": per_seed,
+        }
+    return out
+
+
+def _is_finite(x) -> bool:
+    try:
+        x = float(x)
+        return x == x and x not in (float("inf"), float("-inf"))
+    except (TypeError, ValueError):
+        return False
+
+
+def render_markdown(jax_agg: dict, ext_agg: dict, *, meta: dict) -> str:
+    lines = [
+        "# Offline ablation — JAX vs external (PyTorch) R2Dreamer (WP/CP)",
+        "",
+        "Held-out world-model metrics on the last 10% of episodes "
+        "(mean ± std over seeds {0,1,2}). Lower is better for every column.",
+        "",
+        "Both frameworks run the decoder-free R2-Dreamer objective "
+        "(`rep_loss=\"r2dreamer\"`), so **reconstruction NLL is N/A on both** "
+        "and is omitted from the head-to-head.",
+        "",
+        "| Metric | JAX (3D-26) | external PyTorch (3D-46) |",
+        "| -- | -- | -- |",
+    ]
+    for col in COMPARABLE:
+        j, e = jax_agg.get(col, {}), ext_agg.get(col, {})
+        lines.append(f"| {PRETTY[col]} | {_cell(j)} | {_cell(e)} |")
+    lines += [
+        "",
+        f"- JAX seeds found: {meta.get('jax_seeds', [])}",
+        f"- external seeds found: {meta.get('ext_seeds', [])}",
+        f"- JAX source: {meta.get('jax_source', '?')}",
+    ]
+    if meta.get("wandb_runs"):
+        lines.append(f"- W&B runs: {', '.join(meta['wandb_runs'])}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _cell(agg: dict) -> str:
+    if not agg or agg.get("n", 0) == 0:
+        return "_pending_"
+    return f"{agg['mean']:.4f} ± {agg['std']:.4f} (n={agg['n']})"
+
+
+def write_csv(path: Path, jax_rows: dict, ext_rows: dict) -> None:
+    with path.open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["framework", "seed", "metric", "value"])
+        for fw, rows in (("jax", jax_rows), ("pytorch_external", ext_rows)):
+            for seed, row in sorted(rows.items()):
+                for col in COMPARABLE:
+                    if col in row and row[col] is not None:
+                        w.writerow([fw, seed, col, row[col]])
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument(
+        "--external-glob", required=True,
+        help="Glob to external heldout_table_row.json files (one per seed).",
+    )
+    p.add_argument("--jax-glob", help="Glob to JAX heldout_table_row.json files.")
+    p.add_argument("--jax-wandb", action="store_true", help="Fetch JAX rows from W&B.")
+    p.add_argument("--wandb-entity", default="sailer-luca-university-ulm")
+    p.add_argument("--wandb-project", default="3d-vla-objectnav-offline-ablation")
+    p.add_argument("--wandb-tags", default="3d-26,wp_cp")
+    p.add_argument("--out-md", default="docs/notes/offline-ablation-comparison.md")
+    p.add_argument("--out-csv", default="docs/notes/offline-ablation-comparison.csv")
+    return p
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _build_parser().parse_args(argv)
+
+    ext_rows = load_rows_from_glob(args.external_glob)
+
+    jax_rows: dict[str, dict] = {}
+    jax_source = "none"
+    if args.jax_glob:
+        jax_rows = load_rows_from_glob(args.jax_glob)
+        jax_source = f"glob:{args.jax_glob}"
+    if not jax_rows and args.jax_wandb:
+        tags = [t.strip() for t in args.wandb_tags.split(",") if t.strip()]
+        jax_rows = load_jax_from_wandb(args.wandb_entity, args.wandb_project, tags)
+        jax_source = f"wandb:{args.wandb_entity}/{args.wandb_project} tags={tags}"
+
+    jax_agg, ext_agg = aggregate(jax_rows), aggregate(ext_rows)
+    meta = {
+        "jax_seeds": sorted(jax_rows),
+        "ext_seeds": sorted(ext_rows),
+        "jax_source": jax_source,
+    }
+    md = render_markdown(jax_agg, ext_agg, meta=meta)
+
+    out_md = Path(args.out_md)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    out_md.write_text(md)
+    write_csv(Path(args.out_csv), jax_rows, ext_rows)
+
+    print(md)
+    print(f"\nWrote {out_md} and {args.out_csv}")
+    if not ext_rows:
+        print("WARNING: no external rows found — runs not finished yet?")
+    if not jax_rows:
+        print("WARNING: no JAX rows found — pass --jax-glob or --jax-wandb once available.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/r2dreamer/collect_offline_buffer.py
+++ b/scripts/r2dreamer/collect_offline_buffer.py
@@ -1,10 +1,14 @@
 """Collect the canonical offline replay buffer for the VGGT readout ablation.
 
 The collector rolls out a CNN-policy checkpoint, stores the canonical
-trajectory skeleton, and computes both VGGT readouts from one VGGT extractor
-call per transition. RGB frames are not persisted — PNG encoding dominated the
-hot path (~36 % of per-step time) and the downstream ablation only needs the
-fp16 readouts.
+trajectory skeleton, and computes all three VGGT readouts from one VGGT
+extractor call per transition: WP/CP (4116-d), aggregator global stream
+(3072-d), and aggregator frame ⊕ global (6144-d, 3D-47). RGB frames are not
+persisted — PNG encoding dominated the hot path (~36 % of per-step time) and
+the downstream ablation only needs the fp16 readouts. Because the rollout is
+deterministic in (collect_seed, checkpoint), re-running with the same args
+regenerates a byte-identical skeleton, so a readout added later is recovered by
+a deterministic re-run rather than replaying a (non-existent) RGB cache.
 
     python scripts/r2dreamer/collect_offline_buffer.py \
         --checkpoint output/.../step_001000000.pkl \
@@ -38,7 +42,8 @@ if str(REPO_ROOT) not in sys.path:
 RGB_SIZE = 518
 CNN_SIZE = 64
 WP_CP_DIM = 4116
-AGGREGATOR_DIM = 3072
+AGGREGATOR_DIM = 3072  # global stream only: [cam | mean | max] x 1024
+AGGREGATOR_BOTH_DIM = 6144  # frame ⊕ global: [cam | mean | max] x 2048 (3D-47)
 INTEGRITY_SAMPLE_SIZE = 1000
 
 
@@ -136,26 +141,34 @@ class IntegrityAccumulator:
     sample_indices: set[int]
     wp_cosines: list[float]
     agg_cosines: list[float]
+    agg_both_cosines: list[float]
 
     @classmethod
     def for_steps(cls, n_steps: int, seed: int) -> "IntegrityAccumulator":
         sample_n = min(INTEGRITY_SAMPLE_SIZE, n_steps)
         rng = np.random.default_rng(seed)
         indices = set(int(i) for i in rng.choice(n_steps, size=sample_n, replace=False))
-        return cls(sample_indices=indices, wp_cosines=[], agg_cosines=[])
+        return cls(
+            sample_indices=indices, wp_cosines=[], agg_cosines=[], agg_both_cosines=[],
+        )
 
     def maybe_record(
         self,
         step: int,
         wp_fp32: np.ndarray,
         agg_fp32: np.ndarray,
+        agg_both_fp32: np.ndarray,
         wp_fp16: np.ndarray,
         agg_fp16: np.ndarray,
+        agg_both_fp16: np.ndarray,
     ) -> None:
         if step not in self.sample_indices:
             return
         self.wp_cosines.append(cosine_similarity(wp_fp32, wp_fp16.astype(np.float32)))
         self.agg_cosines.append(cosine_similarity(agg_fp32, agg_fp16.astype(np.float32)))
+        self.agg_both_cosines.append(
+            cosine_similarity(agg_both_fp32, agg_both_fp16.astype(np.float32))
+        )
 
     def summary(self) -> dict[str, Any]:
         def stats(values: list[float]) -> dict[str, float | int | None]:
@@ -172,6 +185,7 @@ class IntegrityAccumulator:
             "sample_size": len(self.sample_indices),
             "wp_cp_fp32_vs_fp16_cosine": stats(self.wp_cosines),
             "aggregator_fp32_vs_fp16_cosine": stats(self.agg_cosines),
+            "aggregator_both_fp32_vs_fp16_cosine": stats(self.agg_both_cosines),
         }
 
 
@@ -242,6 +256,7 @@ def verify_offline_buffer(
     skeleton_path = out_dir / "trajectory_skeleton.npz"
     wp_path = out_dir / "z_wp_cp.npz"
     agg_path = out_dir / "z_aggregator.npz"
+    agg_both_path = out_dir / "z_aggregator_both.npz"
     metadata_path = out_dir / "collection_metadata.json"
     rollout_log_path = out_dir / "rollout_log.jsonl"
 
@@ -301,8 +316,32 @@ def verify_offline_buffer(
     if agg.dtype != np.float16:
         raise AssertionError(f"z_aggregator dtype is {agg.dtype}, expected float16")
 
+    # z_aggregator_both is the 3D-47 frame ⊕ global readout. It's optional so
+    # that --verify-only still passes on legacy buffers collected before it
+    # existed; when present it is checked exactly like the other readouts.
+    agg_both = _load_npz_array(agg_both_path) if agg_both_path.exists() else None
+    if agg_both is not None:
+        if status == "completed":
+            if agg_both.shape != (n, AGGREGATOR_BOTH_DIM):
+                raise AssertionError(
+                    f"z_aggregator_both shape is {agg_both.shape}, "
+                    f"expected {(n, AGGREGATOR_BOTH_DIM)}"
+                )
+        elif agg_both.shape[0] < n or agg_both.shape[1] != AGGREGATOR_BOTH_DIM:
+            raise AssertionError(
+                f"z_aggregator_both shape is {agg_both.shape}, "
+                f"expected ({n}+, {AGGREGATOR_BOTH_DIM})"
+            )
+        if agg_both.dtype != np.float16:
+            raise AssertionError(
+                f"z_aggregator_both dtype is {agg_both.dtype}, expected float16"
+            )
+
     integrity = metadata.get("integrity", {})
-    for key in ("wp_cp_fp32_vs_fp16_cosine", "aggregator_fp32_vs_fp16_cosine"):
+    integrity_keys = ["wp_cp_fp32_vs_fp16_cosine", "aggregator_fp32_vs_fp16_cosine"]
+    if agg_both is not None:
+        integrity_keys.append("aggregator_both_fp32_vs_fp16_cosine")
+    for key in integrity_keys:
         min_value = integrity.get(key, {}).get("min")
         if min_value is None:
             raise AssertionError(f"missing integrity cosine stats for {key}")
@@ -333,11 +372,16 @@ def verify_offline_buffer(
         "n_steps": n,
         "z_wp_cp_shape": list(wp.shape),
         "z_aggregator_shape": list(agg.shape),
+        "z_aggregator_both_shape": list(agg_both.shape) if agg_both is not None else None,
         "total_size_bytes": total_size,
         "total_size_gib": total_size / (1024 ** 3),
         "episodes": len(log_entries),
         "cosine_min_wp_cp": integrity["wp_cp_fp32_vs_fp16_cosine"]["min"],
         "cosine_min_aggregator": integrity["aggregator_fp32_vs_fp16_cosine"]["min"],
+        "cosine_min_aggregator_both": (
+            integrity["aggregator_both_fp32_vs_fp16_cosine"]["min"]
+            if agg_both is not None else None
+        ),
     }
 
 
@@ -354,6 +398,7 @@ def collect_offline_buffer(args: argparse.Namespace) -> dict[str, Any]:
     from src.r2dreamer.adapters.vggt_adapter import (
         flatten_world_points_camera_pose,
         pool_aggregator_tokens,
+        pool_aggregator_tokens_both,
     )
     from src.r2dreamer.agent import R2DreamerAgent
     from src.shared.profiling import StepTimer
@@ -450,6 +495,12 @@ def collect_offline_buffer(args: argparse.Namespace) -> dict[str, Any]:
         shape=(args.n_steps, AGGREGATOR_DIM),
         dtype=np.float16,
     )
+    agg_both_writer = StreamingNpzArray(
+        out_dir / "z_aggregator_both.npz",
+        array_name="features",
+        shape=(args.n_steps, AGGREGATOR_BOTH_DIM),
+        dtype=np.float16,
+    )
 
     timer = StepTimer(warmup=args.profile_warmup) if args.profile else None
 
@@ -488,15 +539,24 @@ def collect_offline_buffer(args: argparse.Namespace) -> dict[str, Any]:
                     pool_aggregator_tokens(vggt_out, extractor.aggregator_feature_shape),
                     dtype=np.float32,
                 )
+                agg_both_fp32 = np.asarray(
+                    pool_aggregator_tokens_both(vggt_out, extractor.aggregator_feature_shape),
+                    dtype=np.float32,
+                )
                 if timer is not None:
                     timer.lap("vggt_extract")
                 wp_fp16 = wp_fp32.astype(np.float16)
                 agg_fp16 = agg_fp32.astype(np.float16)
-                integrity.maybe_record(step, wp_fp32, agg_fp32, wp_fp16, agg_fp16)
+                agg_both_fp16 = agg_both_fp32.astype(np.float16)
+                integrity.maybe_record(
+                    step, wp_fp32, agg_fp32, agg_both_fp32,
+                    wp_fp16, agg_fp16, agg_both_fp16,
+                )
                 if timer is not None:
                     timer.lap("fp16_cast")
                 wp_writer.append(wp_fp16)
                 agg_writer.append(agg_fp16)
+                agg_both_writer.append(agg_both_fp16)
                 if timer is not None:
                     timer.lap("npz_append")
 
@@ -604,9 +664,11 @@ def collect_offline_buffer(args: argparse.Namespace) -> dict[str, Any]:
         if completed_writes:
             wp_writer.close()
             agg_writer.close()
+            agg_both_writer.close()
         else:
             wp_writer.abort()
             agg_writer.abort()
+            agg_both_writer.abort()
             # Always leave usable on-disk state for partial collections,
             # truncated to the last completed-episode boundary.
             if last_completed_step > 0:

--- a/scripts/r2dreamer/record_cnn_2M_512_video.sh
+++ b/scripts/r2dreamer/record_cnn_2M_512_video.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Record HM3D ObjectNav videos for the L1 2M-step CNN checkpoint.
+#
+# Renders the env at 512x512 for high-fidelity FPV + top-down panels and
+# downsamples to 64x64 before the CNN policy (which was trained at 64x64).
+# Writes MP4s to output/cnn-2M-512-video/.
+#
+# Run from the repo root, inside an interactive H100 srun session
+# (see AGENTS.md "Verification" for the 30-min dev-GPU policy).
+
+set -euo pipefail
+
+CKPT="${CKPT:-output/r2dreamer-curriculum-l1/run-4367942/checkpoints/step_002000000.pkl}"
+EPISODES="${EPISODES:-3}"
+OUT_DIR="${OUT_DIR:-output/cnn-2M-512-video}"
+CURRICULUM="${CURRICULUM:-L1}"
+SPLIT="${SPLIT:-val}"
+VIDEO_RES="${VIDEO_RES:-512}"
+FPS="${FPS:-10}"
+
+if [ ! -f "${CKPT}" ]; then
+    echo "Checkpoint not found: ${CKPT}" >&2
+    exit 1
+fi
+
+mkdir -p "${OUT_DIR}"
+
+cat <<EOF
+Recording CNN ObjectNav video
+  checkpoint:        ${CKPT}
+  curriculum:        ${CURRICULUM}
+  split:             ${SPLIT}
+  episodes:          ${EPISODES}
+  video resolution:  ${VIDEO_RES}x${VIDEO_RES} (policy sees 64x64)
+  output dir:        ${OUT_DIR}
+EOF
+
+.venv/bin/python -m src.main evaluate \
+    --env habitat \
+    --encoder cnn \
+    --curriculum "${CURRICULUM}" \
+    --checkpoint "${CKPT}" \
+    --episodes "${EPISODES}" \
+    --split "${SPLIT}" \
+    --output_dir "${OUT_DIR}" \
+    --render_resolution 64 \
+    --video_render_resolution "${VIDEO_RES}" \
+    --save_video_path "${OUT_DIR}" \
+    --log_video_episodes "${EPISODES}" \
+    --video_fps "${FPS}"
+
+echo "Done. MP4s in ${OUT_DIR}/"
+ls -la "${OUT_DIR}"/*.mp4 2>/dev/null || true

--- a/scripts/r2dreamer/slurm/collect_offline_buffer_3d47.sbatch
+++ b/scripts/r2dreamer/slurm/collect_offline_buffer_3d47.sbatch
@@ -1,0 +1,87 @@
+#!/bin/bash
+#SBATCH --job-name=3d47-offline-buffer
+#SBATCH --partition=gpu_h100_il
+#SBATCH --gres=gpu:1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=96G
+#SBATCH --time=12:00:00
+#SBATCH --output=output/offline-buffer-3d47/slurm-%j.out
+#SBATCH --error=output/offline-buffer-3d47/slurm-%j.err
+
+# 3D-47 offline buffer collection. Identical deterministic rollout to the 3D-25
+# buffer (same CNN checkpoint + collect-seed 42) but collected with the 3D-47
+# code, so the collector emits all THREE readouts in one pass:
+#   z_wp_cp.npz (4116) | z_aggregator.npz (3072) | z_aggregator_both.npz (6144)
+# Writes to its own OUT_DIR so the existing data/offline_buffer (used by the
+# 3D-26 runs) is never touched.
+#
+# Args (via env vars / argv):
+#   CNN_CHECKPOINT  source policy ckpt  (default: 3D-25 CNN baseline @ 1M; argv[1] also accepted)
+#   OUT_DIR         buffer output dir   (default data/offline_buffer_3d47)
+#   N_STEPS         transitions         (default 400000 — matches the 3D-25 buffer)
+
+set -euo pipefail
+
+mkdir -p output/offline-buffer-3d47
+
+git_common_dir="$(git rev-parse --git-common-dir)"
+main_root="$(realpath "${git_common_dir}/..")"
+
+DEFAULT_CNN_CHECKPOINT="output/r2dreamer-curriculum-l1/run-4367942/checkpoints/step_001000000.pkl"
+CNN_CHECKPOINT="${CNN_CHECKPOINT:-${1:-${DEFAULT_CNN_CHECKPOINT}}}"
+if [ ! -f "${CNN_CHECKPOINT}" ] && [ -f "${main_root}/${CNN_CHECKPOINT}" ]; then
+    CNN_CHECKPOINT="${main_root}/${CNN_CHECKPOINT}"
+fi
+if [ ! -f "${CNN_CHECKPOINT}" ]; then
+    echo "Checkpoint not found in worktree or main checkout: ${CNN_CHECKPOINT}" >&2
+    echo "Set CNN_CHECKPOINT, pass it as argv[1], or place it at the default path." >&2
+    exit 2
+fi
+
+OUT_DIR="${OUT_DIR:-data/offline_buffer_3d47}"
+N_STEPS="${N_STEPS:-400000}"
+
+echo "Job ${SLURM_JOB_ID} on $(hostname) at $(date)"
+echo "GPU: $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || echo N/A)"
+echo "Checkpoint: ${CNN_CHECKPOINT}"
+echo "Out dir:    ${OUT_DIR}"
+echo "N steps:    ${N_STEPS}"
+echo "Commit: $(git rev-parse HEAD)"
+echo "Dirty files: $(git status --porcelain | wc -l)"
+
+./scripts/setup_worktree.sh
+
+# The JAX VGGT loader resolves StreamVGGT relative to this worktree. These
+# heavy external repos are gitignored in the main checkout, so make local links
+# when the job is launched from a fresh worktree.
+mkdir -p external
+for name in InfiniteVGGT StreamVGGT VGGT; do
+    target="${main_root}/external/${name}"
+    link="external/${name}"
+    if [ ! -e "${link}" ] && [ -e "${target}" ]; then
+        ln -s "$(realpath --relative-to external "${target}")" "${link}"
+    fi
+done
+
+.venv/bin/python scripts/r2dreamer/collect_offline_buffer.py \
+    --checkpoint "${CNN_CHECKPOINT}" \
+    --n-steps "${N_STEPS}" \
+    --collect-seed 42 \
+    --out-dir "${OUT_DIR}" \
+    --curriculum-path data/curriculum/level1_1house_1goal.json \
+    --curriculum-mode train \
+    --wandb-project 3d-vla-objectnav \
+    --wandb-name "3d47-offline-buffer-${SLURM_JOB_ID}" \
+    --wandb-tags "offline-buffer,3d-47,cnn-source,vggt-readouts,aggregator-both" \
+    --wandb-init-timeout 600 \
+    --log-every 1000 \
+    --wandb-log-every 1000 \
+    --skeleton-flush-every 10000
+
+echo "Done at $(date)"
+
+
+##RUN Command:
+# ./scripts/r2dreamer/slurm/submit_3d47.sh smoke   # 25 min on gpu_h100_short
+# ./scripts/r2dreamer/slurm/submit_3d47.sh prod    # 12h on gpu_h100_il, then trains

--- a/scripts/r2dreamer/slurm/submit_3d47.sh
+++ b/scripts/r2dreamer/slurm/submit_3d47.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Submit the 3D-47 ablation: aggregator global-only (3072-d) vs frame+global
+# (6144-d) as R2Dreamer input. Collects a dedicated buffer that contains
+# z_aggregator_both.npz (the 3D-25/26 buffer predates it), then trains the
+# variants off it. Mirrors the 3D-26 submit wrappers' style.
+#
+# Usage:
+#   ./submit_3d47.sh smoke [--dry-run]
+#   ./submit_3d47.sh prod  [--dry-run]
+#
+#   smoke -> gpu_h100_short, 25min: tiny real collection (1500 steps) then a
+#            200-step aggregator_both train, both chained afterok. Validates the
+#            full collect->verify->train path with real VGGT before prod.
+#   prod  -> gpu_h100_il: 400k-step collection (~12h) then ENCODERS x SEEDS
+#            training (~8h each), all chained afterok the collection.
+#
+# Env knobs (prod):
+#   ENCODERS    space-separated (default "aggregator aggregator_both")
+#   SEEDS       space-separated (default "0 1 2")
+#   SKIP_COLLECT=1  reuse an existing BUFFER_DIR instead of collecting
+#   BUFFER_DIR  prod buffer dir (default data/offline_buffer_3d47)
+#   WAIT_FOR    external jobid the collection should wait on (afterok)
+#
+# Every submit is pre-flighted with `sbatch --test-only` first.
+set -euo pipefail
+
+usage() {
+    echo "usage: $0 {smoke|prod} [--dry-run]" >&2
+    exit 2
+}
+
+mode="${1:-}"
+shift || usage
+dry_run=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run) dry_run=1 ;;
+        *) usage ;;
+    esac
+    shift
+done
+case "${mode}" in smoke|prod) ;; *) usage ;; esac
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../../.." && pwd)"
+cd "${repo_root}"
+collect_sbatch="${script_dir}/collect_offline_buffer_3d47.sbatch"
+train_sbatch="${script_dir}/train_offline_ablation_3d47.sbatch"
+
+# submit_job <sbatch_file> <dependency_jid_or_empty> -- prints jobid on stdout,
+# diagnostics on stderr. Relies on the caller having exported the env vars the
+# sbatch reads; uses --export=ALL like the other 3D wrappers.
+submit_job() {
+    local sbatch_file="$1"; local dep="$2"; shift 2
+    local args=(--partition="${PARTITION}" --time="${TIME_LIMIT}"
+                --job-name="${JOB_NAME}" --export=ALL)
+    if [ -n "${dep}" ]; then
+        args+=(--dependency="afterok:${dep}" --kill-on-invalid-dep=yes)
+    fi
+    args+=("${sbatch_file}")
+    sbatch --test-only "${args[@]}" >&2
+    if [ "${dry_run}" -eq 1 ]; then
+        echo "    [dry-run] would submit ${JOB_NAME} (${PARTITION}, ${TIME_LIMIT}, dep='${dep}')" >&2
+        echo "DRYRUN"
+        return 0
+    fi
+    sbatch --parsable "${args[@]}"
+}
+
+if [ "${mode}" = "smoke" ]; then
+    export PARTITION=gpu_h100_short
+    export TIME_LIMIT=00:25:00
+    smoke_buf="data/offline_buffer_3d47_smoke"
+
+    # 1) tiny real collection
+    export OUT_DIR="${smoke_buf}" N_STEPS="${N_STEPS:-1500}" JOB_NAME=3d47-smoke-collect
+    collect_jid="$(submit_job "${collect_sbatch}" "")"
+    echo "[smoke collect] jid=${collect_jid}"
+
+    # 2) aggregator_both train, chained afterok the collection
+    export ENCODER=aggregator_both SEED=0 STEPS=200 BUFFER_DIR="${smoke_buf}"
+    export EXTRA_ARGS="--skip-heldout-eval --checkpoint-every 100 --log-every 10"
+    export JOB_NAME=3d47-smoke-train-aggregator_both
+    dep="${collect_jid}"; [ "${dep}" = "DRYRUN" ] && dep=""
+    train_jid="$(submit_job "${train_sbatch}" "${dep}")"
+    echo "[smoke train ] jid=${train_jid} (afterok:${collect_jid})"
+    echo "watch: squeue -j ${collect_jid},${train_jid}"
+    exit 0
+fi
+
+# ---- prod ----
+export PARTITION=gpu_h100_il
+buffer_dir="${BUFFER_DIR:-data/offline_buffer_3d47}"
+encoders="${ENCODERS:-aggregator aggregator_both}"
+seeds="${SEEDS:-0 1 2}"
+
+collect_jid=""
+if [ "${SKIP_COLLECT:-0}" = "1" ]; then
+    echo "[prod] SKIP_COLLECT=1 — reusing existing buffer ${buffer_dir}"
+else
+    export TIME_LIMIT=12:00:00 OUT_DIR="${buffer_dir}" N_STEPS="${N_STEPS:-400000}"
+    export JOB_NAME=3d47-prod-collect
+    collect_jid="$(submit_job "${collect_sbatch}" "${WAIT_FOR:-}")"
+    echo "[prod collect] jid=${collect_jid}"
+fi
+
+export TIME_LIMIT=08:00:00 BUFFER_DIR="${buffer_dir}" STEPS="${STEPS:-500000}"
+export EXTRA_ARGS="${EXTRA_ARGS:-}"
+for enc in ${encoders}; do
+    for s in ${seeds}; do
+        export ENCODER="${enc}" SEED="${s}" JOB_NAME="3d47-prod-${enc}-s${s}"
+        dep="${collect_jid}"; [ "${dep}" = "DRYRUN" ] && dep=""
+        jid="$(submit_job "${train_sbatch}" "${dep}")"
+        echo "[prod train ] ${enc} seed${s} jid=${jid}${collect_jid:+ (afterok:${collect_jid})}"
+    done
+done

--- a/scripts/r2dreamer/slurm/submit_external_offline.sh
+++ b/scripts/r2dreamer/slurm/submit_external_offline.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Submit one 3D-46 external (PyTorch) R2Dreamer offline run.
+#
+# Usage:
+#   ./submit_external_offline.sh {dev|prod|smoke} <seed> [encoder] [--dry-run]
+#
+# dev/smoke -> gpu_h100_short (<=30 min), STEPS=200 — sanity / smoke.
+# prod      -> gpu_h100_il 8h, STEPS=500000 — the actual 3D-46 baseline runs.
+#
+# seed    in {0, 1, 2}; encoder defaults wp_cp (3D-46 is WP/CP only).
+#
+# Launch all three prod seeds:
+#   for s in 0 1 2; do ./submit_external_offline.sh prod "$s"; done
+
+set -euo pipefail
+
+usage() {
+    echo "usage: $0 {dev|prod|smoke} <seed> [encoder] [--dry-run]" >&2
+    echo "       seed in {0,1,2}; encoder in {wp_cp,aggregator} (default wp_cp)" >&2
+    exit 2
+}
+
+mode="${1:-}"
+seed="${2:-}"
+[ -z "${mode}" ] || [ -z "${seed}" ] && usage
+shift 2 || usage
+
+# Remaining args (any order): optional encoder + optional --dry-run.
+encoder="wp_cp"
+dry_run=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run)        dry_run=1 ;;
+        wp_cp|aggregator) encoder="$1" ;;
+        *)                usage ;;
+    esac
+    shift
+done
+
+case "${seed}"    in 0|1|2)            ;; *) usage ;; esac
+case "${encoder}" in wp_cp|aggregator) ;; *) usage ;; esac
+
+case "${mode}" in
+    dev|smoke)
+        # gpu_h100_short: fast queue, 30-min cap — best fit for smoke. Trim the
+        # held-out eval to a few batches so the short window is enough.
+        partition=gpu_h100_short
+        time_limit=00:25:00
+        export STEPS="${STEPS:-200}"
+        export EXTRA_ARGS="${EXTRA_ARGS:---checkpoint-every 100 --log-every 10 --heldout-eval-batches 4}"
+        # Namespace smoke runs (output + W&B name + tag) so they never collide
+        # with the prod runs the comparison globs over.
+        export RUN_TAG="${RUN_TAG:-smoke}"
+        job_name="3d46-${mode}-${encoder}-s${seed}"
+        ;;
+    prod)
+        partition=gpu_h100_il
+        # ~29 steps/s on H100 -> ~5h for 500k; budget 8h for the final held-out
+        # eval (non-compiled forward over up to 64 batches).
+        time_limit=08:00:00
+        export STEPS="${STEPS:-500000}"
+        export EXTRA_ARGS="${EXTRA_ARGS:-}"
+        job_name="3d46-prod-${encoder}-s${seed}"
+        ;;
+    *)
+        usage
+        ;;
+esac
+
+export ENCODER="${encoder}"
+export SEED="${seed}"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+sbatch_file="${script_dir}/train_external_offline.sbatch"
+
+echo "Mode=${mode}  Partition=${partition}  Time=${time_limit}"
+echo "Encoder=${encoder}  Seed=${seed}  Steps=${STEPS}"
+echo "Sbatch=${sbatch_file}"
+
+sbatch_args=(
+    --partition="${partition}"
+    --time="${time_limit}"
+    --job-name="${job_name}"
+    --export=ALL
+)
+# Optional: launch only after this job ID completes successfully.
+if [ -n "${WAIT_FOR:-}" ]; then
+    sbatch_args+=(--dependency="afterok:${WAIT_FOR}")
+fi
+sbatch_args+=("${sbatch_file}")
+
+# Pre-flight — catches partition / resource mistakes before queueing.
+sbatch --test-only "${sbatch_args[@]}"
+echo "Pre-flight OK."
+
+if [ "${dry_run}" -eq 1 ]; then
+    echo "--dry-run: not submitting."
+    exit 0
+fi
+
+submit_out="$(sbatch "${sbatch_args[@]}")"
+echo "${submit_out}"
+jobid="$(echo "${submit_out}" | awk '{print $NF}')"
+echo "Log: output/3d46-external-offline/slurm-${jobid}.out"

--- a/scripts/r2dreamer/slurm/train_external_offline.sbatch
+++ b/scripts/r2dreamer/slurm/train_external_offline.sbatch
@@ -1,0 +1,66 @@
+#!/bin/bash
+#SBATCH --job-name=3d46-external-offline
+#SBATCH --partition=gpu_h100_il
+#SBATCH --gres=gpu:1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=160G
+#SBATCH --time=08:00:00
+#SBATCH --output=output/3d46-external-offline/slurm-%j.out
+#SBATCH --error=output/3d46-external-offline/slurm-%j.err
+
+# 3D-46 external (PyTorch) R2Dreamer offline baseline — one of the 3 WP/CP runs.
+#
+# Trains the original PyTorch R2Dreamer (external/r2dreamer/) offline on the
+# WP/CP vector readout, then logs held-out WM metrics directly comparable to the
+# JAX 3D-26 numbers. Runs under the EXTERNAL venv (torchrl/tensordict/gymnasium).
+#
+# Args (via env vars):
+#   ENCODER       wp_cp | aggregator   (default wp_cp; 3D-46 is WP/CP only)
+#   SEED          0 | 1 | 2            (required)
+#   STEPS         total grad steps     (default 500_000)
+#   BUFFER_DIR    offline buffer path  (default data/offline_buffer)
+#   WANDB_PROJECT W&B project          (default 3d-vla-objectnav-offline-ablation)
+#   EXTRA_ARGS    extra CLI for train_external_offline.py (default empty)
+
+set -euo pipefail
+
+: "${SEED:?SEED must be set (0|1|2)}"
+ENCODER="${ENCODER:-wp_cp}"
+STEPS="${STEPS:-500000}"
+BUFFER_DIR="${BUFFER_DIR:-data/offline_buffer}"
+WANDB_PROJECT="${WANDB_PROJECT:-3d-vla-objectnav-offline-ablation}"
+EXTRA_ARGS="${EXTRA_ARGS:-}"
+
+# RUN_TAG lets smoke runs land in a separate namespace (output + W&B name) so
+# they never collide with the prod runs the comparison globs over.
+RUN_TAG="${RUN_TAG:-}"
+OUTPUT_DIR="output/3d46-external-offline${RUN_TAG:+/$RUN_TAG}/${ENCODER}-seed${SEED}/run-${SLURM_JOB_ID}"
+WANDB_NAME="ext-${ENCODER}-seed${SEED}${RUN_TAG:+-$RUN_TAG}"
+mkdir -p "${OUTPUT_DIR}"
+
+PY="external/r2dreamer/.venv/bin/python"
+
+echo "Job ${SLURM_JOB_ID} on $(hostname) at $(date)"
+echo "GPU: $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || echo N/A)"
+echo "Encoder: ${ENCODER}   Seed: ${SEED}   Steps: ${STEPS}"
+echo "Buffer:  ${BUFFER_DIR}"
+echo "Output:  ${OUTPUT_DIR}"
+echo "WANDB:   ${WANDB_PROJECT}"
+echo "Commit:  $(git rev-parse HEAD)   external: $(git -C external/r2dreamer rev-parse HEAD 2>/dev/null || echo N/A)"
+
+# shellcheck disable=SC2086
+"${PY}" scripts/r2dreamer/train_external_offline.py \
+    --encoder "${ENCODER}" \
+    --seed "${SEED}" \
+    --steps "${STEPS}" \
+    --buffer-dir "${BUFFER_DIR}" \
+    --output-dir "${OUTPUT_DIR}" \
+    --device cuda:0 \
+    --wandb \
+    --wandb-project "${WANDB_PROJECT}" \
+    --wandb-name "${WANDB_NAME}" \
+    --wandb-tags "offline-ablation,3d-24,framework:pytorch-external,seed${SEED}${RUN_TAG:+,$RUN_TAG}" \
+    ${EXTRA_ARGS}
+
+echo "Done at $(date)"

--- a/scripts/r2dreamer/slurm/train_offline_ablation_3d47.sbatch
+++ b/scripts/r2dreamer/slurm/train_offline_ablation_3d47.sbatch
@@ -1,0 +1,80 @@
+#!/bin/bash
+#SBATCH --job-name=3d47-offline-ablation
+#SBATCH --partition=gpu_h100_il
+#SBATCH --gres=gpu:1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=160G
+#SBATCH --time=08:00:00
+#SBATCH --output=output/3d47-offline-ablation/slurm-%j.out
+#SBATCH --error=output/3d47-offline-ablation/slurm-%j.err
+
+# 3D-47 offline R2Dreamer ablation — one of the runs (encoder x seed).
+# Compares the aggregator global-only readout (3072-d) against frame+global
+# (6144-d). Identical to the 3D-26 ablation harness; only the encoder + buffer
+# differ. Buffer must already contain z_<encoder>.npz (see collect_*_3d47).
+#
+# Args (via env vars):
+#   ENCODER       aggregator | aggregator_both | wp_cp   (required)
+#   SEED          0 | 1 | 2                              (required)
+#   STEPS         total grad steps                       (default 500_000)
+#   BUFFER_DIR    offline buffer path                    (default data/offline_buffer_3d47)
+#   WANDB_PROJECT W&B project        (default 3d-vla-objectnav-offline-ablation)
+#   EXTRA_ARGS    extra CLI for train_offline_ablation.py (default empty)
+
+set -euo pipefail
+
+: "${ENCODER:?ENCODER must be set (aggregator|aggregator_both|wp_cp)}"
+: "${SEED:?SEED must be set (0|1|2)}"
+STEPS="${STEPS:-500000}"
+BUFFER_DIR="${BUFFER_DIR:-data/offline_buffer_3d47}"
+WANDB_PROJECT="${WANDB_PROJECT:-3d-vla-objectnav-offline-ablation}"
+EXTRA_ARGS="${EXTRA_ARGS:-}"
+
+OUTPUT_DIR="output/3d47-offline-ablation/${ENCODER}-seed${SEED}/run-${SLURM_JOB_ID}"
+mkdir -p "${OUTPUT_DIR}"
+mkdir -p output/3d47-offline-ablation
+
+git_common_dir="$(git rev-parse --git-common-dir)"
+main_root="$(realpath "${git_common_dir}/..")"
+
+echo "Job ${SLURM_JOB_ID} on $(hostname) at $(date)"
+echo "GPU: $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || echo N/A)"
+echo "Encoder: ${ENCODER}"
+echo "Seed:    ${SEED}"
+echo "Steps:   ${STEPS}"
+echo "Buffer:  ${BUFFER_DIR}"
+echo "Output:  ${OUTPUT_DIR}"
+echo "WANDB project: ${WANDB_PROJECT}"
+echo "Commit:  $(git rev-parse HEAD)"
+echo "Dirty:   $(git status --porcelain | wc -l) files"
+
+./scripts/setup_worktree.sh
+
+# Mirror the VGGT external-repo links used by the collection job — even though
+# the offline trainer never calls the VGGT extractor, the encoders package
+# imports JAXVGGTFeatureExtractor at module load.
+mkdir -p external
+for name in InfiniteVGGT StreamVGGT VGGT; do
+    target="${main_root}/external/${name}"
+    link="external/${name}"
+    if [ ! -e "${link}" ] && [ -e "${target}" ]; then
+        ln -s "$(realpath --relative-to external "${target}")" "${link}"
+    fi
+done
+
+WANDB_NAME="3d47-${ENCODER}-seed${SEED}-${SLURM_JOB_ID}"
+
+# shellcheck disable=SC2086
+.venv/bin/python scripts/r2dreamer/train_offline_ablation.py \
+    --encoder "${ENCODER}" \
+    --seed "${SEED}" \
+    --steps "${STEPS}" \
+    --buffer-dir "${BUFFER_DIR}" \
+    --output-dir "${OUTPUT_DIR}" \
+    --wandb-project "${WANDB_PROJECT}" \
+    --wandb-name "${WANDB_NAME}" \
+    --wandb-tags "3d-47,offline-ablation,${ENCODER},seed${SEED}" \
+    ${EXTRA_ARGS}
+
+echo "Done at $(date)"

--- a/scripts/r2dreamer/train_external_offline.py
+++ b/scripts/r2dreamer/train_external_offline.py
@@ -99,6 +99,14 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--seq-len", type=int, default=SHARED["seq_len"])
     p.add_argument("--log-every", type=int, default=250)
     p.add_argument("--checkpoint-every", type=int, default=50_000)
+    p.add_argument(
+        "--skip-heldout-eval", action="store_true",
+        help="Skip the final held-out WM metrics (smoke testing).",
+    )
+    p.add_argument(
+        "--heldout-eval-batches", type=int, default=64,
+        help="Max non-overlapping held-out batches averaged for the metrics.",
+    )
     # compile defaults to the model config (True); forced off on CPU.
     p.add_argument("--compile", dest="compile", action="store_true", default=None)
     p.add_argument("--no-compile", dest="compile", action="store_false")
@@ -303,6 +311,53 @@ class OfflineVectorBuffer:
     def count(self):
         return self.size
 
+    def iter_eval_batches(self, max_batches: int | None = None):
+        """Deterministic non-overlapping windows for held-out eval.
+
+        Mirrors `OfflineBufferDataset.iter_heldout_batches`: stride = seq_len, so
+        windows never overlap; chunked into groups of `batch_size`. Yields the
+        same TensorDict schema as `sample()` (no `initial` — the eval caller
+        rebuilds a zeroed initial per batch). The last chunk may be smaller.
+        """
+        torch = self._torch
+        from tensordict import TensorDict
+
+        dev = self.device
+        starts_all = np.arange(0, self.size - self.L + 1, self.L)
+        n_total = len(starts_all)
+        if max_batches is not None:
+            n_total = min(n_total, max_batches * self.B)
+        for chunk in range(0, n_total, self.B):
+            starts = starts_all[chunk : chunk + self.B]
+            if len(starts) == 0:
+                break
+            win = starts[:, None] + np.arange(self.L)[None, :]
+            b = win.shape[0]
+            obs = torch.as_tensor(self.obs[win].astype(np.float32), device=dev)
+            act_idx = torch.as_tensor(self.actions[win].astype(np.int64), device=dev)
+            action = torch.nn.functional.one_hot(act_idx, NUM_ACTIONS).to(torch.float32)
+            reward = torch.as_tensor(
+                self.rewards[win].astype(np.float32), device=dev
+            ).unsqueeze(-1)
+            dones = self.dones[win]
+            is_first = np.zeros_like(dones)
+            is_first[:, 0] = True
+            is_first[:, 1:] = dones[:, :-1]
+            is_first_t = torch.as_tensor(is_first, device=dev).unsqueeze(-1)
+            done_t = torch.as_tensor(dones.astype(np.float32), device=dev).unsqueeze(-1)
+            yield TensorDict(
+                {
+                    "vector": obs,
+                    "action": action,
+                    "reward": reward,
+                    "is_first": is_first_t,
+                    "is_last": done_t,
+                    "is_terminal": done_t,
+                },
+                batch_size=(b, self.L),
+                device=dev,
+            )
+
 
 def _load_metadata(buffer_dir: Path) -> dict:
     """Read collection_metadata.json; tolerate a missing file (all-train)."""
@@ -341,6 +396,87 @@ def _load_features(path: Path) -> np.ndarray:
         return data[key]
     finally:
         data.close()
+
+
+# ---------------------------------------------------------------------------
+# Held-out world-model metrics (mirrors src/r2dreamer/heldout_eval.py)
+# ---------------------------------------------------------------------------
+def compute_heldout_metrics(agent, buffer, *, max_batches=64, k_values=(1, 5, 15)):
+    """Held-out WM metrics with the SAME definitions as the JAX 3D-26 eval.
+
+    Per batch (no grad, full fp32):
+      * dynamics_kl / representation_kl = `rssm.kl_loss(post, prior, kl_free)`
+        means — identical free-bits clipping to training `loss/dyn` `loss/rep`.
+      * reward_mse = MSE of the twohot reward head's expected value
+        (`reward(feat).mode()`, in real reward space) vs the GT reward.
+      * k_step_rollout_mse[k] = start from the posterior at t=0, run
+        `rssm.img_step` with GT actions for k steps, MSE on `get_feat` vs the
+        GT posterior feature at step k.
+      * reconstruction_nll = NaN — decoder-free `rep_loss="r2dreamer"`, same as
+        the JAX side.
+    """
+    import torch
+
+    max_k = max(k_values)
+    if buffer.L < max_k + 1:
+        raise ValueError(f"seq_len {buffer.L} too short for max k_rollout {max_k}")
+
+    rssm = agent.rssm
+    sums = {"loss/dyn": 0.0, "loss/rep": 0.0, "reward_mse": 0.0}
+    rollout_sums = {k: 0.0 for k in k_values}
+    n = 0
+
+    agent.eval()
+    with torch.no_grad():
+        for data in buffer.iter_eval_batches(max_batches=max_batches):
+            b = int(data.batch_size[0])
+            initial = rssm.initial(b)
+            embed = agent.encoder(data)
+            post_stoch, post_deter, post_logit = rssm.observe(
+                embed, data["action"], initial, data["is_first"]
+            )
+            _, prior_logit = rssm.prior(post_deter)
+            dyn, rep = rssm.kl_loss(post_logit, prior_logit, agent.kl_free)
+            sums["loss/dyn"] += float(dyn.mean())
+            sums["loss/rep"] += float(rep.mean())
+
+            feat = rssm.get_feat(post_stoch, post_deter)
+            pred = agent.reward(feat).mode()  # (B, T, 1), expected reward
+            err = pred - data["reward"].to(pred.dtype)
+            sums["reward_mse"] += float(torch.mean(err * err))
+
+            stoch, deter = post_stoch[:, 0], post_deter[:, 0]
+            for step in range(1, max_k + 1):
+                stoch, deter = rssm.img_step(stoch, deter, data["action"][:, step - 1])
+                if step in k_values:
+                    feat_pred = rssm.get_feat(stoch, deter)
+                    feat_gt = rssm.get_feat(post_stoch[:, step], post_deter[:, step])
+                    d = feat_pred - feat_gt
+                    rollout_sums[step] += float(torch.mean(d * d))
+            n += 1
+    agent.train()
+
+    if n == 0:
+        return {}
+    out = {f"heldout/{k}": v / n for k, v in sums.items()}
+    for k, total in rollout_sums.items():
+        out[f"heldout/k_step_rollout_mse/k{k}"] = total / n
+    out["heldout/reconstruction_nll"] = float("nan")  # decoder-free, see docstring
+    out["heldout/num_batches"] = float(n)
+    return out
+
+
+def metrics_table_row(metrics: dict) -> dict:
+    """Translate held-out output into the 3D-26 comparison-table columns."""
+    return {
+        "reconstruction_nll": metrics.get("heldout/reconstruction_nll", float("nan")),
+        "dynamics_kl": metrics.get("heldout/loss/dyn", float("nan")),
+        "representation_kl": metrics.get("heldout/loss/rep", float("nan")),
+        "reward_mse": metrics.get("heldout/reward_mse", float("nan")),
+        "k_step_rollout_k1": metrics.get("heldout/k_step_rollout_mse/k1", float("nan")),
+        "k_step_rollout_k5": metrics.get("heldout/k_step_rollout_mse/k5", float("nan")),
+        "k_step_rollout_k15": metrics.get("heldout/k_step_rollout_mse/k15", float("nan")),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -554,6 +690,34 @@ def main(argv: list[str] | None = None) -> None:
         checkpoint_every=args.checkpoint_every,
         output_dir=output_dir,
     ).run()
+
+    # Final held-out world-model metrics (3D-46). Same definitions + columns as
+    # the JAX 3D-26 eval, so the two are directly comparable.
+    if not args.skip_heldout_eval:
+        heldout_buf = OfflineVectorBuffer(
+            buffer_dir,
+            args.encoder,
+            split="heldout",
+            batch_size=args.batch_size,
+            seq_len=args.seq_len,
+            device=device,
+            seed=args.seed,
+            deter_size=int(model_cfg.rssm.deter),
+            stoch_classes=int(model_cfg.rssm.stoch),
+            stoch_discrete=int(model_cfg.rssm.discrete),
+        )
+        heldout = compute_heldout_metrics(
+            agent, heldout_buf, max_batches=args.heldout_eval_batches
+        )
+        if heldout:
+            (output_dir / "heldout_final.json").write_text(json.dumps(heldout, indent=2))
+            table_row = metrics_table_row(heldout)
+            (output_dir / "heldout_table_row.json").write_text(json.dumps(table_row, indent=2))
+            if wandb_run is not None:
+                wandb_run.log({f"final/{k}": v for k, v in heldout.items()}, step=args.steps)
+            print("Final held-out metrics:")
+            for k, v in heldout.items():
+                print(f"  {k}={v:.6f}")
 
     if wandb_run is not None:
         wandb_run.finish()

--- a/scripts/r2dreamer/train_external_offline.py
+++ b/scripts/r2dreamer/train_external_offline.py
@@ -76,6 +76,8 @@ SHARED = {
 ENCODER_SPECS = {
     "wp_cp": {"z_file": "z_wp_cp.npz", "obs_dim": 4116},
     "aggregator": {"z_file": "z_aggregator.npz", "obs_dim": 3072},
+    # 3D-47: frame ⊕ global aggregator token, 3 pools of 2048-d -> 6144-d.
+    "aggregator_both": {"z_file": "z_aggregator_both.npz", "obs_dim": 6144},
 }
 
 NUM_ACTIONS = 4  # Habitat objectnav: stop / forward / left / right

--- a/scripts/r2dreamer/train_external_offline.py
+++ b/scripts/r2dreamer/train_external_offline.py
@@ -1,0 +1,563 @@
+#!/usr/bin/env python
+"""Offline training of the *external* (PyTorch) R2Dreamer — 3D-45 adapter.
+
+Trains the ORIGINAL PyTorch R2Dreamer (``external/r2dreamer/``) offline from the
+canonical replay buffer (``data/offline_buffer/``) on the WP/CP vector readout
+(``z_wp_cp.npz``, 4116-d), with no live env and no VGGT forward pass. This is the
+infra that the 3D-46 baseline runs depend on: it produces a PyTorch number that
+is apples-to-apples with the JAX 3D-26 offline results.
+
+Why a wrapper instead of ``external/r2dreamer/train.py``
+-------------------------------------------------------
+The stock external entry point is env-driven (``make_envs`` -> ``OnlineTrainer``,
+torchrl ``LazyTensorStorage`` filled by live rollouts) and logs only to
+TensorBoard/jsonl. This wrapper instead:
+
+  * feeds the 4116-d WP/CP vector through the MLP encoder branch by declaring an
+    obs space ``{"vector": Box(4116,)}`` and setting ``encoder.mlp_keys='vector'``
+    / ``cnn_keys='$^'`` (the match-nothing regex that disables the CNN);
+  * replays the fixed offline buffer with the SAME sampling semantics as the JAX
+    ``OfflineBufferDataset`` — contiguous windows that may straddle episode
+    boundaries, ``is_first`` reset wherever ``done`` flipped, ``is_terminal=done``,
+    and a zeroed initial latent each batch (the external R2-Dreamer latent
+    write-back is a no-op offline, matching the JAX path which carries no
+    cross-batch latent state);
+  * reuses ``agent.update()`` verbatim, so the optimizer / GradScaler / AGC /
+    scheduler behaviour is identical to the online external trainer;
+  * optionally mirrors scalars to W&B in the same project as the JAX runs.
+
+The default ``rep_loss="r2dreamer"`` (Barlow-Twins redundancy reduction) carries
+NO decoder — matching the decoder-free JAX R2Dreamer — so there is no
+reconstruction NLL on either side. See 3D-45 / 3D-46.
+
+IMPORTANT — run under the external venv (it has torchrl/tensordict/gymnasium):
+
+    external/r2dreamer/.venv/bin/python scripts/r2dreamer/train_external_offline.py ...
+
+Smoke (NaN-free 100 steps on CPU, no W&B):
+
+    external/r2dreamer/.venv/bin/python scripts/r2dreamer/train_external_offline.py \\
+        --encoder wp_cp --seed 0 --steps 100 \\
+        --buffer-dir data/offline_buffer_smoke --output-dir /tmp/ext_smoke \\
+        --device cpu --batch-size 4 --seq-len 16
+
+Real run (GPU, one of seeds {0,1,2} for 3D-46):
+
+    external/r2dreamer/.venv/bin/python scripts/r2dreamer/train_external_offline.py \\
+        --encoder wp_cp --seed 0 --steps 500000 \\
+        --buffer-dir data/offline_buffer --output-dir output/3d46/ext-wp_cp-seed0 \\
+        --device cuda:0 --wandb --wandb-name ext-wp_cp-seed0
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXT = REPO_ROOT / "external" / "r2dreamer"
+
+# Fairness-contract defaults — must match 3D-26 (the JAX offline runs).
+SHARED = {
+    "batch_size": 16,
+    "seq_len": 64,
+    "imag_horizon": 15,
+}
+
+# z_*.npz file + flat feature dim per readout. Aggregator is wired but out of
+# scope for 3D-45/3D-46 (WP/CP only); kept so a future readout is a one-liner.
+ENCODER_SPECS = {
+    "wp_cp": {"z_file": "z_wp_cp.npz", "obs_dim": 4116},
+    "aggregator": {"z_file": "z_aggregator.npz", "obs_dim": 3072},
+}
+
+NUM_ACTIONS = 4  # Habitat objectnav: stop / forward / left / right
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--encoder", choices=list(ENCODER_SPECS), default="wp_cp")
+    p.add_argument("--seed", type=int, required=True)
+    p.add_argument("--steps", type=int, default=500_000, help="Total grad steps.")
+    p.add_argument("--buffer-dir", default="data/offline_buffer")
+    p.add_argument("--output-dir", required=True)
+    p.add_argument("--device", default="cuda:0")
+    p.add_argument("--model-size", default="size12M")
+    p.add_argument("--batch-size", type=int, default=SHARED["batch_size"])
+    p.add_argument("--seq-len", type=int, default=SHARED["seq_len"])
+    p.add_argument("--log-every", type=int, default=250)
+    p.add_argument("--checkpoint-every", type=int, default=50_000)
+    # compile defaults to the model config (True); forced off on CPU.
+    p.add_argument("--compile", dest="compile", action="store_true", default=None)
+    p.add_argument("--no-compile", dest="compile", action="store_false")
+    p.add_argument("--wandb", action="store_true", help="Enable W&B (off by default).")
+    p.add_argument("--wandb-project", default="3d-vla-objectnav-offline-ablation")
+    p.add_argument("--wandb-name", default=None)
+    p.add_argument(
+        "--wandb-tags",
+        default="offline-ablation,3d-24,framework:pytorch-external",
+        help="Comma-separated. `variant:<encoder>` is appended automatically.",
+    )
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Config / spaces
+# ---------------------------------------------------------------------------
+def build_model_config(model_size: str, device: str, compile_flag: bool | None):
+    """Compose the external model config without hydra's env layer.
+
+    The shipped ``configs/model/_base_.yaml`` interpolates ``${env.encoder.*}``
+    and ``${device}``; we supply those nodes here and point the encoder/decoder
+    at the single ``vector`` obs key (CNN disabled via the ``$^`` regex).
+    """
+    from omegaconf import OmegaConf
+
+    base = OmegaConf.load(EXT / "configs" / "model" / "_base_.yaml")
+    size = OmegaConf.load(EXT / "configs" / "model" / f"{model_size}.yaml")
+    if "defaults" in size:
+        del size["defaults"]  # hydra-only key; we merge _base_ explicitly
+    model = OmegaConf.merge(base, size)
+
+    top = OmegaConf.create(
+        {
+            "device": device,
+            "env": {
+                "encoder": {"mlp_keys": "vector", "cnn_keys": "$^"},
+                "decoder": {"mlp_keys": "vector", "cnn_keys": "$^"},
+            },
+            "model": model,
+        }
+    )
+    OmegaConf.resolve(top)
+    model_cfg = top.model
+    if compile_flag is not None:
+        model_cfg.compile = bool(compile_flag)
+    # Dreamer mutates a few config fields in place (actor.shape, actor.dist, ...).
+    OmegaConf.set_struct(model_cfg, False)
+    return model_cfg
+
+
+def make_spaces(obs_dim: int, num_actions: int):
+    """Build a gymnasium obs Dict + a discrete (one-hot) action Box.
+
+    Mirrors ``envs/wrappers.OneHotAction``: a Box with a ``.discrete`` marker so
+    ``Dreamer`` selects the one-hot actor head. Only the ``vector`` key is
+    declared, so ``MultiEncoder`` routes it (and nothing else) to the MLP encoder.
+    """
+    import gymnasium as gym
+
+    obs_space = gym.spaces.Dict(
+        {"vector": gym.spaces.Box(-np.inf, np.inf, shape=(obs_dim,), dtype=np.float32)}
+    )
+    act_space = gym.spaces.Box(low=0.0, high=1.0, shape=(num_actions,), dtype=np.float32)
+    act_space.discrete = True
+    return obs_space, act_space
+
+
+# ---------------------------------------------------------------------------
+# Offline replay buffer (drop-in for external Buffer's sample/update/count)
+# ---------------------------------------------------------------------------
+class OfflineVectorBuffer:
+    """Replays ``data/offline_buffer`` windows with JAX-identical semantics.
+
+    Exposes the ``(data, index, initial) = sample()`` / ``update(index, stoch,
+    deter)`` / ``count()`` interface that ``Dreamer.update`` calls, so the agent's
+    training step is reused unchanged. Sampling matches
+    ``src/buffer/offline_buffer_dataset.OfflineBufferDataset``: contiguous windows
+    over a single split's index range, ``is_first[:,0]=True`` plus wherever
+    ``done`` flipped, ``is_terminal=is_last=done``, and a zeroed initial latent
+    (episode reset is driven entirely by ``is_first``).
+    """
+
+    def __init__(
+        self,
+        buffer_dir: Path,
+        encoder: str,
+        split: str,
+        *,
+        batch_size: int,
+        seq_len: int,
+        device,
+        seed: int,
+        deter_size: int,
+        stoch_classes: int,
+        stoch_discrete: int,
+    ) -> None:
+        import torch
+
+        self._torch = torch
+        self.device = torch.device(device)
+        self.B = int(batch_size)
+        self.L = int(seq_len)
+        self._init_dims = (int(stoch_classes), int(stoch_discrete), int(deter_size))
+
+        spec = ENCODER_SPECS[encoder]
+        meta = _load_metadata(buffer_dir)
+        self.metadata = meta
+        n = meta["n_completed_steps"]
+        heldout_start = meta["heldout_start_episode"]
+
+        skeleton = np.load(buffer_dir / "trajectory_skeleton.npz")
+        try:
+            actions = skeleton["action"][:n]
+            rewards = skeleton["reward"][:n]
+            dones = skeleton["done"][:n]
+            episode_ids = skeleton["episode_id"][:n]
+        finally:
+            skeleton.close()
+
+        z = _load_features(buffer_dir / spec["z_file"])[:n]
+
+        if split == "train":
+            mask = episode_ids < heldout_start
+        elif split == "heldout":
+            mask = episode_ids >= heldout_start
+        else:
+            raise ValueError(f"unknown split: {split!r}")
+        if not mask.any():
+            raise ValueError(
+                f"split={split!r} empty (heldout_start={heldout_start}, "
+                f"episodes={meta['num_episodes']})"
+            )
+        idx = np.where(mask)[0]
+        if not np.all(np.diff(idx) == 1):
+            raise ValueError(
+                f"split={split!r} is not a contiguous transition range — the "
+                f"collector reordered episodes? Aborting to avoid wrap-around."
+            )
+        start, end = int(idx[0]), int(idx[-1]) + 1
+
+        self.obs = z[start:end]  # kept float16 in RAM; cast per-batch
+        self.actions = actions[start:end]
+        self.rewards = rewards[start:end]
+        self.dones = dones[start:end]
+        self.size = int(self.obs.shape[0])
+        self.obs_dim = int(self.obs.shape[1])
+        if self.size < self.L:
+            raise ValueError(f"split has {self.size} steps < seq_len {self.L}")
+        self._rng = np.random.default_rng(seed)
+
+        print(
+            f"OfflineVectorBuffer[{split}]: {self.size} steps, obs={self.obs.shape} "
+            f"{self.obs.dtype}, {encoder} from {buffer_dir}"
+        )
+
+    def sample(self):
+        torch = self._torch
+        n_valid = self.size - self.L + 1
+        starts = self._rng.integers(0, n_valid, size=self.B)
+        win = starts[:, None] + np.arange(self.L)[None, :]  # (B, L)
+
+        dev = self.device
+        obs = torch.as_tensor(self.obs[win].astype(np.float32), device=dev)
+        act_idx = torch.as_tensor(self.actions[win].astype(np.int64), device=dev)
+        action = torch.nn.functional.one_hot(act_idx, NUM_ACTIONS).to(torch.float32)
+        reward = torch.as_tensor(
+            self.rewards[win].astype(np.float32), device=dev
+        ).unsqueeze(-1)
+
+        dones = self.dones[win]  # (B, L) bool
+        is_first = np.zeros_like(dones)
+        is_first[:, 0] = True
+        is_first[:, 1:] = dones[:, :-1]
+        is_first_t = torch.as_tensor(is_first, device=dev).unsqueeze(-1)
+        done_t = torch.as_tensor(dones.astype(np.float32), device=dev).unsqueeze(-1)
+
+        from tensordict import TensorDict
+
+        data = TensorDict(
+            {
+                "vector": obs,
+                "action": action,
+                "reward": reward,
+                "is_first": is_first_t,
+                "is_last": done_t,
+                "is_terminal": done_t,
+            },
+            batch_size=(self.B, self.L),
+            device=dev,
+        )
+        s_classes, s_discrete, deter = self._init_dims
+        initial = (
+            torch.zeros(self.B, s_classes, s_discrete, device=dev),
+            torch.zeros(self.B, deter, device=dev),
+        )
+        return data, win, initial
+
+    def update(self, index, stoch, deter):  # noqa: D401 - offline no-op
+        """No-op: offline replay carries no cross-batch latent state (matches JAX)."""
+
+    def count(self):
+        return self.size
+
+
+def _load_metadata(buffer_dir: Path) -> dict:
+    """Read collection_metadata.json; tolerate a missing file (all-train)."""
+    skeleton = np.load(buffer_dir / "trajectory_skeleton.npz")
+    try:
+        episode_ids = skeleton["episode_id"]
+        n_rows = int(episode_ids.shape[0])
+    finally:
+        skeleton.close()
+
+    meta_path = buffer_dir / "collection_metadata.json"
+    raw = json.loads(meta_path.read_text()) if meta_path.exists() else {}
+    n_completed = int(raw.get("n_completed_steps", n_rows))
+    if n_completed > n_rows:
+        raise ValueError(
+            f"metadata n_completed_steps={n_completed} > skeleton rows {n_rows}"
+        )
+    num_episodes = int(episode_ids[:n_completed].max()) + 1 if n_completed else 0
+    heldout = raw.get("heldout_split", {})
+    return {
+        "n_completed_steps": n_completed,
+        "num_episodes": num_episodes,
+        "heldout_start_episode": int(
+            heldout.get("episode_id_start_inclusive", num_episodes)
+        ),
+        "code_sha": raw.get("code_sha"),
+        "checkpoint_sha256": raw.get("checkpoint_sha256"),
+        "collect_seed": int(raw.get("collect_seed", -1)),
+    }
+
+
+def _load_features(path: Path) -> np.ndarray:
+    data = np.load(path)
+    try:
+        key = "features" if "features" in data.files else data.files[0]
+        return data[key]
+    finally:
+        data.close()
+
+
+# ---------------------------------------------------------------------------
+# Logger (TensorBoard/jsonl via tools.Logger, + optional W&B mirror)
+# ---------------------------------------------------------------------------
+def make_logger(output_dir: Path, wandb_run):
+    import tools  # external/r2dreamer/tools.py (EXT is on sys.path)
+
+    if wandb_run is None:
+        return tools.Logger(output_dir)
+
+    class _WandbLogger(tools.Logger):
+        def write(self, step, fps=False):
+            scalars = dict(self._scalars)  # snapshot before super() clears
+            super().write(step, fps=fps)
+            wandb_run.log(scalars, step=int(step))
+
+    return _WandbLogger(output_dir)
+
+
+# ---------------------------------------------------------------------------
+# Offline trainer
+# ---------------------------------------------------------------------------
+class OfflineTrainer:
+    """Pure offline loop: ``steps`` grad updates, no env, no eval episodes."""
+
+    def __init__(self, agent, buffer, logger, *, steps, log_every, checkpoint_every, output_dir):
+        self.agent = agent
+        self.buffer = buffer
+        self.logger = logger
+        self.steps = int(steps)
+        self.log_every = int(log_every)
+        self.checkpoint_every = int(checkpoint_every)
+        self.output_dir = Path(output_dir)
+
+    def run(self):
+        import torch
+
+        import tools
+
+        self.agent.train()
+        t0 = time.time()
+        last = t0
+        for step in range(self.steps):
+            metrics = self.agent.update(self.buffer)
+            scalars = {k: _to_float(v) for k, v in metrics.items()}
+
+            bad = [k for k, v in scalars.items() if not math.isfinite(v)]
+            if bad:
+                raise RuntimeError(f"non-finite metric(s) at step {step}: {bad}")
+
+            if step % self.log_every == 0:
+                now = time.time()
+                for k, v in scalars.items():
+                    self.logger.scalar(f"train/{k}", v)
+                self.logger.scalar("perf/sps", self.log_every / max(now - last, 1e-6))
+                self.logger.scalar("perf/elapsed_min", (now - t0) / 60.0)
+                self.logger.write(step, fps=True)
+                last = now
+
+            if self.checkpoint_every and step > 0 and step % self.checkpoint_every == 0:
+                self._save(step)
+
+        self._save(self.steps, latest=True)
+        print(f"Done: {self.steps} grad steps in {(time.time() - t0) / 60:.1f} min")
+
+    def _save(self, step, latest=False):
+        import torch
+
+        import tools
+
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "step": step,
+            "agent_state_dict": self.agent.state_dict(),
+            "optims_state_dict": tools.recursively_collect_optim_state_dict(self.agent),
+        }
+        torch.save(payload, self.output_dir / f"checkpoint_{step:09d}.pt")
+        if latest:
+            torch.save(payload, self.output_dir / "latest.pt")
+        print(f"  saved checkpoint @ step {step}")
+
+
+def _to_float(v) -> float:
+    try:
+        return float(v.item()) if hasattr(v, "item") else float(v)
+    except Exception:
+        return float("nan")
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+def _git_sha(path: Path) -> str | None:
+    try:
+        return subprocess.check_output(
+            ["git", "-C", str(path), "rev-parse", "HEAD"], text=True
+        ).strip()
+    except Exception:
+        return None
+
+
+def _resolve(path_str: str) -> Path:
+    p = Path(path_str)
+    return p if p.is_absolute() else (REPO_ROOT / p)
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _build_parser().parse_args(argv)
+
+    # Make the external package importable (it imports siblings by bare name).
+    if str(EXT) not in sys.path:
+        sys.path.insert(0, str(EXT))
+
+    import torch
+
+    import tools
+    from dreamer import Dreamer
+
+    buffer_dir = _resolve(args.buffer_dir)
+    output_dir = _resolve(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    device = args.device
+    compile_flag = args.compile
+    if device.startswith("cpu"):
+        compile_flag = False  # reduce-overhead/cudagraphs require CUDA
+
+    tools.set_seed_everywhere(args.seed)
+    if device.startswith("cuda"):
+        torch.set_float32_matmul_precision("high")
+
+    spec = ENCODER_SPECS[args.encoder]
+    model_cfg = build_model_config(args.model_size, device, compile_flag)
+    obs_space, act_space = make_spaces(spec["obs_dim"], NUM_ACTIONS)
+
+    print(
+        f"3D-45 external offline: encoder={args.encoder} seed={args.seed} "
+        f"steps={args.steps} device={device} compile={bool(model_cfg.compile)}"
+    )
+    agent = Dreamer(model_cfg, obs_space, act_space).to(device)
+
+    train_buf = OfflineVectorBuffer(
+        buffer_dir,
+        args.encoder,
+        split="train",
+        batch_size=args.batch_size,
+        seq_len=args.seq_len,
+        device=device,
+        seed=args.seed,
+        deter_size=int(model_cfg.rssm.deter),
+        stoch_classes=int(model_cfg.rssm.stoch),
+        stoch_discrete=int(model_cfg.rssm.discrete),
+    )
+    if train_buf.obs_dim != spec["obs_dim"]:
+        raise ValueError(
+            f"buffer obs_dim={train_buf.obs_dim} != encoder {args.encoder} "
+            f"expected {spec['obs_dim']}"
+        )
+
+    # W&B (off by default; real 3D-46 runs pass --wandb).
+    wandb_run = None
+    if args.wandb:
+        import wandb
+        from omegaconf import OmegaConf
+
+        tags = [t.strip() for t in args.wandb_tags.split(",") if t.strip()]
+        tags.append(f"variant:{args.encoder}")
+        wandb_run = wandb.init(
+            project=args.wandb_project,
+            name=args.wandb_name or f"ext-{args.encoder}-seed{args.seed}",
+            tags=tags,
+            config=OmegaConf.to_container(model_cfg, resolve=True),
+        )
+
+    # Reproducibility record.
+    from omegaconf import OmegaConf
+
+    run_config = {
+        "issue": "3D-45/3D-46",
+        "framework": "pytorch-external",
+        "encoder": args.encoder,
+        "obs_dim": spec["obs_dim"],
+        "num_actions": NUM_ACTIONS,
+        "seed": args.seed,
+        "steps": args.steps,
+        "batch_size": args.batch_size,
+        "seq_len": args.seq_len,
+        "device": device,
+        "model_size": args.model_size,
+        "rep_loss": str(model_cfg.rep_loss),
+        "compile": bool(model_cfg.compile),
+        "buffer_dir": str(buffer_dir),
+        "train_split_size": train_buf.size,
+        "buffer_metadata": train_buf.metadata,
+        "code_sha_main": _git_sha(REPO_ROOT),
+        "code_sha_external": _git_sha(EXT),
+        "wandb_run_id": wandb_run.id if wandb_run is not None else None,
+        "wandb_run_url": wandb_run.url if wandb_run is not None else None,
+        "model_config": OmegaConf.to_container(model_cfg, resolve=True),
+    }
+    (output_dir / "run_config.json").write_text(json.dumps(run_config, indent=2, default=str))
+
+    logger = make_logger(output_dir, wandb_run)
+    OfflineTrainer(
+        agent,
+        train_buf,
+        logger,
+        steps=args.steps,
+        log_every=args.log_every,
+        checkpoint_every=args.checkpoint_every,
+        output_dir=output_dir,
+    ).run()
+
+    if wandb_run is not None:
+        wandb_run.finish()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/r2dreamer/train_offline_ablation.py
+++ b/scripts/r2dreamer/train_offline_ablation.py
@@ -66,8 +66,12 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--encoder",
         required=True,
-        choices=["wp_cp", "aggregator"],
-        help="Encoder kind. wp_cp -> z_wp_cp.npz (4116-d); aggregator -> z_aggregator.npz (3072-d).",
+        choices=["wp_cp", "aggregator", "aggregator_both"],
+        help=(
+            "Encoder kind. wp_cp -> z_wp_cp.npz (4116-d); "
+            "aggregator -> z_aggregator.npz (3072-d, global stream); "
+            "aggregator_both -> z_aggregator_both.npz (6144-d, frame ⊕ global)."
+        ),
     )
     p.add_argument("--seed", type=int, required=True, help="Training seed (one of {0,1,2}).")
     p.add_argument("--steps", type=int, default=500_000, help="Total grad steps.")
@@ -110,6 +114,12 @@ def _encoder_spec(encoder_kind: str) -> dict[str, Any]:
             "module_cls": wm_encoders.VGGTAggregatorMLPEncoder,
             "obs_shape": (3072,),
             "encoder_type": "vggt_aggregator_mlp",
+        }
+    if encoder_kind == "aggregator_both":
+        return {
+            "module_cls": wm_encoders.VGGTAggregatorBothMLPEncoder,
+            "obs_shape": (6144,),
+            "encoder_type": "vggt_aggregator_both_mlp",
         }
     raise ValueError(f"unknown encoder: {encoder_kind!r}")
 

--- a/src/buffer/offline_buffer_dataset.py
+++ b/src/buffer/offline_buffer_dataset.py
@@ -30,7 +30,7 @@ import jax.numpy as jnp
 import numpy as np
 
 
-EncoderKind = Literal["wp_cp", "aggregator"]
+EncoderKind = Literal["wp_cp", "aggregator", "aggregator_both"]
 
 
 @dataclass(frozen=True)
@@ -49,6 +49,8 @@ def _resolve_z_path(buffer_dir: Path, encoder_kind: EncoderKind) -> Path:
         return buffer_dir / "z_wp_cp.npz"
     if encoder_kind == "aggregator":
         return buffer_dir / "z_aggregator.npz"
+    if encoder_kind == "aggregator_both":
+        return buffer_dir / "z_aggregator_both.npz"
     raise ValueError(f"unknown encoder_kind: {encoder_kind!r}")
 
 

--- a/src/r2dreamer/adapters/vggt_adapter.py
+++ b/src/r2dreamer/adapters/vggt_adapter.py
@@ -12,7 +12,7 @@ from src.vggt.jax.feature_extractor import JAXVGGTFeatureExtractor as VGGTFeatur
 
 
 VGGT_FEATURE_DIM = 4116  # 37*37*3 + 9
-VGGTFeatureKind = Literal["wp_cp", "aggregator"]
+VGGTFeatureKind = Literal["wp_cp", "aggregator", "aggregator_both"]
 
 
 def flatten_world_points_camera_pose(out: dict) -> jnp.ndarray:
@@ -49,6 +49,32 @@ def pool_aggregator_tokens(out: dict, expected_shape: tuple[int, ...]) -> jnp.nd
     return jnp.concatenate([cam, mean_p, max_p], axis=0)
 
 
+def pool_aggregator_tokens_both(out: dict, expected_shape: tuple[int, ...]) -> jnp.ndarray:
+    """Return three pre-head pools of the *full* aggregator token as ``(6*D,)``.
+
+    Same camera/mean/max recipe as :func:`pool_aggregator_tokens`, but it keeps
+    the aggregator's native ``[frame_inter, global_inter]`` token instead of the
+    global half alone (see ``src/vggt/jax/feature_extractor.py``). The frame and
+    global ``(P, D)`` halves are recombined in their native concat order into a
+    ``(P, 2*D)`` token before pooling, so the only thing that differs from the
+    global-only readout is the extra per-frame/local stream. ``expected_shape``
+    is the per-stream shape (i.e. ``extractor.aggregator_feature_shape``).
+    """
+    frame = out["aggregator_features_frame"]
+    glob = out["aggregator_features"]
+    if frame.shape != expected_shape or glob.shape != expected_shape:
+        raise ValueError(
+            f"expected per-stream aggregator_features shape {expected_shape}, "
+            f"got frame={frame.shape}, global={glob.shape}"
+        )
+    features = jnp.concatenate([frame, glob], axis=-1).astype(jnp.float32)  # (P, 2*D)
+    cam = features[0]
+    patches = features[_PATCH_START_IDX:]
+    mean_p = patches.mean(axis=0)
+    max_p = patches.max(axis=0)
+    return jnp.concatenate([cam, mean_p, max_p], axis=0)  # (6*D,)
+
+
 class VGGTObsAdapter(ObsAdapter):
     """Runs VGGT extraction, returns features for both buffer and agent."""
 
@@ -59,6 +85,11 @@ class VGGTObsAdapter(ObsAdapter):
         elif feature_kind == "aggregator":
             embed_dim = int(extractor.aggregator_feature_shape[-1])
             buffer_shape = (3 * embed_dim,)  # [cam | mean_patches | max_patches]
+            buffer_dtype = "float32"
+        elif feature_kind == "aggregator_both":
+            embed_dim = int(extractor.aggregator_feature_shape[-1])
+            # Full frame ⊕ global token is 2*embed_dim wide; 3 pools -> 6*embed_dim.
+            buffer_shape = (6 * embed_dim,)  # [cam | mean_patches | max_patches]
             buffer_dtype = "float32"
         else:
             raise ValueError(f"unknown VGGT feature_kind {feature_kind!r}")
@@ -76,13 +107,15 @@ class VGGTObsAdapter(ObsAdapter):
         out = self._extractor.extract(obs_dict["image"])
         if self._feature_kind == "aggregator":
             features_jax = pool_aggregator_tokens(out, self._aggregator_feature_shape)
+        elif self._feature_kind == "aggregator_both":
+            features_jax = pool_aggregator_tokens_both(out, self._aggregator_feature_shape)
         else:
             features_jax = flatten_world_points_camera_pose(out)
 
         # The replay buffer is CPU/NumPy storage. The acting path keeps JAX
         # float32 features so it can feed the JIT-compiled agent directly.
         replay_features = np.asarray(features_jax)
-        if self._feature_kind == "aggregator":
+        if self._feature_kind in ("aggregator", "aggregator_both"):
             replay_features = replay_features.astype(np.float32)
 
         agent_features = features_jax.astype(jnp.float32)

--- a/src/r2dreamer/agent.py
+++ b/src/r2dreamer/agent.py
@@ -30,6 +30,7 @@ from .world_model.encoders import (
     ConvEncoder,
     VGGTEncoder as WMVGGTEncoder,
     VGGTAggregatorMLPEncoder as WMVGGTAggregatorMLPEncoder,
+    VGGTAggregatorBothMLPEncoder as WMVGGTAggregatorBothMLPEncoder,
 )
 from .world_model.heads import R2MLP, R2TwoHotDist
 from .world_model.loss import world_model_loss, kl_loss as _kl_loss
@@ -115,6 +116,7 @@ def _make_encoder(cfg: R2DreamerConfig):
             "cnn": ConvEncoder,
             "vggt": WMVGGTEncoder,
             "vggt_aggregator_mlp": WMVGGTAggregatorMLPEncoder,
+            "vggt_aggregator_both_mlp": WMVGGTAggregatorBothMLPEncoder,
         }.get(cfg.encoder_type)
         if cls is None:
             raise ValueError(f"unknown encoder_type {cfg.encoder_type!r}")
@@ -298,7 +300,9 @@ class R2DreamerAgent:
         Returns:
             Integer action in [0, num_actions).
         """
-        if self.cfg.encoder_type in ("vggt", "vggt_aggregator_mlp"):
+        if self.cfg.encoder_type in (
+            "vggt", "vggt_aggregator_mlp", "vggt_aggregator_both_mlp",
+        ):
             obs = jnp.asarray(obs_dict["features"])[None]
         else:
             image = obs_dict["image"].astype(np.float32) / 255.0

--- a/src/r2dreamer/config.py
+++ b/src/r2dreamer/config.py
@@ -20,7 +20,7 @@ class R2DreamerConfig:
     img_layers: int = 2
 
     # --- Encoder ---
-    encoder_type: str = "cnn"  # "cnn", "vggt", or "vggt_aggregator_mlp"
+    encoder_type: str = "cnn"  # "cnn", "vggt", "vggt_aggregator_mlp", or "vggt_aggregator_both_mlp"
     encoder_module_cls: Any = None  # Flax nn.Module class; sourced from EncoderSpec.module_cls
     encoder_depth: int = 16
     encoder_kernel: int = 5

--- a/src/r2dreamer/encoders/__init__.py
+++ b/src/r2dreamer/encoders/__init__.py
@@ -164,10 +164,35 @@ class VGGTAggregatorMLPEncoder(VGGTEncoder):
     )
 
 
+class VGGTAggregatorBothMLPEncoder(VGGTAggregatorMLPEncoder):
+    """VGGT extractor pooling the full frame ⊕ global aggregator token (3D-47).
+
+    Same pre-head, heads-skipped pipeline as the global-only Aggregator variant,
+    but the adapter keeps the aggregator's native 2048-d token (frame/local ⊕
+    global/contextual) instead of the global half alone, yielding a (6144,)
+    pooled vector. The only thing that differs from `vggt_aggregator_mlp` is the
+    token set fed to the encoder; this is the variable under test.
+    """
+
+    feature_kind = "aggregator_both"
+    encoder_type = "vggt_aggregator_both_mlp"
+    module_cls = wm_encoders.VGGTAggregatorBothMLPEncoder
+    design_notes = (
+        "3D-47 encoder: identical to vggt_aggregator_mlp but the adapter pools "
+        "the aggregator's native [frame_inter, global_inter] 2048-d token rather "
+        "than the 1024-d global stream alone, so the discarded per-frame/local "
+        "stream is included. Pooling is the same cam/mean/max recipe over the "
+        "wider token -> flat (6144,) float32 in replay; the encoder applies a "
+        "per-slice RMSNorm (3 x 2048) + 2-layer MLP -> embed_dim. Compared "
+        "head-to-head against the global-only readout under an identical buffer."
+    )
+
+
 __all__ = [
     "EncoderSpec",
     "Encoder",
     "CNNEncoder",
     "VGGTEncoder",
     "VGGTAggregatorMLPEncoder",
+    "VGGTAggregatorBothMLPEncoder",
 ]

--- a/src/r2dreamer/launch/evaluate.py
+++ b/src/r2dreamer/launch/evaluate.py
@@ -20,6 +20,8 @@ from src.shared.video_utils import (
     compose_frame,
     log_episode_video,
     render_topdown_frame,
+    resize_chw_uint8,
+    write_mp4_local,
 )
 
 
@@ -121,8 +123,21 @@ def evaluate(
         render_resolution = args.render_resolution if args.render_resolution is not None else 518
     else:
         render_resolution = args.render_resolution if args.render_resolution is not None else 64
+
+    # Decouple a (higher-fidelity) video render from the policy input. The env
+    # renders at video_render_resolution; we downsample to render_resolution
+    # before the policy sees it. None / equal-to-render_resolution disables.
+    video_render_resolution = args.video_render_resolution
+    if video_render_resolution is not None and video_render_resolution < render_resolution:
+        raise ValueError(
+            f"--video_render_resolution ({video_render_resolution}) must be "
+            f">= --render_resolution ({render_resolution})"
+        )
+    env_render_resolution = video_render_resolution or render_resolution
+    downsample_for_policy = env_render_resolution != render_resolution
+
     hab_config = DreamerConfig(
-        obs_shape=(3, render_resolution, render_resolution),
+        obs_shape=(3, env_render_resolution, env_render_resolution),
         max_episode_steps=500,
         split=args.split,
         reward_type="geodesic_delta",
@@ -175,11 +190,17 @@ def evaluate(
     ACTIONS = {0: "STOP", 1: "MOVE_FORWARD", 2: "TURN_LEFT", 3: "TURN_RIGHT"}
     results = []
 
+    def _policy_obs(env_obs: dict) -> dict:
+        """Downsample obs['image'] to policy render_resolution; passthrough otherwise."""
+        if not downsample_for_policy:
+            return env_obs
+        return {**env_obs, "image": resize_chw_uint8(env_obs["image"], render_resolution)}
+
     for ep_idx in range(args.episodes):
         obs = env_instance.reset()
         if adapter.on_episode_reset:
             adapter.on_episode_reset()
-        _, agent_obs = adapter.transform(obs)
+        _, agent_obs = adapter.transform(_policy_obs(obs))
         actions_taken = []
         rewards = []
         trajectory = []
@@ -193,10 +214,15 @@ def evaluate(
         trajectory.append(start_pos)
         headings.append(_get_agent_heading(env_instance))
         video_frames = []
-        record_video = wandb_module is not None and ep_idx < args.log_video_episodes
+        # Record video if either W&B logging or local MP4 output is requested.
+        record_video = ep_idx < args.log_video_episodes and (
+            wandb_module is not None or args.save_video_path is not None
+        )
         if record_video:
-            topdown = render_topdown_frame(env_instance, trajectory, goal_positions)
-            video_frames.append(compose_frame(obs["image"], topdown))
+            topdown = render_topdown_frame(
+                env_instance, trajectory, goal_positions, size_px=env_render_resolution)
+            video_frames.append(
+                compose_frame(obs["image"], topdown, panel_size=env_render_resolution))
 
         for _step in range(500):
             if agent is not None:
@@ -206,7 +232,7 @@ def evaluate(
                 action = np.random.randint(0, config.num_actions)
 
             next_obs = env_instance.step(action)
-            _, next_agent_obs = adapter.transform(next_obs)
+            _, next_agent_obs = adapter.transform(_policy_obs(next_obs))
             actions_taken.append(int(action))
             rewards.append(float(next_obs["reward"]))
 
@@ -214,8 +240,11 @@ def evaluate(
             trajectory.append(pos)
             headings.append(_get_agent_heading(env_instance))
             if record_video:
-                topdown = render_topdown_frame(env_instance, trajectory, goal_positions)
-                video_frames.append(compose_frame(next_obs["image"], topdown))
+                topdown = render_topdown_frame(
+                    env_instance, trajectory, goal_positions,
+                    size_px=env_render_resolution)
+                video_frames.append(compose_frame(
+                    next_obs["image"], topdown, panel_size=env_render_resolution))
 
             if next_obs["done"]:
                 obs = next_obs
@@ -251,6 +280,12 @@ def evaluate(
         if record_video:
             log_episode_video(
                 wandb_module, f"eval/episode_video_{ep_idx}", video_frames, ep_idx)
+            if args.save_video_path is not None:
+                os.makedirs(args.save_video_path, exist_ok=True)
+                mp4_path = os.path.join(
+                    args.save_video_path, f"episode_{ep_idx:03d}.mp4")
+                write_mp4_local(mp4_path, video_frames, fps=args.video_fps)
+                print(f"  wrote video {mp4_path}")
 
         print(
             f"Episode {ep_idx}: steps={len(actions_taken):3d}  "

--- a/src/r2dreamer/launch/parser.py
+++ b/src/r2dreamer/launch/parser.py
@@ -96,6 +96,13 @@ def _build_parser_eval() -> argparse.ArgumentParser:
                    help="Override shim curriculum path (escape hatch)")
     p.add_argument("--render_resolution", type=int, default=None,
                    help="Render resolution (default: 518 for vggt, 64 for cnn)")
+    p.add_argument("--video_render_resolution", type=int, default=None,
+                   help="If set, render env at this resolution for video frames "
+                        "and downsample to --render_resolution before the policy. "
+                        "Lets a CNN trained at 64x64 produce e.g. 512x512 video.")
+    p.add_argument("--save_video_path", type=str, default=None,
+                   help="Directory to write per-episode MP4 videos locally")
+    p.add_argument("--video_fps", type=int, default=10)
     p.add_argument("--split", type=str, default="val")
     p.add_argument("--save_frames", action="store_true")
     p.add_argument("--semantic", action="store_true")

--- a/src/r2dreamer/launch/registries.py
+++ b/src/r2dreamer/launch/registries.py
@@ -7,6 +7,7 @@ from src.r2dreamer.encoders import (
     CNNEncoder,
     VGGTEncoder,
     VGGTAggregatorMLPEncoder,
+    VGGTAggregatorBothMLPEncoder,
 )
 from src.r2dreamer.launch.habitat_setup import make_habitat_env
 
@@ -21,6 +22,7 @@ encoder_registry: dict[str, type[Encoder]] = {
     "cnn": CNNEncoder,
     "vggt": VGGTEncoder,
     "vggt_aggregator_mlp": VGGTAggregatorMLPEncoder,
+    "vggt_aggregator_both_mlp": VGGTAggregatorBothMLPEncoder,
 }
 
 env_registry: dict[str, Callable] = {

--- a/src/r2dreamer/world_model/__init__.py
+++ b/src/r2dreamer/world_model/__init__.py
@@ -1,13 +1,19 @@
 """World-model subpackage: encoders, RSSM, head primitives, and world-model loss."""
 
 from .rssm import RMSNorm, BlockLinear, Deter, R2RSSM
-from .encoders import ConvEncoder, VGGTEncoder, VGGTAggregatorMLPEncoder
+from .encoders import (
+    ConvEncoder,
+    VGGTEncoder,
+    VGGTAggregatorMLPEncoder,
+    VGGTAggregatorBothMLPEncoder,
+)
 from .heads import R2MLP, R2TwoHotDist, onehot_mode_st
 from .loss import world_model_loss, kl_loss
 
 __all__ = [
     "RMSNorm", "BlockLinear", "Deter", "R2RSSM",
     "ConvEncoder", "VGGTEncoder", "VGGTAggregatorMLPEncoder",
+    "VGGTAggregatorBothMLPEncoder",
     "R2MLP", "R2TwoHotDist", "onehot_mode_st",
     "world_model_loss", "kl_loss",
 ]

--- a/src/r2dreamer/world_model/encoders.py
+++ b/src/r2dreamer/world_model/encoders.py
@@ -86,3 +86,34 @@ class VGGTAggregatorMLPEncoder(nn.Module):
         x = nn.Dense(self.hidden, name="hidden")(x)
         x = nn.silu(x)
         return nn.Dense(self.embed_dim, name="proj")(x)
+
+
+class VGGTAggregatorBothMLPEncoder(nn.Module):
+    """Encoder for the frame+global aggregator readout (3D-47).
+
+    Identical wiring to ``VGGTAggregatorMLPEncoder`` but each pooled slice is the
+    aggregator's native ``2 * D``-wide token (frame ⊕ global) rather than the
+    global stream alone — i.e. it keeps the per-frame/local stream the
+    global-only readout discards (see ``src/vggt/jax/feature_extractor.py``).
+    Input layout is ``[cam | mean_patches | max_patches]`` flat, shape
+    ``(B, 3 * pool_dim)`` with ``pool_dim = 2048``. Each slice is normalised
+    separately so the mean/max scale mismatch does not bleed into the projection.
+    """
+    embed_dim: int = 1024
+    pool_dim: int = 2048
+    hidden: int = 1024
+
+    @nn.compact
+    def __call__(self, obs):
+        if obs.ndim != 2 or obs.shape[-1] != 3 * self.pool_dim:
+            raise ValueError(
+                f"expected (B, {3 * self.pool_dim}) VGGT pooled features, got {obs.shape}"
+            )
+        cam, mean_p, max_p = jnp.split(obs, 3, axis=-1)
+        cam = RMSNorm(name="norm_cam")(cam)
+        mean_p = RMSNorm(name="norm_mean")(mean_p)
+        max_p = RMSNorm(name="norm_max")(max_p)
+        x = jnp.concatenate([cam, mean_p, max_p], axis=-1)
+        x = nn.Dense(self.hidden, name="hidden")(x)
+        x = nn.silu(x)
+        return nn.Dense(self.embed_dim, name="proj")(x)

--- a/src/shared/video_utils.py
+++ b/src/shared/video_utils.py
@@ -50,10 +50,11 @@ def _resize_panel(frame: np.ndarray, target_size: int = MAX_PANEL_SIZE) -> np.nd
     return frame
 
 
-def compose_frame(rgb: np.ndarray, topdown: np.ndarray) -> np.ndarray:
-    """Return a side-by-side RGB frame with both panels fit to 256px."""
-    left = _resize_panel(_as_hwc_uint8(rgb))
-    right = _resize_panel(_as_hwc_uint8(topdown))
+def compose_frame(rgb: np.ndarray, topdown: np.ndarray,
+                  panel_size: int = MAX_PANEL_SIZE) -> np.ndarray:
+    """Return a side-by-side RGB frame with both panels fit to ``panel_size``."""
+    left = _resize_panel(_as_hwc_uint8(rgb), panel_size)
+    right = _resize_panel(_as_hwc_uint8(topdown), panel_size)
     height = max(left.shape[0], right.shape[0])
 
     def pad(panel: np.ndarray) -> np.ndarray:
@@ -70,8 +71,9 @@ def render_topdown_frame(
     env: Any,
     trajectory_so_far: Sequence[Sequence[float]],
     goal_positions: Sequence[Sequence[float]],
+    size_px: int = 256,
 ) -> np.ndarray:
-    """Render a top-down Habitat map frame as ``(H, W, 3) uint8``."""
+    """Render a top-down Habitat map frame as ``(size_px, size_px, 3) uint8``."""
     import matplotlib
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
@@ -81,7 +83,8 @@ def render_topdown_frame(
     else:
         from src.environments.habitat import sample_navmesh
         nav = sample_navmesh(env._env, resolution=0.1)
-    fig, ax = plt.subplots(1, 1, figsize=(2.56, 2.56), dpi=100)
+    dpi = 100
+    fig, ax = plt.subplots(1, 1, figsize=(size_px / dpi, size_px / dpi), dpi=dpi)
 
     extent = [nav["x_min"], nav["x_max"], nav["z_max"], nav["z_min"]]
     ax.imshow(nav["grid"], extent=extent, cmap="Greys_r", alpha=0.3)
@@ -118,3 +121,29 @@ def log_episode_video(wandb_module: Any, key: str, frames: list[np.ndarray],
     wandb_video = wandb_module.Video(video, fps=fps, format="mp4")
     wandb_module.log({key: wandb_video}, step=step)
     return wandb_video
+
+
+def write_mp4_local(path: str, frames: list[np.ndarray], fps: int = 10) -> str | None:
+    """Write frames as an MP4 to ``path``. Caps frames to ``MAX_VIDEO_FRAMES``."""
+    if not frames:
+        return None
+    import imageio.v2 as imageio
+
+    stride = max(1, math.ceil(len(frames) / MAX_VIDEO_FRAMES))
+    frames = frames[::stride][:MAX_VIDEO_FRAMES]
+    hwc = [_as_hwc_uint8(f) for f in frames]
+    h, w = hwc[0].shape[:2]
+    # H.264 requires even pixel dimensions; pad bottom/right by 1 if needed.
+    if h % 2 or w % 2:
+        pad_h = h % 2
+        pad_w = w % 2
+        hwc = [np.pad(f, ((0, pad_h), (0, pad_w), (0, 0)), constant_values=0) for f in hwc]
+
+    writer = imageio.get_writer(path, fps=fps, codec="libx264", quality=8,
+                                macro_block_size=None)
+    try:
+        for frame in hwc:
+            writer.append_data(frame)
+    finally:
+        writer.close()
+    return path

--- a/src/vggt/jax/feature_extractor.py
+++ b/src/vggt/jax/feature_extractor.py
@@ -431,12 +431,16 @@ class JAXVGGTFeatureExtractor:
 
         # Final pre-head aggregator tokens for encoder ablations. The JAX port
         # stores frame/local and global/contextual streams concatenated as
-        # 2048-d tokens for DPT heads; expose the 1024-d global stream requested
-        # by Variant 1 before camera/point heads transform it into WP+CP. Keep
-        # all VGGT-DP / VGGT-World tokens: camera + register + spatial patches.
+        # 2048-d tokens for DPT heads. Expose them as two 1024-d halves so a
+        # single forward feeds both readouts (3D-47): the global stream alone
+        # (3072-d pooled) or frame ⊕ global together (6144-d pooled). Keep all
+        # VGGT-DP / VGGT-World tokens: camera + register + spatial patches.
         final_tokens = out_list[-1]
-        final_global = final_tokens[..., final_tokens.shape[-1] // 2:]
+        half = final_tokens.shape[-1] // 2
+        final_global = final_tokens[..., half:]
+        final_frame = final_tokens[..., :half]
         aggregator_features = final_global[0, 0].astype(jnp.float32)
+        aggregator_features_frame = final_frame[0, 0].astype(jnp.float32)
 
         self._frame_idx += 1
 
@@ -445,5 +449,9 @@ class JAXVGGTFeatureExtractor:
                 "world_points": world_points_out,
                 "camera_pose": camera_pose_out,
                 "aggregator_features": aggregator_features,
+                "aggregator_features_frame": aggregator_features_frame,
             }
-        return {"aggregator_features": aggregator_features}
+        return {
+            "aggregator_features": aggregator_features,
+            "aggregator_features_frame": aggregator_features_frame,
+        }

--- a/start_gpu_session.sh
+++ b/start_gpu_session.sh
@@ -24,7 +24,7 @@ while [[ "$1" == --* ]]; do
 done
 
 SESSION="${1:-gpu-work}"
-PARTITION="${2:-gpu_h100}"
+PARTITION="${2:-gpu_h100_il}"
 TIME="${3:-24:00:00}"
 PROJECT_DIR="/pfs/data6/home/ul/ul_student/ul_hfj15/Master-Thesis-3D-VLA"
 

--- a/tests/r2dreamer/launch/test_encoders.py
+++ b/tests/r2dreamer/launch/test_encoders.py
@@ -11,6 +11,7 @@ from src.r2dreamer.encoders import (
     EncoderSpec,
     VGGTEncoder,
     VGGTAggregatorMLPEncoder,
+    VGGTAggregatorBothMLPEncoder,
 )
 
 
@@ -151,6 +152,67 @@ class TestVGGTEncoderConfiguration:
         np.testing.assert_allclose(replay_features, expected)
         assert agent_obs["features"].shape == (3 * 4,)
         assert agent_obs["features"].dtype.name == "float32"
+
+    def test_aggregator_both_encoder_spec_uses_doubled_feature_dim(self, monkeypatch):
+        class FakeExtractor:
+            aggregator_feature_shape = (86, 128)
+
+            def __init__(self, **kwargs):
+                pass
+
+            def reset(self):
+                pass
+
+        monkeypatch.setattr(
+            "src.r2dreamer.encoders.VGGTFeatureExtractor",
+            FakeExtractor,
+        )
+
+        enc = VGGTAggregatorBothMLPEncoder(resolution=256)
+        adapter = enc.make_adapter()
+        spec = enc.spec()
+
+        # Full frame ⊕ global token is 2*embed_dim; 3 pools -> 6 * embed_dim.
+        assert adapter.buffer_shape == (6 * 128,)
+        assert adapter.buffer_dtype == "float32"
+        assert spec.obs_shape == (6 * 128,)
+        assert spec.encoder_type == "vggt_aggregator_both_mlp"
+        assert spec.module_cls.__name__ == "VGGTAggregatorBothMLPEncoder"
+
+    def test_aggregator_both_adapter_concatenates_frame_then_global(self):
+        # 1 cam + 4 register + 5 patch tokens, per-stream D = 4.
+        class FakeExtractor:
+            aggregator_feature_shape = (10, 4)
+
+            def reset(self):
+                pass
+
+            def extract(self, image):
+                import jax.numpy as jnp
+
+                glob = jnp.arange(40, dtype=jnp.float32).reshape(10, 4)
+                frame = glob + 100.0
+                return {
+                    "aggregator_features": glob,
+                    "aggregator_features_frame": frame,
+                }
+
+        adapter = VGGTObsAdapter(FakeExtractor(), feature_kind="aggregator_both")
+        replay_features, agent_obs = adapter.transform(
+            {"image": np.zeros((3, 4, 4), dtype=np.uint8)}
+        )
+
+        glob = np.arange(40, dtype=np.float32).reshape(10, 4)
+        frame = glob + 100.0
+        token = np.concatenate([frame, glob], axis=-1)  # native (10, 8) token
+        expected = np.concatenate(
+            [token[0], token[5:].mean(axis=0), token[5:].max(axis=0)]
+        )
+
+        assert replay_features.shape == (6 * 4,)
+        assert replay_features.dtype == np.float32
+        np.testing.assert_allclose(replay_features, expected)
+        assert agent_obs["features"].shape == (6 * 4,)
 
 
 @pytest.mark.gpu

--- a/tests/r2dreamer/test_collect_offline_buffer.py
+++ b/tests/r2dreamer/test_collect_offline_buffer.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 from scripts.r2dreamer.collect_offline_buffer import (
+    AGGREGATOR_BOTH_DIM,
     AGGREGATOR_DIM,
     WP_CP_DIM,
     StreamingNpzArray,
@@ -16,6 +17,7 @@ from scripts.r2dreamer.collect_offline_buffer import (
 from src.r2dreamer.adapters.vggt_adapter import (
     flatten_world_points_camera_pose,
     pool_aggregator_tokens,
+    pool_aggregator_tokens_both,
 )
 
 
@@ -49,6 +51,49 @@ def test_pool_aggregator_keeps_camera_and_pools_patches():
     np.testing.assert_array_equal(got[:1024], np.ones(1024, dtype=np.float32))
     np.testing.assert_array_equal(got[1024:2048], np.full(1024, 3.0, dtype=np.float32))
     np.testing.assert_array_equal(got[2048:], np.full(1024, 4.0, dtype=np.float32))
+
+
+def test_pool_aggregator_both_concatenates_frame_then_global():
+    # Per-stream shape (5 cam+register + 2 patches, D=1024). The "both" pool
+    # keeps the native [frame_inter, global_inter] token order, so each pooled
+    # slice is 2*D wide with the frame half first.
+    frame = np.zeros((5 + 2, 1024), dtype=np.float32)
+    frame[0] = 10.0  # camera token
+    frame[5] = 20.0  # patch 0
+    frame[6] = 40.0  # patch 1
+    glob = np.zeros((5 + 2, 1024), dtype=np.float32)
+    glob[0] = 1.0
+    glob[5] = 2.0
+    glob[6] = 4.0
+
+    got = np.asarray(
+        pool_aggregator_tokens_both(
+            {"aggregator_features": glob, "aggregator_features_frame": frame},
+            expected_shape=frame.shape,
+        ),
+        dtype=np.float32,
+    )
+
+    assert got.shape == (AGGREGATOR_BOTH_DIM,)
+    # cam = [frame_cam | global_cam]
+    np.testing.assert_array_equal(got[0:1024], np.full(1024, 10.0, dtype=np.float32))
+    np.testing.assert_array_equal(got[1024:2048], np.full(1024, 1.0, dtype=np.float32))
+    # mean patch = [frame_mean(30) | global_mean(3)]
+    np.testing.assert_array_equal(got[2048:3072], np.full(1024, 30.0, dtype=np.float32))
+    np.testing.assert_array_equal(got[3072:4096], np.full(1024, 3.0, dtype=np.float32))
+    # max patch = [frame_max(40) | global_max(4)]
+    np.testing.assert_array_equal(got[4096:5120], np.full(1024, 40.0, dtype=np.float32))
+    np.testing.assert_array_equal(got[5120:6144], np.full(1024, 4.0, dtype=np.float32))
+
+
+def test_pool_aggregator_both_rejects_mismatched_stream_shape():
+    frame = np.zeros((7, 1024), dtype=np.float32)
+    glob = np.zeros((6, 1024), dtype=np.float32)  # wrong row count
+    with pytest.raises(ValueError, match="per-stream aggregator_features shape"):
+        pool_aggregator_tokens_both(
+            {"aggregator_features": glob, "aggregator_features_frame": frame},
+            expected_shape=(7, 1024),
+        )
 
 
 def test_streaming_npz_array_writes_loadable_npz(tmp_path: Path):

--- a/tests/r2dreamer/test_external_offline_buffer.py
+++ b/tests/r2dreamer/test_external_offline_buffer.py
@@ -1,0 +1,135 @@
+"""Semantics of the external-R2Dreamer offline buffer adapter (3D-45).
+
+Validates that `OfflineVectorBuffer` (scripts/r2dreamer/train_external_offline.py)
+reproduces the JAX `OfflineBufferDataset` sampling contract: the train/heldout
+split, contiguous windows, `is_first` reset on `done`, `is_terminal == is_last ==
+done`, one-hot actions, and a zeroed initial latent.
+
+These run under the *external* venv (torch + tensordict + gymnasium). Under the
+main venv they are skipped — tensordict is not installed there.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("tensordict")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "r2dreamer" / "train_external_offline.py"
+
+
+def _load_module():
+    # The external package imports siblings by bare name; put it on the path so
+    # the module's lazy `from dreamer import Dreamer` etc. could resolve too.
+    sys.path.insert(0, str(REPO_ROOT / "external" / "r2dreamer"))
+    spec = importlib.util.spec_from_file_location("train_external_offline", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _make_buffer(tmp: Path, *, ep_lengths, obs_dim=8, heldout_start=None, seed=0):
+    """Write a tiny offline buffer (skeleton + z_wp_cp + metadata) to `tmp`."""
+    rng = np.random.default_rng(seed)
+    actions, rewards, dones, episode_ids = [], [], [], []
+    for ep, length in enumerate(ep_lengths):
+        actions.append(rng.integers(0, 4, size=length).astype(np.int32))
+        rewards.append(rng.standard_normal(length).astype(np.float32))
+        d = np.zeros(length, dtype=bool)
+        d[-1] = True  # episode terminates on its last step
+        dones.append(d)
+        episode_ids.append(np.full(length, ep, dtype=np.int32))
+    action = np.concatenate(actions)
+    reward = np.concatenate(rewards)
+    done = np.concatenate(dones)
+    episode_id = np.concatenate(episode_ids)
+    n = action.shape[0]
+
+    np.savez(tmp / "trajectory_skeleton.npz", action=action, reward=reward, done=done, episode_id=episode_id)
+    np.savez(tmp / "z_wp_cp.npz", features=rng.standard_normal((n, obs_dim)).astype(np.float16))
+
+    meta = {"n_completed_steps": n, "num_episodes": len(ep_lengths)}
+    if heldout_start is not None:
+        meta["heldout_split"] = {"episode_id_start_inclusive": heldout_start}
+    (tmp / "collection_metadata.json").write_text(json.dumps(meta))
+    return n
+
+
+def _buf(mod, tmp, *, split, batch_size=4, seq_len=5, obs_dim=8):
+    return mod.OfflineVectorBuffer(
+        tmp, "wp_cp", split=split,
+        batch_size=batch_size, seq_len=seq_len, device="cpu", seed=0,
+        deter_size=16, stoch_classes=6, stoch_discrete=3,
+    )
+
+
+def test_split_partitions_episodes(tmp_path):
+    mod = _load_module()
+    # 5 episodes of 10 steps = 50; heldout = episodes >= 4 (last episode, 10 steps).
+    _make_buffer(tmp_path, ep_lengths=[10] * 5, heldout_start=4)
+    train = _buf(mod, tmp_path, split="train")
+    heldout = _buf(mod, tmp_path, split="heldout")
+    assert train.size == 40
+    assert heldout.size == 10
+    assert train.size + heldout.size == 50
+
+
+def test_sample_shapes_and_flags(tmp_path):
+    import torch
+
+    mod = _load_module()
+    _make_buffer(tmp_path, ep_lengths=[10] * 5, heldout_start=4, obs_dim=8)
+    buf = _buf(mod, tmp_path, split="train", batch_size=4, seq_len=5, obs_dim=8)
+    data, index, initial = buf.sample()
+
+    assert tuple(data.batch_size) == (4, 5)
+    assert data["vector"].shape == (4, 5, 8)
+    assert data["action"].shape == (4, 5, mod.NUM_ACTIONS)
+    assert data["reward"].shape == (4, 5, 1)
+    for k in ("is_first", "is_last", "is_terminal"):
+        assert data[k].shape == (4, 5, 1)
+
+    # Actions are one-hot.
+    assert torch.allclose(data["action"].sum(-1), torch.ones(4, 5))
+    # First column of every window is a reset.
+    assert bool(data["is_first"][:, 0].all())
+    # is_terminal == is_last == done.
+    assert torch.equal(data["is_terminal"], data["is_last"])
+    # Zeroed initial latent of the right shape.
+    s, d = initial
+    assert s.shape == (4, 6, 3) and d.shape == (4, 16)
+    assert float(s.abs().sum()) == 0.0 and float(d.abs().sum()) == 0.0
+    assert index.shape == (4, 5)
+
+
+def test_is_first_tracks_done_shift(tmp_path):
+    mod = _load_module()
+    # Two episodes of 8 in a single (all-train) split, so windows straddle the
+    # boundary and exercise the interior is_first reset.
+    _make_buffer(tmp_path, ep_lengths=[8, 8], heldout_start=99)
+    buf = _buf(mod, tmp_path, split="train", batch_size=8, seq_len=5)
+    data, index, _ = buf.sample()
+    isf = data["is_first"][..., 0].bool().numpy()  # (B, L)
+
+    # Invariant (matches JAX OfflineBufferDataset): is_first[:,0]=True, and
+    # is_first[:,t] = done at the previous global step.
+    expected = np.zeros_like(isf)
+    expected[:, 0] = True
+    expected[:, 1:] = buf.dones[index[:, :-1]]
+    assert np.array_equal(isf, expected)
+    # The boundary at global index 7 must show up as a reset somewhere.
+    assert isf[:, 1:].any() or not (index[:, :-1] == 7).any()
+
+
+def test_missing_metadata_is_all_train(tmp_path):
+    mod = _load_module()
+    # No heldout_split / no metadata file beyond n_completed -> everything is train.
+    n = _make_buffer(tmp_path, ep_lengths=[6, 6, 6], heldout_start=None)
+    train = _buf(mod, tmp_path, split="train", seq_len=4)
+    assert train.size == n

--- a/tests/r2dreamer/test_offline_comparison.py
+++ b/tests/r2dreamer/test_offline_comparison.py
@@ -1,0 +1,94 @@
+"""Aggregation + rendering for the 3D-46 JAX-vs-external comparison builder.
+
+Pure-stdlib (no torch/jax), so it runs in any venv.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "r2dreamer" / "build_offline_comparison.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("build_offline_comparison", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _row(dyn, rep, rew, k1, k5, k15, recon=float("nan")):
+    return {
+        "reconstruction_nll": recon,
+        "dynamics_kl": dyn,
+        "representation_kl": rep,
+        "reward_mse": rew,
+        "k_step_rollout_k1": k1,
+        "k_step_rollout_k5": k5,
+        "k_step_rollout_k15": k15,
+    }
+
+
+def test_aggregate_mean_std():
+    mod = _load()
+    rows = {
+        "0": _row(10.0, 10.0, 1.0, 0.1, 0.5, 1.5),
+        "1": _row(12.0, 12.0, 2.0, 0.2, 0.6, 1.6),
+        "2": _row(14.0, 14.0, 3.0, 0.3, 0.7, 1.7),
+    }
+    agg = mod.aggregate(rows)
+    assert agg["dynamics_kl"]["mean"] == 12.0
+    assert agg["dynamics_kl"]["n"] == 3
+    assert abs(agg["dynamics_kl"]["std"] - 2.0) < 1e-9  # sample stdev of 10,12,14
+    assert abs(agg["reward_mse"]["mean"] - 2.0) < 1e-9
+    # recon NLL must not be a comparable column.
+    assert "reconstruction_nll" not in agg
+
+
+def test_aggregate_ignores_nan_and_missing():
+    mod = _load()
+    rows = {
+        "0": _row(10.0, 10.0, float("nan"), 0.1, 0.5, 1.5),
+        "1": _row(12.0, 12.0, 2.0, 0.2, 0.6, 1.6),
+    }
+    agg = mod.aggregate(rows)
+    # reward_mse has one finite value (seed 1); n=1, std=0.
+    assert agg["reward_mse"]["n"] == 1
+    assert agg["reward_mse"]["mean"] == 2.0
+    assert agg["reward_mse"]["std"] == 0.0
+
+
+def test_seed_from_path():
+    mod = _load()
+    assert mod._seed_from_path("output/3d46/wp_cp-seed2/run-99/heldout_table_row.json") == "2"
+    assert mod._seed_from_path("ext-wp_cp-seed0") == "0"
+
+
+def test_end_to_end_glob_and_outputs(tmp_path):
+    mod = _load()
+    # Synthesize 3 external seed dirs with table rows.
+    for s in range(3):
+        d = tmp_path / f"wp_cp-seed{s}" / "run-1"
+        d.mkdir(parents=True)
+        (d / "heldout_table_row.json").write_text(
+            json.dumps(_row(10.0 + s, 10.0 + s, 1.0 + s, 0.1, 0.5, 1.5))
+        )
+    ext_glob = str(tmp_path / "wp_cp-seed*" / "run-*" / "heldout_table_row.json")
+    out_md = tmp_path / "cmp.md"
+    out_csv = tmp_path / "cmp.csv"
+
+    mod.main([
+        "--external-glob", ext_glob,
+        "--out-md", str(out_md),
+        "--out-csv", str(out_csv),
+    ])
+
+    md = out_md.read_text()
+    assert "external PyTorch (3D-46)" in md
+    assert "11.0000 ± 1.0000 (n=3)" in md  # dynamics_kl mean of 10,11,12
+    assert "_pending_" in md  # JAX column has no data yet
+    # CSV has the external per-seed rows (3 seeds × 6 comparable metrics).
+    csv_lines = out_csv.read_text().strip().splitlines()
+    assert csv_lines[0] == "framework,seed,metric,value"
+    assert sum(1 for ln in csv_lines if ln.startswith("pytorch_external")) == 18

--- a/tests/r2dreamer/test_vggt_encoder.py
+++ b/tests/r2dreamer/test_vggt_encoder.py
@@ -6,13 +6,19 @@ import numpy as np
 import pytest
 
 from src.r2dreamer.config import R2DreamerConfig
-from src.r2dreamer.world_model.encoders import VGGTEncoder, VGGTAggregatorMLPEncoder
+from src.r2dreamer.world_model.encoders import (
+    VGGTEncoder,
+    VGGTAggregatorMLPEncoder,
+    VGGTAggregatorBothMLPEncoder,
+)
 from src.buffer.replay_buffer import VGGTReplayBuffer
 
 
 FEATURE_DIM = 4116  # 37*37*3 + 9
 POOL_DIM = 1024
 POOLED_FEATURE_DIM = 3 * POOL_DIM  # [cam | mean_patches | max_patches]
+POOL_DIM_BOTH = 2048  # frame ⊕ global token width
+POOLED_FEATURE_DIM_BOTH = 3 * POOL_DIM_BOTH  # 6144
 
 
 class TestVGGTAggregatorMLPEncoder:
@@ -45,6 +51,42 @@ class TestVGGTAggregatorMLPEncoder:
 
     def test_per_pool_norms_and_mlp_params(self):
         enc = VGGTAggregatorMLPEncoder(embed_dim=32, pool_dim=8, hidden=16)
+        rng = jax.random.PRNGKey(0)
+        dummy = jnp.arange(2 * 24, dtype=jnp.float32).reshape(2, 24)
+        params = enc.init(rng, dummy)
+        out = enc.apply(params, dummy)
+
+        assert out.shape == (2, 32)
+        assert set(params["params"].keys()) == {
+            "norm_cam", "norm_mean", "norm_max", "hidden", "proj",
+        }
+
+
+class TestVGGTAggregatorBothMLPEncoder:
+    """3D-47 frame ⊕ global readout: same MLP, 2048-d pooled slices (6144 total)."""
+
+    def test_output_shape(self):
+        enc = VGGTAggregatorBothMLPEncoder(embed_dim=1024)
+        rng = jax.random.PRNGKey(0)
+        dummy = jnp.zeros((2, POOLED_FEATURE_DIM_BOTH))
+        params = enc.init(rng, dummy)
+        out = enc.apply(params, dummy)
+        assert out.shape == (2, 1024)
+        assert jnp.isfinite(out).all()
+
+    def test_default_pool_dim_is_2048(self):
+        assert VGGTAggregatorBothMLPEncoder().pool_dim == 2048
+
+    def test_rejects_global_only_width(self):
+        """A 3072-d (global-only) vector must not be silently accepted."""
+        enc = VGGTAggregatorBothMLPEncoder(embed_dim=32)
+        rng = jax.random.PRNGKey(0)
+        dummy = jnp.zeros((2, POOLED_FEATURE_DIM), dtype=jnp.float32)  # 3072, wrong
+        with pytest.raises(ValueError, match="VGGT pooled features"):
+            enc.init(rng, dummy)
+
+    def test_per_pool_norms_and_mlp_params(self):
+        enc = VGGTAggregatorBothMLPEncoder(embed_dim=32, pool_dim=8, hidden=16)
         rng = jax.random.PRNGKey(0)
         dummy = jnp.arange(2 * 24, dtype=jnp.float32).reshape(2, 24)
         params = enc.init(rng, dummy)
@@ -210,6 +252,55 @@ class TestVGGTAgentInit:
         metrics = agent.train_step(batch, train_key)
         assert "total_loss" in metrics
         assert np.isfinite(metrics["total_loss"])
+
+    def test_agent_train_step_vggt_aggregator_both_mlp(self):
+        from src.r2dreamer.agent import R2DreamerAgent
+
+        cfg = R2DreamerConfig(
+            encoder_type="vggt_aggregator_both_mlp",
+            obs_shape=(POOLED_FEATURE_DIM_BOTH,),
+            num_actions=4,
+            batch_size=2,
+            seq_len=8,
+            imagination_horizon=3,
+        )
+        rng = jax.random.PRNGKey(42)
+        agent = R2DreamerAgent(cfg, rng)
+
+        B, T = cfg.batch_size, cfg.seq_len
+        batch = {
+            "obs": jnp.zeros((B, T, POOLED_FEATURE_DIM_BOTH)),
+            "actions": jax.nn.one_hot(
+                jnp.zeros((B, T), dtype=jnp.int32), cfg.num_actions
+            ),
+            "rewards": jnp.zeros((B, T)),
+            "is_first": jnp.zeros((B, T)).at[:, 0].set(1.0),
+            "is_last": jnp.zeros((B, T)),
+            "is_terminal": jnp.zeros((B, T)),
+        }
+        rng, train_key = jax.random.split(rng)
+        metrics = agent.train_step(batch, train_key)
+        assert "total_loss" in metrics
+        assert np.isfinite(metrics["total_loss"])
+
+    def test_agent_act_vggt_aggregator_both_mlp(self):
+        from src.r2dreamer.agent import R2DreamerAgent
+
+        cfg = R2DreamerConfig(
+            encoder_type="vggt_aggregator_both_mlp",
+            obs_shape=(POOLED_FEATURE_DIM_BOTH,),
+            num_actions=4,
+        )
+        rng = jax.random.PRNGKey(42)
+        agent = R2DreamerAgent(cfg, rng)
+
+        obs_dict = {
+            "features": np.random.randn(POOLED_FEATURE_DIM_BOTH).astype(np.float32),
+            "is_first": True,
+        }
+        rng, act_key = jax.random.split(rng)
+        action = agent.act(obs_dict, act_key)
+        assert 0 <= action < 4
 
     def test_agent_train_step_vggt_aggregator_mlp(self):
         from src.r2dreamer.agent import R2DreamerAgent

--- a/tests/vggt/test_jax_integration.py
+++ b/tests/vggt/test_jax_integration.py
@@ -140,10 +140,15 @@ class TestJAXFeatureExtractorContract:
         ext = JAXVGGTFeatureExtractor(device="cuda", compute_heads=False)
         ext.reset()
         out = ext.extract(_make_frame(seed=7))
-        assert set(out.keys()) == {"aggregator_features"}
+        # Both halves of the native aggregator token are exposed (3D-47): the
+        # global stream (default readout) and the frame stream it used to drop.
+        assert set(out.keys()) == {"aggregator_features", "aggregator_features_frame"}
         assert out["aggregator_features"].shape == (1374, 1024)
         assert out["aggregator_features"].dtype == np.float32
         assert not np.any(np.isnan(out["aggregator_features"]))
+        assert out["aggregator_features_frame"].shape == (1374, 1024)
+        assert out["aggregator_features_frame"].dtype == np.float32
+        assert not np.any(np.isnan(out["aggregator_features_frame"]))
 
     def test_compute_heads_false_aggregator_matches_full(self, extractor):
         """Skipping heads must not change the aggregator output values."""


### PR DESCRIPTION
## Summary

Adds a third VGGT aggregator readout for R2Dreamer that keeps the per-frame/local stream the current global-only readout throws away, and wires up the 3D-47 offline ablation comparing:

- `aggregator`: current global-only pooled aggregator token, 3072-d
- `aggregator_both`: frame + global pooled aggregator token, 6144-d

The aggregator already emits a native 2048-d `[frame_inter, global_inter]` token (`src/vggt/jax/aggregator.py`); the existing readout slices off the frame half. This PR exposes both halves from the extractor and adds a pooling path that produces a 6144-d `[cam | mean | max]` vector at zero extra VGGT compute.

Closes the implementation portion of [3D-47](https://linear.app/3d-wm-objectnav/issue/3D-47).

## Why

3D-47 is a representation ablation: does retaining the per-frame/local aggregator stream improve the downstream R2Dreamer policy compared with the current global-only aggregator readout?

The comparison target is downstream ObjectNav behavior, not held-out world-model reconstruction metrics. Held-out WM metrics are intentionally not used as the merge criterion here because they are indirect for the research question and depend on a separate eval-loss path. The useful signal for this ablation is:

- stable offline training for both variants across seeds,
- finite losses / no NaNs,
- completed 500k-step checkpoints and W&B traces,
- follow-up fixed online ObjectNav eval on the same scenes/checkpoint steps, using SR/SPL as the main comparison.

## Changes

**Core (offline + acting)**
- `feature_extractor.py` — expose `aggregator_features_frame` alongside the global half in both heads/no-heads branches.
- `vggt_adapter.py` — add `pool_aggregator_tokens_both` and `aggregator_both` feature kind.
- `world_model/encoders.py` — add `VGGTAggregatorBothMLPEncoder` (`pool_dim=2048`).
- `agent.py` — register `vggt_aggregator_both_mlp` in the encoder map and acting-path obs gate.

**Wiring**
- Launch registry + `encoders.EncoderSpec` — add `vggt_aggregator_both_mlp` for online/eval use.
- `offline_buffer_dataset.py` — map `aggregator_both` to `z_aggregator_both.npz`.
- JAX (`train_offline_ablation.py`) + external PyTorch (`train_external_offline.py`) entrypoints understand the new feature kind.
- `collect_offline_buffer.py` — emits all three readouts in one pass; `verify_offline_buffer` checks `z_aggregator_both` conditionally so legacy buffers still pass.

**SLURM** (`scripts/r2dreamer/slurm/`)
- `collect_offline_buffer_3d47.sbatch`
- `train_offline_ablation_3d47.sbatch`
- `submit_3d47.sh` orchestrator

## Design Note: No RGB Cache

The collector intentionally does not persist RGB, so the new readout cannot be backfilled from disk. Instead the collector emits all three readouts in one pass, and the buffer is regenerated by a deterministic re-run using the same collection seed/checkpoint lineage. 3D-47 writes to `data/offline_buffer_3d47` so existing 3D-26 runs reading `data/offline_buffer` are untouched.

## Verification

Completed:
- `47 passed, 2 skipped` (CUDA-gated) across collector, buffer-dataset, launcher-encoder, and agent suites, including `pool_aggregator_tokens_both`, adapter/spec wiring, encoder shape, and agent act/train_step for `vggt_aggregator_both_mlp`.
- On-cluster smoke (`gpu_h100_short`) passed: collector wrote a 6144-d `z_aggregator_both.npz` (`cosine_min = 0.99999964`), and trainer consumed it for 200 steps NaN-free.
- 3D-47 prod buffer collection completed: `data/offline_buffer_3d47`, 400k steps, includes `z_aggregator.npz` and `z_aggregator_both.npz`.

Current prod training run plan:

```bash
SKIP_COLLECT=1 EXTRA_ARGS='--skip-heldout-eval' scripts/r2dreamer/slurm/submit_3d47.sh prod
```

Submitted jobs:
- `4848248` — `3d47-prod-aggregator-s0`
- `4848250` — `3d47-prod-aggregator-s1`
- `4848252` — `3d47-prod-aggregator-s2`
- `4848254` — `3d47-prod-aggregator_both-s0`
- `4848256` — `3d47-prod-aggregator_both-s1`
- `4848258` — `3d47-prod-aggregator_both-s2`

Held-out world-model eval is intentionally skipped for these runs. The merge evidence should be the completed training jobs, W&B traces/run IDs, checkpoints, and the follow-up fixed online ObjectNav evaluation.

## W&B

Smoke runs are logged in `3d-vla-objectnav-offline-ablation`. Prod W&B run IDs will be added once jobs `4848248`-`4848258` start and finish.

## Risk

Medium. The new readout doubles the pooled aggregator input width from 3072 to 6144 for the `aggregator_both` variant, but it is additive and does not change the existing `wp_cp` or global-only `aggregator` readout. The main risk is training/runtime stability, covered by the six 500k-step prod runs.

## How to Test

```bash
.venv/bin/python -m pytest \
  tests/r2dreamer/test_collect_offline_buffer.py \
  tests/r2dreamer/test_vggt_encoder.py \
  tests/r2dreamer/launch/test_encoders.py \
  tests/r2dreamer/launch/test_registries.py

SKIP_COLLECT=1 EXTRA_ARGS='--skip-heldout-eval' \
  scripts/r2dreamer/slurm/submit_3d47.sh prod --dry-run
```

## What Was Intentionally Not Done

- Held-out WM metrics are not used as the decision metric for 3D-47.
- Downstream fixed online ObjectNav evaluation (SR/SPL on the same scenes/checkpoint steps) is the follow-up comparison path once the six offline checkpoints are available.

## Agent Involvement

Implemented by Claude Code. PR story and verification notes updated by Codex after reviewing the current run plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
