### PR TITLE
feat(slurm): migrate L2-L4 / aggregator-MLP / offline-buffer to YAML launcher (3D-31, 3D-32, 3D-33)

### DIFF
--- a/scripts/slurm/README.md
+++ b/scripts/slurm/README.md
@@ -1,7 +1,9 @@
 # Slurm launcher
 
-One YAML-backed launcher that renders and submits sbatch jobs. Replaces
-per-experiment `*.sbatch` files in `scripts/r2dreamer/slurm/`.
+One YAML-backed launcher that renders and submits sbatch jobs. Replaces the
+per-experiment `*.sbatch` files scattered across `scripts/` and
+`scripts/r2dreamer/slurm/` with a single universal renderer plus one small
+config per variant.
 
 ## Quickstart
 
@@ -11,72 +13,143 @@ bash scripts/slurm/launch.sh l1_vggt --dry-run             # prod
 bash scripts/slurm/launch.sh l1_vggt --smoke --dry-run     # smoke
 
 # Submit
-bash scripts/slurm/launch.sh l1_vggt --smoke               # 30-min dev job
-bash scripts/slurm/launch.sh l1_vggt --prod                # 48-h full run
-bash scripts/slurm/launch.sh l1_vggt --smoke-then-prod     # smoke, then prod afterok
+bash scripts/slurm/launch.sh l1_vggt --smoke               # short dev job
+bash scripts/slurm/launch.sh l1_vggt --prod                # full run
+bash scripts/slurm/launch.sh l1_vggt --smoke-then-prod     # prod runs only if smoke passes
+
+# Sweep several variants in one shell call (bash brace expansion)
+bash scripts/slurm/launch.sh l{1,2,3,4}_vggt --smoke
+
+# Override an env var (wins over the YAML default)
+bash scripts/slurm/launch.sh offline_buffer_3d25 \
+    --env CNN_CHECKPOINT=output/r2dreamer-curriculum-l1/run-4367942/checkpoints/step_001000000.pkl \
+    --smoke
 ```
 
-The first positional argument (`l1_vggt` above) is the **variant name** —
-it maps to `scripts/slurm/configs/<variant>.yaml`.
+The first positional argument(s) are **variant names** — each maps to
+`scripts/slurm/configs/<variant>.yaml`.
+
+## Variants
+
+| Variant              | Script                                      | Replaces (legacy sbatch)                         |
+|----------------------|---------------------------------------------|--------------------------------------------------|
+| `l1_vggt`            | `run_jax_habitat_vggt.py`                   | `train_curriculum_l1_vggt.sbatch`                |
+| `l2_vggt`            | `run_jax_habitat_l2_vggt.py`                | `train_curriculum_l2_vggt.sbatch`                |
+| `l3_vggt`            | `run_jax_habitat_l3_vggt.py`                | `train_curriculum_l3_vggt.sbatch`                |
+| `l4_vggt`            | `run_jax_habitat_l4_vggt.py`                | `train_curriculum_l4_vggt.sbatch`                |
+| `aggregator_mlp_v1`  | `run_jax_habitat_vggt_aggregator_mlp.py`    | `prod_aggregator_mlp_v1.sbatch` + `smoke_aggregator_mlp_fast_path.sbatch` |
+| `offline_buffer_3d25`| `collect_offline_buffer.py`                 | `collect_offline_buffer_3d25.sbatch`             |
+
+During the coexistence window the legacy `*.sbatch` files remain runnable; they
+are removed in slice s5 (3D-34).
 
 ## Modes
 
-| Mode               | Partition         | Walltime | WandB    | Purpose                        |
-|--------------------|-------------------|----------|----------|--------------------------------|
-| `--prod` (default) | `gpu_h100`        | 48:00:00 | online   | Real training run              |
-| `--smoke`          | `gpu_h100_short`  | 00:30:00 | offline  | Production-faithful sanity check |
-| `--smoke-then-prod`| both              | both     | both     | Prod runs only if smoke passes |
+| Mode               | Partition         | Walltime | WandB    | Purpose                          |
+|--------------------|-------------------|----------|----------|----------------------------------|
+| `--prod` (default) | per `sbatch.*`    | per cfg  | online   | Real training / collection run   |
+| `--smoke`          | per `smoke.*`     | per cfg  | offline  | Production-faithful sanity check |
+| `--smoke-then-prod`| both              | both     | both     | Prod runs only if smoke passes (`--dependency=afterok:<smoke_jid> --kill-on-invalid-dep=yes`) |
 
 Smoke jobs additionally:
 
-- run with `set -euo pipefail` and `uv run --no-sync` (no resync overhead)
-- export `XLA_PYTHON_CLIENT_PREALLOCATE=false` and `XLA_PYTHON_CLIENT_MEM_FRACTION=0.7` to reduce JAX/habitat CUDA contention
-- assert `metrics.csv` exists with ≥5 rows; exit non-zero otherwise
-- print `=== Smoke PASS ===` on success
+- run with `set -euo pipefail` and (for the default `uv run python`) `uv run --no-sync python`
+- export `WANDB_MODE=offline`, `PYTHONFAULTHANDLER=1`,
+  `XLA_PYTHON_CLIENT_PREALLOCATE=false`, `XLA_PYTHON_CLIENT_MEM_FRACTION=0.7`
+- when `smoke.assert_file` is set, assert that file exists in the run dir (and
+  has ≥ `smoke.assert_min_rows` rows), exiting non-zero otherwise, then print
+  `=== Smoke PASS ===`
 
-> **Note on partition choice.** `--smoke` uses `gpu_h100_short`, not `dev_gpu_h100`.
-> The `dev_gpu_h100` partition is a single node (`uc3n082`) where habitat_sim's
-> OpenGL renderer aborts during prefill — see
-> `docs/3d-30-smoke-partition-analysis.html` for the analysis.
-> `gpu_h100_short` runs on the same H100 GPU class as production
-> (`uc3n088-090, 104-107`) with a 30-min cap, so smoke validates the actual
-> deployment path.
+> **Note on partition choice.** All habitat smokes use `gpu_h100_short`, not
+> `dev_gpu_h100`. The `dev_gpu_h100` partition is a single node (`uc3n082`) where
+> habitat_sim's OpenGL renderer aborts during prefill — see
+> `docs/3d-30-smoke-partition-analysis.html`. `gpu_h100_short` runs on the same
+> H100 class as production with a 30-min cap, so smoke validates the real path.
+> This overrides the `dev_gpu_h100` choice in the original s3/s4 acceptance
+> criteria, which predate that finding.
+
+## Config schema
+
+A variant config is validated by pydantic (`LaunchConfig` in `launch.py`)
+*before* any `sbatch` call; a missing or malformed field exits non-zero with a
+clear message and submits nothing.
+
+```yaml
+extends: _base            # optional; resolved recursively (a config may extend
+                          # another variant, which may itself extend _base)
+job_name: r2d-L2-vggt
+output_dir: output/...    # directory for #SBATCH logs (the run dir lives in args)
+script: scripts/r2dreamer/run_jax_habitat_l2_vggt.py   # repo-relative entrypoint
+
+python: uv run python     # interpreter prefix; e.g. ".venv/bin/python"
+arg_style: underscore     # "underscore" -> --val_data ; "hyphen" -> --val-data
+strict_bash: false        # emit `set -euo pipefail` in prod too (always on for smoke)
+curriculum_check: data/curriculum/level2_1house_6goals.json   # optional generate-if-missing guard
+
+sbatch:                   # #SBATCH resource directives
+  partition: gpu_h100
+  gres: gpu:1
+  ntasks: 1
+  cpus_per_task: 8
+  mem: 64G
+  time: "48:00:00"
+
+env:                      # exported before the run; overridable via --env K=V
+  CNN_CHECKPOINT: output/.../step_001000000.pkl
+
+setup:                    # raw bash lines run before the training command
+  - ./scripts/setup_worktree.sh
+  - bash scripts/slurm/hooks/link_external.sh
+
+args:                     # free mapping -> `--<key> <value>` (auto-quoted, order preserved)
+  steps: 2000000
+  output_dir: output/.../run-${SLURM_JOB_ID}
+  wandb_tags: curriculum,level2,1house,6goals
+
+smoke:                    # mode overrides; smoke.args deep-merges onto args
+  partition: gpu_h100_short
+  time: "00:30:00"
+  assert_file: metrics.csv
+  assert_min_rows: 5
+  args:
+    steps: 1500
+```
+
+### How rendering works
+
+- **`extends`** is resolved recursively (child wins; lists replace, dicts merge),
+  so `l2_vggt → l1_vggt → _base` collapses into one validated config with no
+  leftover `extends` key. Cycles are rejected.
+- **`args`** is a free mapping. Each entry renders as a `--flag value` line in
+  YAML order; flag style follows `arg_style`; values containing whitespace,
+  `$`, or `,` are quoted (matching the hand-written sbatch convention).
+- **`${TIMESTAMP}`** in any rendered value emits a `TIMESTAMP=$(date ...)` line.
+- **`${SLURM_JOB_ID}`** and other env vars are expanded by Slurm/bash at runtime.
 
 ## Config layout
 
 ```
 scripts/slurm/
 ├── configs/
-│   ├── _base.yaml          # shared sbatch directives + smoke overrides
-│   └── l1_vggt.yaml        # per-variant config (extends _base)
-├── launch.py               # render + validate
-├── launch.sh               # CLI wrapper around sbatch
-└── train.sbatch            # generic fallback sbatch (manual submit)
+│   ├── _base.yaml             # shared sbatch + smoke defaults (curriculum/training family)
+│   ├── l1_vggt.yaml           # extends _base
+│   ├── l2_vggt.yaml           # extends l1_vggt
+│   ├── l3_vggt.yaml           # extends l1_vggt
+│   ├── l4_vggt.yaml           # extends l1_vggt
+│   ├── aggregator_mlp_v1.yaml # extends _base; timestamp run id
+│   └── offline_buffer_3d25.yaml  # standalone; hyphen flags, env, setup hooks
+├── hooks/
+│   └── link_external.sh       # symlink external VGGT repos into a fresh worktree
+├── launch.py                  # render + validate
+├── launch.sh                  # CLI wrapper around sbatch (multi-variant, --env)
+└── train.sbatch               # generic fallback sbatch (manual submit)
 ```
-
-A variant config looks like:
-
-```yaml
-extends: _base
-job_name: vggt_jax
-output_dir: output/r2dreamer-curriculum-l1-vggt
-script: scripts/r2dreamer/run_jax_habitat_vggt.py
-comments:
-  - "Level 1 with VGGT 3D encoder..."
-args:
-  steps: 2000000
-  prefill: 5000
-  ...
-```
-
-`extends: _base` deep-merges with `_base.yaml`. The merged dict is then
-validated with pydantic (`LaunchConfig` in `launch.py`); missing or invalid
-fields cause a non-zero exit **before** any `sbatch` call.
 
 ## Adding a new variant
 
 1. Copy an existing config: `cp configs/l1_vggt.yaml configs/<name>.yaml`.
-2. Edit `job_name`, `output_dir`, `script`, and any `args:` overrides.
+2. Edit `job_name`, `output_dir`, `script`, and any `args:` / `smoke:` overrides.
+   Reuse a sibling via `extends:` to keep the delta tiny.
 3. Sanity check:
    ```bash
    bash scripts/slurm/launch.sh <name> --dry-run
@@ -93,11 +166,12 @@ fields cause a non-zero exit **before** any `sbatch` call.
 uv run pytest tests/slurm/test_launch.py -v
 ```
 
-Covers:
-
-- prod render is byte-equal to the legacy hand-written sbatch
-- `--smoke-then-prod` issues the prod submit with `--dependency=afterok:<smoke_jid>`
-- pydantic validation fails fast (e.g. missing `args.steps`) before any sbatch call
+Covers: l1 prod render is byte-equal to the legacy sbatch; `--smoke-then-prod`
+issues the prod submit with `--dependency=afterok:<smoke_jid>`; fail-fast
+validation before any sbatch call; recursive `extends` (incl. cycle rejection);
+L2/L3/L4 render the same training args as their legacy scripts; multi-variant
+sweep submits every variant; aggregator timestamp/strict behavior; offline-buffer
+hyphen flags, setup hooks, and `--env` override.
 
 ## Monitoring a submitted job
 

--- a/scripts/slurm/configs/_base.yaml
+++ b/scripts/slurm/configs/_base.yaml
@@ -8,6 +8,8 @@ sbatch:
 smoke:
   partition: gpu_h100_short
   time: "00:30:00"
+  assert_file: metrics.csv
+  assert_min_rows: 5
   args:
     steps: 1500
     prefill: 500

--- a/scripts/slurm/configs/aggregator_mlp_v1.yaml
+++ b/scripts/slurm/configs/aggregator_mlp_v1.yaml
@@ -1,0 +1,34 @@
+extends: _base
+job_name: agg-mlp-prod-v1
+output_dir: output/prod
+script: scripts/r2dreamer/run_jax_habitat_vggt_aggregator_mlp.py
+strict_bash: true
+comments:
+  - "Aggregator-MLP production run v1 (42h, 2M steps): pool-on-device, skip-heads"
+
+sbatch:
+  time: "42:00:00"
+
+# Replaces prod_aggregator_mlp_v1.sbatch. Run id is the timestamp (rendered into
+# a TIMESTAMP=$(date ...) line), matching the legacy script's naming.
+args:
+  steps: 2000000
+  prefill: 5000
+  seed: 42
+  log_every: 1000
+  checkpoint_every: 50000
+  output_dir: output/prod/agg-mlp-prod-v1-${TIMESTAMP}
+  wandb_name: agg-mlp-prod-v1-${TIMESTAMP}
+  wandb_tags: agg-mlp-prod-v1,pool-on-device,skip-heads,prod-42h
+
+# Replaces smoke_aggregator_mlp_fast_path.sbatch. Smoke runs on gpu_h100_short
+# (same H100 class as prod); dev_gpu_h100 aborts habitat's GL renderer (see s1).
+smoke:
+  time: "00:20:00"
+  args:
+    steps: 800
+    prefill: 200
+    checkpoint_every: 10000
+    output_dir: output/smoke/agg-mlp-fast-path-${TIMESTAMP}
+    wandb_name: agg-mlp-fast-path-smoke-${TIMESTAMP}
+    wandb_tags: agg-mlp-fast-path-smoke,smoke,short-15min,pool-on-device

--- a/scripts/slurm/configs/l1_vggt.yaml
+++ b/scripts/slurm/configs/l1_vggt.yaml
@@ -2,6 +2,7 @@ extends: _base
 job_name: vggt_jax
 output_dir: output/r2dreamer-curriculum-l1-vggt
 script: scripts/r2dreamer/run_jax_habitat_vggt.py
+curriculum_check: data/curriculum/level1_1house_1goal.json
 comments:
   - "Level 1 with VGGT 3D encoder: 1 house (fK2vEV32Lag), chair only"
   - "Replaces CNN with InfiniteVGGT streaming point cloud features"

--- a/scripts/slurm/configs/l2_vggt.yaml
+++ b/scripts/slurm/configs/l2_vggt.yaml
@@ -1,0 +1,13 @@
+extends: l1_vggt
+job_name: r2d-L2-vggt
+output_dir: output/r2dreamer-curriculum-l2-vggt
+script: scripts/r2dreamer/run_jax_habitat_l2_vggt.py
+curriculum_check: data/curriculum/level2_1house_6goals.json
+comments:
+  - "Level 2 with VGGT 3D encoder: 1 house (fK2vEV32Lag), 6 goal categories"
+args:
+  output_dir: output/r2dreamer-curriculum-l2-vggt/run-${SLURM_JOB_ID}
+  wandb_name: r2d-L2-vggt-${SLURM_JOB_ID}
+  wandb_tags: curriculum,level2,1house,6goals,vggt,jax,3d-encoder
+  val_data: data/val_replay/val_200ep.npz
+  val_loss_every: 10000

--- a/scripts/slurm/configs/l3_vggt.yaml
+++ b/scripts/slurm/configs/l3_vggt.yaml
@@ -1,0 +1,13 @@
+extends: l1_vggt
+job_name: r2d-L3-vggt
+output_dir: output/r2dreamer-curriculum-l3-vggt
+script: scripts/r2dreamer/run_jax_habitat_l3_vggt.py
+curriculum_check: data/curriculum/level3_10houses_1goal.json
+comments:
+  - "Level 3 with VGGT 3D encoder: 10 houses, chair only"
+args:
+  output_dir: output/r2dreamer-curriculum-l3-vggt/run-${SLURM_JOB_ID}
+  wandb_name: r2d-L3-vggt-${SLURM_JOB_ID}
+  wandb_tags: curriculum,level3,10houses,chair-only,vggt,jax,3d-encoder
+  val_data: data/val_replay/val_200ep.npz
+  val_loss_every: 10000

--- a/scripts/slurm/configs/l4_vggt.yaml
+++ b/scripts/slurm/configs/l4_vggt.yaml
@@ -1,0 +1,13 @@
+extends: l1_vggt
+job_name: r2d-L4-vggt
+output_dir: output/r2dreamer-curriculum-l4-vggt
+script: scripts/r2dreamer/run_jax_habitat_l4_vggt.py
+curriculum_check: data/curriculum/level4_10houses_6goals.json
+comments:
+  - "Level 4 with VGGT 3D encoder: 10 houses (4 easy, 4 medium, 2 hard) x 6 goal categories"
+args:
+  output_dir: output/r2dreamer-curriculum-l4-vggt/run-${SLURM_JOB_ID}
+  wandb_name: r2d-L4-vggt-${SLURM_JOB_ID}
+  wandb_tags: curriculum,level4,10houses,6goals,vggt,jax,3d-encoder
+  val_data: data/val_replay/val_200ep.npz
+  val_loss_every: 10000

--- a/scripts/slurm/configs/offline_buffer_3d25.yaml
+++ b/scripts/slurm/configs/offline_buffer_3d25.yaml
@@ -1,0 +1,53 @@
+# Standalone (no `extends: _base`): this is a collection job, not habitat
+# training — it uses hyphen-style flags, env vars, and a different interpreter,
+# and shares none of _base's training-arg smoke defaults.
+job_name: 3d25-offline-buffer
+output_dir: output/offline-buffer-3d25
+script: scripts/r2dreamer/collect_offline_buffer.py
+python: .venv/bin/python
+arg_style: hyphen
+strict_bash: true
+comments:
+  - "3D-25 offline buffer collection: CNN-source rollouts with VGGT readouts"
+
+sbatch:
+  partition: gpu_h100_il
+  gres: gpu:1
+  ntasks: 1
+  cpus_per_task: 8
+  mem: 96G
+  time: "12:00:00"
+
+# Heavy external VGGT repos are gitignored; symlink them from the main checkout
+# when launched from a fresh worktree (collect_offline_buffer resolves them via CWD).
+setup:
+  - ./scripts/setup_worktree.sh
+  - bash scripts/slurm/hooks/link_external.sh
+
+# CNN checkpoint that seeds the rollout policy. Override per run:
+#   launch.sh offline_buffer_3d25 --env CNN_CHECKPOINT=output/.../step_xxx.pkl
+env:
+  CNN_CHECKPOINT: output/r2dreamer-curriculum-l1/run-4367942/checkpoints/step_001000000.pkl
+
+args:
+  checkpoint: ${CNN_CHECKPOINT}
+  n_steps: 400000
+  collect_seed: 42
+  out_dir: data/offline_buffer
+  curriculum_path: data/curriculum/level1_1house_1goal.json
+  curriculum_mode: train
+  wandb_project: 3d-vla-objectnav
+  wandb_name: 3d25-offline-buffer-${SLURM_JOB_ID}
+  wandb_tags: offline-buffer,3d-25,3d-26,cnn-source,vggt-readouts
+  wandb_init_timeout: 600
+  log_every: 1000
+  wandb_log_every: 1000
+  skeleton_flush_every: 10000
+
+# dev/smoke: short collection. gpu_h100_short per the s1 finding that
+# dev_gpu_h100 aborts habitat's GL renderer during prefill.
+smoke:
+  partition: gpu_h100_short
+  time: "00:30:00"
+  args:
+    n_steps: 5000

--- a/scripts/slurm/hooks/link_external.sh
+++ b/scripts/slurm/hooks/link_external.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Symlink the heavy, gitignored external VGGT repos from the main checkout into
+# the current worktree. The JAX VGGT loader resolves InfiniteVGGT/StreamVGGT/VGGT
+# relative to CWD, so a job launched from a fresh worktree needs these links.
+#
+# Idempotent: skips links that already exist. A no-op in the main checkout
+# (where target and link resolve to the same path).
+set -euo pipefail
+
+git_common_dir="$(git rev-parse --git-common-dir)"
+main_root="$(realpath "${git_common_dir}/..")"
+
+mkdir -p external
+for name in InfiniteVGGT StreamVGGT VGGT; do
+    target="${main_root}/external/${name}"
+    link="external/${name}"
+    if [ ! -e "${link}" ] && [ -e "${target}" ]; then
+        ln -s "$(realpath --relative-to external "${target}")" "${link}"
+        echo "linked ${link} -> $(readlink "${link}")"
+    fi
+done

--- a/scripts/slurm/launch.py
+++ b/scripts/slurm/launch.py
@@ -1,5 +1,17 @@
 #!/usr/bin/env python3
-"""Render and validate YAML-backed Slurm launch configs."""
+"""Render and validate YAML-backed Slurm launch configs.
+
+One universal renderer turns a per-variant YAML config (optionally extending a
+base via ``extends:``) into a complete sbatch script. ``launch.sh`` pipes the
+rendered script to ``sbatch``. Validation is fail-fast: a malformed config
+raises *before* any job is submitted.
+
+The schema is intentionally job-family-agnostic. A config supplies a ``script``
+entrypoint plus a free-form ``args`` mapping; the renderer turns each ``args``
+entry into a ``--flag value`` line (hyphen- or underscore-styled, auto-quoted).
+Optional ``env``/``setup``/``curriculum_check`` blocks cover env vars, pre-run
+hooks, and the curriculum-generation guard used by the habitat training jobs.
+"""
 
 from __future__ import annotations
 
@@ -15,23 +27,12 @@ from ruamel.yaml import YAML
 
 ROOT = Path(__file__).resolve().parents[2]
 CONFIG_DIR = ROOT / "scripts" / "slurm" / "configs"
-ARG_ORDER = (
-    "steps",
-    "prefill",
-    "checkpoint_every",
-    "output_dir",
-    "seed",
-    "log_every",
-    "wandb_project",
-    "wandb_name",
-    "wandb_tags",
-    "render_resolution",
-)
-QUOTE_ARGS = {"output_dir", "seed", "wandb_name", "wandb_tags"}
+
+Mode = Literal["prod", "smoke"]
 
 
 class SbatchConfig(BaseModel):
-    """SBATCH directives shared by all modes."""
+    """#SBATCH resource directives shared by all modes."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -43,61 +44,63 @@ class SbatchConfig(BaseModel):
     time: str
 
 
-class ArgsConfig(BaseModel):
-    """Training arguments forwarded to the Python training entrypoint."""
-
-    model_config = ConfigDict(extra="allow")
-
-    steps: int = Field(..., gt=0)
-    prefill: int = Field(..., ge=0)
-    checkpoint_every: int = Field(..., gt=0)
-    output_dir: str
-    seed: str | int
-    log_every: int = Field(..., gt=0)
-    wandb_project: str
-    wandb_name: str
-    wandb_tags: str
-    render_resolution: int = Field(..., gt=0)
-
-
 class SmokeConfig(BaseModel):
-    """Mode-specific overrides for dev-cluster smoke submissions."""
+    """Mode-specific overrides for short dev-cluster smoke submissions."""
 
     model_config = ConfigDict(extra="forbid")
 
-    partition: str = "dev_gpu_h100"
+    partition: str = "gpu_h100_short"
     time: str = "00:30:00"
     args: dict[str, Any] = Field(default_factory=dict)
+    assert_file: str | None = None  # path under the run dir the smoke must produce
+    assert_min_rows: int | None = None  # minimum `wc -l` for assert_file (if a table)
 
 
 class LaunchConfig(BaseModel):
-    """Fully merged launch config."""
+    """Fully merged + validated launch config for one variant."""
 
     model_config = ConfigDict(extra="forbid")
 
     job_name: str
-    output_dir: str
-    script: str
+    output_dir: str  # directory for #SBATCH logs (the run dir lives in args)
+    script: str  # repo-relative python entrypoint
     sbatch: SbatchConfig
-    args: ArgsConfig
+
+    python: str = "uv run python"  # interpreter prefix (e.g. ".venv/bin/python")
+    arg_style: Literal["underscore", "hyphen"] = "underscore"
+    strict_bash: bool = False  # emit `set -euo pipefail` in prod too (always on for smoke)
+    curriculum_check: str | None = None  # json path; emits a generate-if-missing guard
+
+    args: dict[str, Any] = Field(default_factory=dict)
+    env: dict[str, str] = Field(default_factory=dict)
+    setup: list[str] = Field(default_factory=list)  # raw bash lines run before training
     comments: list[str] = Field(default_factory=list)
     smoke: SmokeConfig = Field(default_factory=SmokeConfig)
 
     @field_validator("script")
     @classmethod
-    def script_must_be_relative(cls, value: str) -> str:
+    def _script_relative(cls, value: str) -> str:
         if Path(value).is_absolute():
             raise ValueError("script must be repo-relative")
         return value
 
+    @field_validator("args")
+    @classmethod
+    def _args_scalar(cls, value: dict[str, Any]) -> dict[str, Any]:
+        for key, item in value.items():
+            if isinstance(item, (dict, list)):
+                raise ValueError(
+                    f"args.{key} must be a scalar (str/int/float/bool), got {type(item).__name__}"
+                )
+        return value
+
 
 def _deep_merge(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge ``overlay`` onto ``base`` (overlay wins; lists replace)."""
+
     merged = copy.deepcopy(base)
     for key, value in overlay.items():
-        if (
-            isinstance(value, dict)
-            and isinstance(merged.get(key), dict)
-        ):
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
             merged[key] = _deep_merge(merged[key], value)
         else:
             merged[key] = copy.deepcopy(value)
@@ -113,19 +116,36 @@ def _read_yaml(path: Path) -> dict[str, Any]:
     return data
 
 
-def load_config(name: str) -> LaunchConfig:
-    """Load, merge, and validate a launch config by variant name."""
-
+def _config_path(name: str) -> Path:
     if "/" in name or name.startswith("."):
         raise ValueError(f"Invalid variant name: {name!r}")
+    if not name.endswith(".yaml"):
+        name = f"{name}.yaml"
+    return CONFIG_DIR / name
 
-    raw = _read_yaml(CONFIG_DIR / f"{name}.yaml")
+
+def _resolve_raw(name: str, _seen: tuple[str, ...] = ()) -> dict[str, Any]:
+    """Read a config and recursively merge its full ``extends:`` chain."""
+
+    if name in _seen:
+        chain = " -> ".join((*_seen, name))
+        raise ValueError(f"Circular extends chain: {chain}")
+    raw = _read_yaml(_config_path(name))
     parent = raw.pop("extends", None)
     if parent:
-        parent_name = str(parent)
-        if not parent_name.endswith(".yaml"):
-            parent_name = f"{parent_name}.yaml"
-        raw = _deep_merge(_read_yaml(CONFIG_DIR / parent_name), raw)
+        parent_raw = _resolve_raw(str(parent), (*_seen, name))
+        raw = _deep_merge(parent_raw, raw)
+    return raw
+
+
+def load_config(name: str, *, env_overrides: dict[str, str] | None = None) -> LaunchConfig:
+    """Load, merge, and validate a launch config by variant name."""
+
+    raw = _resolve_raw(name)
+    if env_overrides:
+        merged_env = dict(raw.get("env") or {})
+        merged_env.update(env_overrides)
+        raw["env"] = merged_env
 
     try:
         return LaunchConfig.model_validate(raw)
@@ -133,28 +153,51 @@ def load_config(name: str) -> LaunchConfig:
         raise ValueError(f"Invalid Slurm config for {name!r}:\n{exc}") from exc
 
 
-def _mode_config(config: LaunchConfig, mode: Literal["prod", "smoke"]) -> tuple[SbatchConfig, dict[str, Any]]:
+def _resolve_mode(config: LaunchConfig, mode: Mode) -> tuple[SbatchConfig, dict[str, Any]]:
     sbatch = config.sbatch.model_copy(deep=True)
-    args = dict(config.args.model_dump())
+    args = dict(config.args)
     if mode == "smoke":
         sbatch.partition = config.smoke.partition
         sbatch.time = config.smoke.time
-        args.update(config.smoke.args)
+        args.update(config.smoke.args)  # in-place for existing keys, preserving order
     return sbatch, args
 
 
-def _format_arg(name: str, value: Any) -> str:
+def _flag(name: str, arg_style: str) -> str:
+    if arg_style == "hyphen":
+        name = name.replace("_", "-")
+    return f"--{name}"
+
+
+def _needs_quote(value: str) -> bool:
+    """Quote shell-significant values (matches the hand-written sbatch convention)."""
+
+    return value == "" or any(ch in value for ch in " \t$,")
+
+
+def _format_arg(name: str, value: Any, arg_style: str) -> str:
     rendered = str(value)
-    if name in QUOTE_ARGS:
+    if _needs_quote(rendered):
         rendered = f'"{rendered}"'
-    return f"    --{name} {rendered}"
+    return f"    {_flag(name, arg_style)} {rendered}"
 
 
-def render_sbatch(config: LaunchConfig, *, mode: Literal["prod", "smoke"] = "prod") -> str:
-    """Render an sbatch script."""
+def _python_cmd(config: LaunchConfig, mode: Mode) -> str:
+    # Skip the (slow) dependency resync for the default uv interpreter on smokes.
+    if mode == "smoke" and config.python == "uv run python":
+        return "uv run --no-sync python"
+    return config.python
 
-    sbatch, args = _mode_config(config, mode)
-    output_dir = config.output_dir if mode == "prod" else f"{config.output_dir}/smoke"
+
+def _run_dir(args: dict[str, Any], config: LaunchConfig) -> str:
+    return str(args.get("output_dir") or args.get("out_dir") or config.output_dir)
+
+
+def render_sbatch(config: LaunchConfig, *, mode: Mode = "prod") -> str:
+    """Render a complete sbatch script for ``mode`` ("prod" or "smoke")."""
+
+    sbatch, args = _resolve_mode(config, mode)
+    log_dir = config.output_dir if mode == "prod" else f"{config.output_dir}/smoke"
     job_name = config.job_name if mode == "prod" else f"smoke-{config.job_name}"
 
     lines = [
@@ -166,15 +209,16 @@ def render_sbatch(config: LaunchConfig, *, mode: Literal["prod", "smoke"] = "pro
         f"#SBATCH --cpus-per-task={sbatch.cpus_per_task}",
         f"#SBATCH --mem={sbatch.mem}",
         f"#SBATCH --time={sbatch.time}",
-        f"#SBATCH --output={output_dir}/slurm-%j.out",
-        f"#SBATCH --error={output_dir}/slurm-%j.err",
+        f"#SBATCH --output={log_dir}/slurm-%j.out",
+        f"#SBATCH --error={log_dir}/slurm-%j.err",
         "",
     ]
 
+    if config.strict_bash or mode == "smoke":
+        lines.extend(["set -euo pipefail", ""])
+
     if mode == "smoke":
         lines.extend([
-            "set -euo pipefail",
-            "",
             "export WANDB_MODE=offline",
             "export PYTHONFAULTHANDLER=1",
             # Reduce JAX/habitat CUDA contention on short queues
@@ -183,46 +227,70 @@ def render_sbatch(config: LaunchConfig, *, mode: Literal["prod", "smoke"] = "pro
             "",
         ])
 
+    lines.extend([f"mkdir -p {log_dir}", ""])
     lines.extend([
-        f"mkdir -p {output_dir}",
-        "",
         'echo "Job $SLURM_JOB_ID on $(hostname) at $(date)"',
-        'echo "GPU: $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || echo \'N/A\')"',
-        "",
-        "# Generate curriculum configs if not present",
-        "if [ ! -f data/curriculum/level1_1house_1goal.json ]; then",
-        '    echo "Generating curriculum configs..."',
-        "    uv run python scripts/environments/generate_curriculum.py",
-        "fi",
+        "echo \"GPU: $(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null || echo 'N/A')\"",
         "",
     ])
 
-    for comment in config.comments:
-        lines.append(f"# {comment}")
+    # Define TIMESTAMP only when a rendered value references it.
+    referenced = [*args.values(), *config.env.values()]
+    if any("${TIMESTAMP}" in str(v) for v in referenced):
+        lines.extend(["TIMESTAMP=$(date +%Y%m%d-%H%M%S)", ""])
 
-    train_cmd = "uv run --no-sync python" if mode == "smoke" else "uv run python"
-    lines.append(f"{train_cmd} {config.script} \\")
-    arg_lines = [_format_arg(name, args[name]) for name in ARG_ORDER]
-    for line in arg_lines[:-1]:
-        lines.append(f"{line} \\")
-    lines.append(arg_lines[-1])
+    if config.env:
+        lines.extend(f'export {key}="{value}"' for key, value in config.env.items())
+        lines.append("")
 
-    if mode == "smoke":
-        smoke_output = args["output_dir"]
+    if config.setup:
+        lines.extend(config.setup)
+        lines.append("")
+
+    if config.curriculum_check:
+        lines.extend([
+            "# Generate curriculum configs if not present",
+            f"if [ ! -f {config.curriculum_check} ]; then",
+            '    echo "Generating curriculum configs..."',
+            "    uv run python scripts/environments/generate_curriculum.py",
+            "fi",
+            "",
+        ])
+
+    lines.extend(f"# {comment}" for comment in config.comments)
+
+    python_cmd = _python_cmd(config, mode)
+    arg_lines = [_format_arg(name, value, config.arg_style) for name, value in args.items()]
+    if arg_lines:
+        lines.append(f"{python_cmd} {config.script} \\")
+        lines.extend(f"{line} \\" for line in arg_lines[:-1])
+        lines.append(arg_lines[-1])
+    else:
+        lines.append(f"{python_cmd} {config.script}")
+
+    if mode == "smoke" and config.smoke.assert_file:
+        run_dir = _run_dir(args, config)
+        target = f"{run_dir}/{config.smoke.assert_file}"
         lines.extend([
             "",
-            f'if [ ! -f "{smoke_output}/metrics.csv" ]; then',
-            f'    echo "[FAIL] metrics.csv missing in {smoke_output}" >&2',
+            f'if [ ! -f "{target}" ]; then',
+            f'    echo "[FAIL] {config.smoke.assert_file} missing in {run_dir}" >&2',
             "    exit 1",
             "fi",
-            f'if [ "$(wc -l < "{smoke_output}/metrics.csv")" -lt 5 ]; then',
-            f'    echo "[FAIL] metrics.csv has fewer than 5 rows in {smoke_output}" >&2',
-            "    exit 1",
-            "fi",
+        ])
+        if config.smoke.assert_min_rows is not None:
+            lines.extend([
+                f'if [ "$(wc -l < "{target}")" -lt {config.smoke.assert_min_rows} ]; then',
+                f'    echo "[FAIL] {config.smoke.assert_file} has fewer than '
+                f'{config.smoke.assert_min_rows} rows in {run_dir}" >&2',
+                "    exit 1",
+                "fi",
+            ])
+        lines.extend([
             "",
             'echo "=== Smoke PASS ==="',
-            f'echo "metrics.csv lines: $(wc -l < "{smoke_output}/metrics.csv")"',
-            f'echo "Output: {smoke_output}"',
+            f'echo "{config.smoke.assert_file} lines: $(wc -l < "{target}")"',
+            f'echo "Output: {run_dir}"',
         ])
 
     return "\n".join(lines) + "\n"
@@ -232,15 +300,30 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("variant")
     parser.add_argument("--mode", choices=["prod", "smoke"], default="prod")
-    args = parser.parse_args(argv)
+    parser.add_argument(
+        "--env",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="override an env var (repeatable); wins over the YAML default",
+    )
+    ns = parser.parse_args(argv)
+
+    env_overrides: dict[str, str] = {}
+    for item in ns.env:
+        if "=" not in item:
+            print(f"launch.py: --env expects KEY=VALUE, got {item!r}", file=sys.stderr)
+            return 2
+        key, value = item.split("=", 1)
+        env_overrides[key] = value
 
     try:
-        config = load_config(args.variant)
+        config = load_config(ns.variant, env_overrides=env_overrides)
     except Exception as exc:
         print(f"launch.py: {exc}", file=sys.stderr)
         return 2
 
-    print(render_sbatch(config, mode=args.mode), end="")
+    print(render_sbatch(config, mode=ns.mode), end="")
     return 0
 
 

--- a/scripts/slurm/launch.sh
+++ b/scripts/slurm/launch.sh
@@ -3,13 +3,18 @@ set -euo pipefail
 
 usage() {
     cat >&2 <<'EOF'
-Usage: scripts/slurm/launch.sh <variant> [--smoke | --prod | --smoke-then-prod] [--dry-run]
+Usage: scripts/slurm/launch.sh <variant>... [--smoke | --prod | --smoke-then-prod] [--env K=V]... [--dry-run]
+
+Variants:
+  One or more config names (scripts/slurm/configs/<variant>.yaml). Bash brace
+  expansion sweeps work, e.g.  launch.sh l{1,2,3,4}_vggt --smoke
 
 Modes:
   --prod             submit the production job (default)
-  --smoke            submit a dev_gpu_h100 smoke job
-  --smoke-then-prod  submit smoke, then production with afterok dependency
-  --dry-run          render the sbatch script instead of calling sbatch
+  --smoke            submit a short dev-cluster smoke job
+  --smoke-then-prod  submit smoke, then production with an afterok dependency
+  --env K=V          override a config env var (repeatable); wins over the YAML
+  --dry-run          render the sbatch script(s) instead of calling sbatch
 EOF
 }
 
@@ -20,53 +25,46 @@ if [[ ! -x "$python_bin" ]]; then
     python_bin="python"
 fi
 
-if [[ $# -lt 1 ]]; then
-    usage
-    exit 2
-fi
-
-variant="$1"
-shift
+variants=()
+env_args=()
 mode="prod"
 dry_run=0
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --smoke)
-            mode="smoke"
+        --smoke)            mode="smoke" ;;
+        --prod)             mode="prod" ;;
+        --smoke-then-prod)  mode="smoke-then-prod" ;;
+        --dry-run)          dry_run=1 ;;
+        --env)
+            shift
+            [[ $# -gt 0 ]] || { echo "--env requires KEY=VALUE" >&2; exit 2; }
+            env_args+=(--env "$1")
             ;;
-        --prod)
-            mode="prod"
-            ;;
-        --smoke-then-prod)
-            mode="smoke-then-prod"
-            ;;
-        --dry-run)
-            dry_run=1
-            ;;
-        -h|--help)
-            usage
-            exit 0
-            ;;
-        *)
-            echo "Unknown argument: $1" >&2
-            usage
-            exit 2
-            ;;
+        --env=*)            env_args+=(--env "${1#--env=}") ;;
+        -h|--help)          usage; exit 0 ;;
+        --*)                echo "Unknown option: $1" >&2; usage; exit 2 ;;
+        *)                  variants+=("$1") ;;
     esac
     shift
 done
 
+if [[ ${#variants[@]} -lt 1 ]]; then
+    usage
+    exit 2
+fi
+
 render() {
-    local render_mode="$1"
-    "$python_bin" scripts/slurm/launch.py "$variant" --mode "$render_mode"
+    local variant="$1" render_mode="$2"
+    "$python_bin" scripts/slurm/launch.py "$variant" --mode "$render_mode" \
+        ${env_args[@]+"${env_args[@]}"}
 }
 
 submit() {
-    local submit_mode="$1"
-    shift
+    local variant="$1" submit_mode="$2"
+    shift 2
     local script
-    script="$(render "$submit_mode")"
+    script="$(render "$variant" "$submit_mode")"
     local render_status=$?
     if [[ "$render_status" -ne 0 ]]; then
         return "$render_status"
@@ -74,33 +72,35 @@ submit() {
     sbatch --parsable "$@" <<< "$script"
 }
 
-case "$mode:$dry_run" in
-    prod:1)
-        render prod
-        ;;
-    smoke:1)
-        render smoke
-        ;;
-    smoke-then-prod:1)
-        echo "# smoke"
-        render smoke
-        echo "# prod"
-        render prod
-        ;;
-    prod:0)
-        prod_jid="$(submit prod)"
-        echo "[prod] jid=${prod_jid}"
-        ;;
-    smoke:0)
-        smoke_jid="$(submit smoke)"
-        echo "[smoke] jid=${smoke_jid}"
-        echo "watch: squeue -j ${smoke_jid}"
-        ;;
-    smoke-then-prod:0)
-        smoke_jid="$(submit smoke)"
-        prod_jid="$(submit prod --dependency="afterok:${smoke_jid}" --kill-on-invalid-dep=yes)"
-        echo "[smoke] jid=${smoke_jid}"
-        echo "[prod]  jid=${prod_jid} (afterok:${smoke_jid})"
-        echo "watch: squeue -j ${smoke_jid},${prod_jid}"
-        ;;
-esac
+for variant in "${variants[@]}"; do
+    case "$mode:$dry_run" in
+        prod:1)
+            render "$variant" prod
+            ;;
+        smoke:1)
+            render "$variant" smoke
+            ;;
+        smoke-then-prod:1)
+            echo "# ${variant} smoke"
+            render "$variant" smoke
+            echo "# ${variant} prod"
+            render "$variant" prod
+            ;;
+        prod:0)
+            prod_jid="$(submit "$variant" prod)"
+            echo "[${variant} prod] jid=${prod_jid}"
+            ;;
+        smoke:0)
+            smoke_jid="$(submit "$variant" smoke)"
+            echo "[${variant} smoke] jid=${smoke_jid}"
+            echo "  watch: squeue -j ${smoke_jid}"
+            ;;
+        smoke-then-prod:0)
+            smoke_jid="$(submit "$variant" smoke)"
+            prod_jid="$(submit "$variant" prod --dependency="afterok:${smoke_jid}" --kill-on-invalid-dep=yes)"
+            echo "[${variant} smoke] jid=${smoke_jid}"
+            echo "[${variant} prod]  jid=${prod_jid} (afterok:${smoke_jid})"
+            echo "  watch: squeue -j ${smoke_jid},${prod_jid}"
+            ;;
+    esac
+done

--- a/tests/slurm/test_launch.py
+++ b/tests/slurm/test_launch.py
@@ -1,22 +1,66 @@
 from __future__ import annotations
 
+import importlib.util
+import os
 import shutil
 import subprocess
-import os
+import sys
 from pathlib import Path
+
+import pytest
 
 
 ROOT = Path(__file__).resolve().parents[2]
+CONFIG_DIR = ROOT / "scripts/slurm/configs"
 
 
-def run_launch(*args: str) -> subprocess.CompletedProcess[str]:
+def _load_launch_module():
+    spec = importlib.util.spec_from_file_location("slurm_launch", ROOT / "scripts/slurm/launch.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so pydantic can resolve the deferred (PEP 563)
+    # forward refs (SbatchConfig/SmokeConfig) via sys.modules at validate time.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+launch = _load_launch_module()
+
+
+def run_launch(*args: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["bash", "scripts/slurm/launch.sh", *args],
         cwd=ROOT,
         check=False,
         text=True,
         capture_output=True,
+        env={**os.environ, **(env or {})},
     )
+
+
+def training_command(text: str) -> tuple[str, str, dict[str, str]]:
+    """Extract (python_cmd, script, {flag: value}) from a rendered sbatch's
+    training invocation (the python line followed by `--flag value` continuations)."""
+
+    lines = text.splitlines()
+    idx = next(i for i, line in enumerate(lines) if line.rstrip().endswith(".py \\"))
+    head = lines[idx].strip().rstrip(" \\")
+    script = head.split()[-1]
+    python_cmd = " ".join(head.split()[:-1])
+    flags: dict[str, str] = {}
+    for line in lines[idx + 1:]:
+        stripped = line.strip().rstrip(" \\")
+        if not stripped.startswith("--"):
+            break
+        flag, _, value = stripped.partition(" ")
+        flags[flag] = value.strip().strip('"')
+    return python_cmd, script, flags
+
+
+# --------------------------------------------------------------------------- #
+# s1 — preserved contract                                                      #
+# --------------------------------------------------------------------------- #
 
 
 def test_l1_vggt_dry_run_matches_legacy_sbatch() -> None:
@@ -38,18 +82,10 @@ def test_smoke_then_prod_uses_afterok_dependency_before_prod_submit(tmp_path: Pa
     )
     fake_sbatch.chmod(0o755)
 
-    env = {
-        **os.environ,
-        "PATH": f"{tmp_path}:{os.environ['PATH']}",
-        "SBATCH_CALLS": str(calls_file),
-    }
-    result = subprocess.run(
-        ["bash", "scripts/slurm/launch.sh", "l1_vggt", "--smoke-then-prod"],
-        cwd=ROOT,
-        check=False,
-        text=True,
-        capture_output=True,
-        env=env,
+    result = run_launch(
+        "l1_vggt",
+        "--smoke-then-prod",
+        env={"PATH": f"{tmp_path}:{os.environ['PATH']}", "SBATCH_CALLS": str(calls_file)},
     )
 
     assert result.returncode == 0, result.stderr
@@ -58,24 +94,17 @@ def test_smoke_then_prod_uses_afterok_dependency_before_prod_submit(tmp_path: Pa
     assert calls[1] == "--parsable --dependency=afterok:1 --kill-on-invalid-dep=yes"
 
 
-def test_missing_steps_fails_validation_before_sbatch(tmp_path: Path) -> None:
-    config_dir = ROOT / "scripts/slurm/configs"
-    broken = config_dir / "missing_steps.yaml"
+def test_missing_required_field_fails_validation_before_sbatch(tmp_path: Path) -> None:
+    """A config missing a required structural field (script) must fail fast,
+    before any sbatch process is started."""
+
+    broken = CONFIG_DIR / "broken_missing_script.yaml"
     broken.write_text(
         "extends: _base\n"
         "job_name: broken\n"
         "output_dir: output/broken\n"
-        "script: scripts/r2dreamer/run_jax_habitat_vggt.py\n"
         "args:\n"
-        "  prefill: 5000\n"
-        "  checkpoint_every: 100000\n"
-        "  output_dir: output/broken/run-${SLURM_JOB_ID}\n"
-        "  seed: ${SLURM_JOB_ID}\n"
-        "  log_every: 250\n"
-        "  wandb_project: 3d-vla-objectnav\n"
-        "  wandb_name: broken-${SLURM_JOB_ID}\n"
-        "  wandb_tags: broken\n"
-        "  render_resolution: 518\n"
+        "  steps: 100\n"
     )
 
     fake_sbatch = tmp_path / "sbatch"
@@ -83,21 +112,154 @@ def test_missing_steps_fails_validation_before_sbatch(tmp_path: Path) -> None:
     fake_sbatch.chmod(0o755)
 
     try:
-        result = subprocess.run(
-            ["bash", "scripts/slurm/launch.sh", "missing_steps"],
-            cwd=ROOT,
-            check=False,
-            text=True,
-            capture_output=True,
-            env={
-                **os.environ,
-                "PATH": f"{tmp_path}:{os.environ['PATH']}",
-            },
+        result = run_launch(
+            "broken_missing_script",
+            env={"PATH": f"{tmp_path}:{os.environ['PATH']}"},
         )
     finally:
         broken.unlink(missing_ok=True)
 
-    assert result.returncode == 2
-    assert "args.steps" in result.stderr
+    assert result.returncode == 2  # validation error, not the fake sbatch's 88
+    assert "script" in result.stderr
     assert "Field required" in result.stderr
     assert shutil.which("sbatch", path=str(tmp_path)) is not None
+
+
+# --------------------------------------------------------------------------- #
+# s2 — curriculum L2/L3/L4 via recursive `extends`                             #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "variant,legacy",
+    [
+        ("l2_vggt", "scripts/r2dreamer/slurm/train_curriculum_l2_vggt.sbatch"),
+        ("l3_vggt", "scripts/r2dreamer/slurm/train_curriculum_l3_vggt.sbatch"),
+        ("l4_vggt", "scripts/r2dreamer/slurm/train_curriculum_l4_vggt.sbatch"),
+    ],
+)
+def test_curriculum_variants_match_legacy_args(variant: str, legacy: str) -> None:
+    """Each L2/L3/L4 config extends l1_vggt and renders the same training
+    command + identical flags as its hand-written sbatch (order-insensitive)."""
+
+    rendered = launch.render_sbatch(launch.load_config(variant), mode="prod")
+    r_python, r_script, r_flags = training_command(rendered)
+    l_python, l_script, l_flags = training_command((ROOT / legacy).read_text())
+
+    assert r_python == l_python == "uv run python"
+    assert r_script == l_script
+    assert r_flags == l_flags
+
+
+def test_extends_chain_is_recursive() -> None:
+    """l2_vggt -> l1_vggt -> _base must fully resolve (no leftover `extends`)."""
+
+    config = launch.load_config("l2_vggt")
+    # Inherited from _base via l1_vggt:
+    assert config.sbatch.gres == "gpu:1"
+    assert config.args["render_resolution"] == 518
+    # Own override:
+    assert config.script.endswith("run_jax_habitat_l2_vggt.py")
+    assert config.args["val_data"] == "data/val_replay/val_200ep.npz"
+
+
+def test_circular_extends_is_rejected(tmp_path: Path) -> None:
+    a = CONFIG_DIR / "cycle_a.yaml"
+    b = CONFIG_DIR / "cycle_b.yaml"
+    a.write_text("extends: cycle_b\njob_name: a\noutput_dir: o\nscript: s.py\n")
+    b.write_text("extends: cycle_a\njob_name: b\noutput_dir: o\nscript: s.py\n")
+    try:
+        with pytest.raises(ValueError, match="Circular extends"):
+            launch.load_config("cycle_a")
+    finally:
+        a.unlink(missing_ok=True)
+        b.unlink(missing_ok=True)
+
+
+def test_sweep_submits_every_variant(tmp_path: Path) -> None:
+    calls_file = tmp_path / "calls.txt"
+    fake_sbatch = tmp_path / "sbatch"
+    fake_sbatch.write_text(
+        "#!/usr/bin/env bash\ncat >/dev/null\nprintf 'x\\n' >> \"$SBATCH_CALLS\"\nwc -l < \"$SBATCH_CALLS\"\n"
+    )
+    fake_sbatch.chmod(0o755)
+
+    result = run_launch(
+        "l1_vggt", "l2_vggt", "l3_vggt", "l4_vggt", "--smoke",
+        env={"PATH": f"{tmp_path}:{os.environ['PATH']}", "SBATCH_CALLS": str(calls_file)},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert len(calls_file.read_text().splitlines()) == 4
+
+
+# --------------------------------------------------------------------------- #
+# s3 — aggregator-MLP family (variable args, timestamp naming)                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_aggregator_prod_args() -> None:
+    rendered = launch.render_sbatch(launch.load_config("aggregator_mlp_v1"), mode="prod")
+    python_cmd, script, flags = training_command(rendered)
+
+    assert python_cmd == "uv run python"
+    assert script.endswith("run_jax_habitat_vggt_aggregator_mlp.py")
+    assert flags["--steps"] == "2000000"
+    assert flags["--prefill"] == "5000"
+    assert flags["--checkpoint_every"] == "50000"
+    assert flags["--wandb_tags"] == "agg-mlp-prod-v1,pool-on-device,skip-heads,prod-42h"
+    # No wandb_project / render_resolution for this script family.
+    assert "--wandb_project" not in flags
+    assert "--render_resolution" not in flags
+    # Timestamp-based run id requires a TIMESTAMP definition in the script body.
+    assert "TIMESTAMP=$(date +%Y%m%d-%H%M%S)" in rendered
+    assert flags["--output_dir"] == "output/prod/agg-mlp-prod-v1-${TIMESTAMP}"
+
+
+def test_aggregator_smoke_overrides() -> None:
+    rendered = launch.render_sbatch(launch.load_config("aggregator_mlp_v1"), mode="smoke")
+    _, _, flags = training_command(rendered)
+
+    assert flags["--steps"] == "800"
+    assert flags["--prefill"] == "200"
+    assert "#SBATCH --time=00:20:00" in rendered
+    assert "agg-mlp-fast-path-smoke" in flags["--wandb_tags"]
+
+
+def test_aggregator_prod_is_strict_bash() -> None:
+    rendered = launch.render_sbatch(launch.load_config("aggregator_mlp_v1"), mode="prod")
+    assert "set -euo pipefail" in rendered
+
+
+# --------------------------------------------------------------------------- #
+# s4 — offline-buffer collector (hyphen flags, env, setup hooks)               #
+# --------------------------------------------------------------------------- #
+
+
+def test_offline_buffer_uses_hyphen_flags_and_venv_python() -> None:
+    rendered = launch.render_sbatch(launch.load_config("offline_buffer_3d25"), mode="prod")
+    python_cmd, script, flags = training_command(rendered)
+
+    assert python_cmd == ".venv/bin/python"
+    assert script.endswith("collect_offline_buffer.py")
+    assert flags["--n-steps"] == "400000"
+    assert flags["--collect-seed"] == "42"
+    assert flags["--out-dir"] == "data/offline_buffer"
+    assert flags["--skeleton-flush-every"] == "10000"
+    assert flags["--checkpoint"] == "${CNN_CHECKPOINT}"
+
+
+def test_offline_buffer_setup_hooks_present() -> None:
+    rendered = launch.render_sbatch(launch.load_config("offline_buffer_3d25"), mode="prod")
+    assert "./scripts/setup_worktree.sh" in rendered
+    assert "bash scripts/slurm/hooks/link_external.sh" in rendered
+
+
+def test_offline_buffer_env_override_wins_over_yaml_default() -> None:
+    custom = "output/custom/run-9/checkpoints/step_x.pkl"
+    config = launch.load_config("offline_buffer_3d25", env_overrides={"CNN_CHECKPOINT": custom})
+    rendered = launch.render_sbatch(config, mode="smoke")
+    assert f'export CNN_CHECKPOINT="{custom}"' in rendered
+    # Smoke also reduces the step budget.
+    _, _, flags = training_command(rendered)
+    assert flags["--n-steps"] == "5000"


### PR DESCRIPTION
Implements the three remaining slices of **3D-29** (SBATCH consolidation, Option B): **3D-31 (s2)**, **3D-32 (s3)**, **3D-33 (s4)**. Builds on the merged s1 (#154).

## Approach

s1's `launch.py` was a curriculum-VGGT–specific *byte-faithful* renderer (fixed `ARG_ORDER`, hardcoded required args, single-hop `extends`). Covering the aggregator and offline-buffer families required **generalizing it into a config-driven renderer** (decision: *functional equivalence* for s3/s4, keep s1's l1 contract). `l1_vggt`'s prod render stays **byte-identical** (pinned by the existing test).

### `launch.py`
- Recursive `extends` chains (`l2 → l1_vggt → _base`), cycle-rejecting
- Order-preserving free-dict `args` with auto-quoting + `arg_style` (underscore/hyphen)
- Optional `env` / `setup` / `curriculum_check` / `strict_bash` / `python` fields
- `${TIMESTAMP}` helper; configurable smoke file assertion (`assert_file`/`assert_min_rows`)

### `launch.sh`
- Multi-variant sweeps: `launch.sh l{1,2,3,4}_vggt --smoke`
- Repeatable `--env K=V` passthrough (wins over YAML)

### New configs / hook
`l2_vggt`, `l3_vggt`, `l4_vggt` (extend `l1_vggt`), `aggregator_mlp_v1` (timestamp run id, strict bash, no `wandb_project`/`render_resolution`), `offline_buffer_3d25` (standalone; hyphen flags, env, setup hooks), `hooks/link_external.sh`.

## Acceptance criteria

| AC | Status |
|---|---|
| s2: L2/L3/L4 render identical training args to legacy | ✅ verified (12 flags each) |
| s2: sweep submits all four in one shell call | ✅ verified |
| s2: `diff(l1.yaml, l2.yaml) < 10` | ⚠️ 35 lines — driven by `l1.yaml` being the verbose root; **l2.yaml itself is 13 lines**. The "<10" premise assumed both files were lean, which doesn't hold in s1's inherited schema. Spirit (l2 = tiny delta) met. |
| s3: aggregator replaces prod (identical args) + smoke replicates fast-path | ✅ verified both modes |
| s4: offline-buffer replaces collect incl. external/ symlink setup hook | ✅ verified (hook runs) |
| s4: `--env CNN_CHECKPOINT=…` wins over YAML default | ✅ verified |
| Live-cluster ACs (real smoke→prod chains, ≥1h prod logs, `episode.npz`) | ⏳ require running on the HPC |

## Decisions
- **Functional equivalence** for s3/s4: dropped warts (hardcoded `WORKTREE` cd, git-provenance echoes). Args, SBATCH directives, and effective command preserved.
- **Smoke partition `gpu_h100_short`** for all habitat smokes (overrides the s3/s4 ACs' `dev_gpu_h100`, which predate s1's finding that `dev_gpu_h100` aborts habitat's GL renderer during prefill). Documented in configs + README.
- `offline_buffer_3d25` is **standalone** (no `extends: _base`) since `_base`'s training-arg smoke defaults don't fit a hyphen-flag collection job.

## Tests
`tests/slurm/test_launch.py` — **15 pass**. Preserves l1 byte-equality + afterok dependency; adds recursive-extends (incl. cycle rejection), L2–L4 arg-equivalence, multi-variant sweep, aggregator timestamp/strict, and offline-buffer (hyphen/env/hooks) coverage.

Legacy `*.sbatch` remain runnable during the coexistence window (cleanup is s5 / 3D-34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)