### PR TITLE
refactor(r2dreamer): DRY run-shim registry, shared launch helpers, dim SSOT guard

### DIFF
--- a/docs/notes/2026-06-01-dry-modularity-review.md
+++ b/docs/notes/2026-06-01-dry-modularity-review.md
@@ -1,0 +1,138 @@
+# DRY + Modularity Review — `3d-50-hybrid-cnn-vggt` branch
+
+**Date:** 2026-06-01
+**Scope:** the ~2,200-line diff of `lucasailerls/3d-50-hybrid-cnn-vggt` vs `main`
+(merge-base `a7c917e`) — the hybrid CNN(RGB)+gated-MLP(VGGT) encoder and the WP-grid
+ablations.
+**Method:** 10 read-only reviewer agents (one per module slice) fanned out over the
+diff with a DRY + modularity rubric, each returning structured findings; a synthesizer
+deduped cross-module findings and prioritized them. 33 raw findings → 22 consolidated.
+**Applied in:** worktree `worktrees/dry-modularity`, branch
+`lucasailerls/3d-50-dry-modularity` (off the branch HEAD).
+
+---
+
+## Verdict
+
+The branch is **structurally sound** — clean `Encoder`/`EncoderSpec` hierarchy, good
+SLURM `extends:` chains, a properly parametrized WP-pooling refactor (zero findings in
+`feature_extractor.py`). The DRY/modularity debt clusters around **one dominant theme:
+encoder metadata has no single source of truth.** Encoder type strings and the feature
+dimensions (VGGT `4116`, hybrid `16404`, RGB resolution `64`) are re-typed across the
+encoders, adapters, config, agent dispatch, parser/`main` choices, the registry, and the
+run shims — so adding an encoder or changing a grid touches 3–5+ files with silent
+train-time drift on a typo.
+
+Severity calibration is deliberately strict: DRY duplication is only **must-fix** when the
+copies can *drift apart and change behavior*. Two such cases exist (parser `--steps`
+default; the SLURM copy-paste defaults). The rest is ordinary should/nice consolidation.
+
+---
+
+## Cross-cutting themes
+
+1. **Encoder metadata has no single source of truth** *(dominant)* — type strings + feature
+   dims echoed across `encoders/__init__.py`, `registries.py`, `agent.py` dispatch,
+   `parser.py` choices, `main.py` (two identical `choices=` lists), `config.py` docstring,
+   and the run shims.
+2. **Launch + run-config boilerplate** — curriculum resolution duplicated in `train()`/
+   `evaluate()`; agent-config assembly diverges between them; 13 run shims duplicate the
+   `sys.path` bootstrap + a hardcoded `train()` call.
+3. **Config-as-source-of-truth eroded by drifting defaults/docs** — parser `--steps`
+   default (2.4M) overrides `config.total_steps` (1M); stale `config.py` enum comment;
+   stale `tests/.../AGENTS.md` "No conftest.py" claim (one exists).
+4. **Test setup duplication** — 10 inline `FakeExtractor` stubs, 5+ minimal-config builders,
+   ad-hoc RNG init that ignores the fixed-key convention.
+5. **Intra-module shape/forward-pass + CNN duplication** *(jit paths — higher apply-risk)* —
+   `ConvEncoder`/`WPConvEncoder` share an identical conv stack; hybrid RGB-slice extraction
+   duplicated in `loss.py` + `agent.reconstruct()`; `reconstruct()` reimplements
+   `_world_model_forward()`.
+
+---
+
+## Applied in this worktree (low-risk, test-verified)
+
+| # | Change | Theme | Files |
+|---|--------|-------|-------|
+| 1 | **Run-shim registry** — new `scripts/r2dreamer/_run_configs.py` holds `RUN_CONFIGS` (one table) + `launch_run(name)` that validates the encoder against `encoder_registry` at launch; the 3 new shims collapse from ~20→7 lines. Files kept so SLURM `script:` paths stay valid. | 2 | `_run_configs.py` (new), `run_jax_habitat_hybrid.py`, `…_vggt_wp_cp_64.py`, `…_vggt_wp_dense.py`, `AGENTS.md` |
+| 2 | **Shared `resolve_curriculum_path()`** — extracted the verbatim curriculum block out of `train()` and `evaluate()` into `launch/_helpers.py`. | 2 | `launch/_helpers.py` (new), `train.py`, `evaluate.py` |
+| 3 | **`LATENT_PRESETS` table** — replaced the `if/elif` + manual field-loop preset logic with a `config.LATENT_PRESETS` lookup. | 5 | `config.py`, `train.py` |
+| 4 | **`HYBRID_FEATURE_DIM` derived** — `3*64*64 + VGGT_FEATURE_DIM` instead of the magic `16404`; VGGT dim now has one owner in the adapter layer. | 1 | `adapters/hybrid_adapter.py` |
+| 5 | **Dimension-consistency guard test** — pins `VGGT_FEATURE_DIM == HYBRID_VGGT_DIM == config.vggt_feature_dim` and `HYBRID_FEATURE_DIM == RGB + VGGT`. Enforces the single-source-of-truth invariant **without** cross-layer import coupling. | 1 | `tests/r2dreamer/test_dims_consistency.py` (new) |
+| 6 | **Package exports** — added `HybridEncoder`, `ConvDecoder` to `world_model/__init__.py` `__all__`. | 1 | `world_model/__init__.py` |
+| 7 | **Doc fixes** — `tests/.../AGENTS.md` no longer claims "No conftest.py"; `config.py` encoder comment points to the registry instead of a stale enum list. | 3 | `tests/r2dreamer/AGENTS.md`, `config.py` |
+
+Net **−21 lines** + 3 new focused modules. CPU suite green (see below).
+
+### Two reviewer suggestions deliberately *not* followed as written
+
+- **Import `VGGT_FEATURE_DIM` into `encoders.py`/`config.py`.** Rejected: it would drag the
+  heavy VGGT extractor stack into those lightweight, widely-imported modules — a coupling
+  regression. Used a **guard test** to enforce equality instead (finding #5).
+- **`choices = list(encoder_registry)` in `main.py`.** Rejected for now: `registries.py`
+  eagerly imports the Flax/VGGT encoder classes, so this would make every `src.main` CLI
+  invocation (and every shim `from src.main import train`) pull in the heavy stack at import.
+  Proper fix is a *names-only* `ENCODER_TYPES` tuple in a dependency-free module (deferred).
+
+---
+
+## Deferred (documented — apply with care / behavior-affecting / jit paths)
+
+### Must-fix (behavior divergence — left for an explicit decision, not silently changed)
+
+- **Parser `--steps` default (2.4M) ≠ `config.total_steps` (1M).** `parser.py:9`
+  `default=2_400_000`. When `--steps` is omitted the parser default wins over the config,
+  violating config-first SSOT. *In practice the SLURM configs always pass `steps`, so this
+  only bites a bare launcher CLI run.* Fix: set the parser default to `None`, resolve
+  `total_steps = args.steps if args.steps is not None else cfg.total_steps` in `train.py`.
+  Not applied here because it changes effective run length — wanted explicit sign-off rather
+  than a silent change during a refactor pass.
+
+- **SLURM `_base` hoist.** *Attempted and reverted.* The reviewer claimed 8/9 configs
+  copy-paste universal defaults; a finer audit showed they are **family-specific**
+  (`aggregator_mlp_v1`, `offline_buffer_3d25`, `l4_cnn` legitimately diverge/omit
+  `prefill`/`checkpoint_every`/`render_resolution`/`seed`/`wandb_project`). Only
+  `log_every: 250` is declared by *every* config, so it was the one safe hoist — but hoisting
+  it into `_base.args` changed the **render order** of flags in the generated sbatch (parent
+  keys merge first), which broke `test_l1_vggt_dry_run_matches_legacy_sbatch`, a deliberate
+  byte-parity-with-legacy contract. Reverted. **Proper fix:** introduce an intermediate
+  `_curriculum_base.yaml` for the VGGT/hybrid family (l1–l4_vggt, wp_*, hybrid) that the
+  non-curriculum configs do *not* extend, and hoist the shared keys there — then either
+  accept the new golden output or sort flags deterministically.
+
+### Should-fix
+
+- **Encoder type strings — single source of truth.** Auto-build `encoder_registry` from
+  `Encoder` subclasses; expose a dependency-free `ENCODER_TYPES` + capability helpers
+  (`is_vggt_encoder()`, `is_rgb_encoder()`); feed `parser.py`/`main.py` choices and shim
+  validation from it; replace `agent.py`'s `_make_encoder` dict + `act()` VGGT tuple. Medium
+  risk (touches jit'd `act()`/`_loss_fn`) — stage the non-jit parts first.
+- **`build_agent_config_from_args()`** shared by `train()`/`evaluate()` — today eval recovers
+  arch fields from `MANIFEST.json` via a separate `_ARCH_FIELDS` list, so a new arch field can
+  be missed at eval (checkpoint-load failure).
+- **Test dedup** — hoist 2–3 reusable `FakeExtractor` fakes + a `minimal_r2dreamer_cfg`
+  factory + an `agent_rng` fixture into `conftest.py` / `tests/r2dreamer/_helpers.py`
+  (the AGENTS.md doc fix #7 unblocks this). Left untouched to keep the suite green; high-touch.
+
+### Nice-to-have / jit-path (verify under jit + GPU before applying)
+
+- `_conv_stack(x, depth, kernel, mults)` shared by `ConvEncoder`/`WPConvEncoder`.
+- `extract_rgb_from_hybrid_obs(obs, rgb_dim)` shared by `loss.py` + `agent.reconstruct()`.
+- `_encode_and_observe()` shared by `reconstruct()` + `_world_model_forward()`.
+- `HybridEncoder` `rgb_shape` field (or `isqrt(rgb_dim//3)`) instead of the hardcoded
+  `(B, 3, 64, 64)` reshape at `encoders.py:210`.
+- `_norm_act(x, name)` helper for the recurring `RMSNorm→SiLU`; `vggt_dim` shape assertion
+  in `HybridEncoder._branches`.
+
+---
+
+## Verification
+
+```
+uv run pytest tests/r2dreamer/ tests/slurm/ -m "not gpu" \
+  --ignore=tests/r2dreamer/test_cross_framework.py
+```
+
+`test_cross_framework.py` is excluded: it unconditionally imports the external PyTorch
+reference (`from rssm import RSSM`) which needs `external/r2dreamer` on `PYTHONPATH`; it is
+pre-existing and untouched by this branch. GPU-marked tests are auto-skipped on CPU.

--- a/scripts/r2dreamer/AGENTS.md
+++ b/scripts/r2dreamer/AGENTS.md
@@ -28,8 +28,12 @@ publication plots. Scripts are thin — heavy logic lives in `src/r2dreamer/`.
 ### Live training launchers (shims → `src.r2dreamer.launch.train`)
 `run_jax_habitat.py` (L1 CNN), `…_l2/_l3/_l4.py`, the `_vggt` variants,
 `run_jax_habitat_vggt_aggregator_mlp.py`, `…_vggt_wp_dense.py`, `…_vggt_wp_cp_64.py`,
-`run_jax_habitat_hybrid.py`, `run_jax_crafter.py`. Each is ~14 lines: it just selects
-`(env, encoder, curriculum)` and delegates. Eval shims: `eval_habitat.py`,
+`run_jax_habitat_hybrid.py`, `run_jax_crafter.py`. Newer shims are ~7 lines and
+delegate to `_run_configs.launch_run("<run-id>")`, where the per-run `(env, encoder,
+curriculum, output_dir, wandb_name, wandb_tags)` lives in the `RUN_CONFIGS` table in
+[`_run_configs.py`](_run_configs.py) (single source of truth; encoder validated against
+`encoder_registry` at launch). Older shims still inline their `train(...)` call —
+migrate them into `RUN_CONFIGS` when touched. Eval shims: `eval_habitat.py`,
 `eval_habitat_vggt.py`. Validation shims: `run_parity_training.py`, `run_benchmark.py`.
 
 ### Curriculum / analysis / profiling

--- a/scripts/r2dreamer/_run_configs.py
+++ b/scripts/r2dreamer/_run_configs.py
@@ -1,0 +1,88 @@
+"""Central registry of R2Dreamer experiment run configurations.
+
+DRY: the ``run_jax_*.py`` shims used to each repeat the same ~5-line ``sys.path``
+bootstrap plus a hardcoded ``train(...)`` call differing only in
+env/encoder/curriculum/output_dir/wandb_name/wandb_tags. That metadata now lives
+here as one ``RUN_CONFIGS`` table, and each shim collapses to::
+
+    import _run_configs
+    if __name__ == "__main__":
+        _run_configs.launch_run("habitat-l1-hybrid")
+
+One file per run id is kept (rather than a single CLI) so the ``script:`` paths
+referenced by ``scripts/slurm/configs/*.yaml`` stay valid. ``launch_run`` also
+validates the encoder against the canonical ``encoder_registry`` at launch, so a
+typo fails fast instead of at train-time.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+
+# Make ``src`` importable regardless of the CWD the shim is launched from.
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+# Each value is the full kwargs forwarded to ``src.main.train`` for one run.
+RUN_CONFIGS: dict[str, dict[str, Any]] = {
+    # L1 Hybrid — CNN(RGB) + gated MLP(WP/CP) hybrid encoder (3D-50/51/52).
+    "habitat-l1-hybrid": dict(
+        env="habitat",
+        encoder="hybrid",
+        curriculum="L1",
+        output_dir="output/runs/r2dreamer-curriculum-l1-hybrid",
+        wandb_name="hybrid-cnn-vggt",
+        wandb_tags=[
+            "curriculum", "level1", "1house", "chair-only", "vggt",
+            "hybrid", "cnn", "wp-cp", "3d-encoder", "jax",
+        ],
+    ),
+    # L1 VGGT — WP+CP MLP at a 64x64 world-point grid (3D-52/3D-53).
+    "habitat-l1-vggt-wp-cp-64": dict(
+        env="habitat",
+        encoder="vggt_wp_cp_64",
+        curriculum="L1",
+        output_dir="output/runs/r2dreamer-curriculum-l1-vggt-wp-cp-64",
+        wandb_name="wp-cp-mlp-64",
+        wandb_tags=[
+            "curriculum", "level1", "1house", "chair-only", "vggt",
+            "wp-cp", "mlp-3layer", "wp-64", "3d-52", "jax", "3d-encoder",
+        ],
+    ),
+    # L1 VGGT — full-resolution 518x518x3 world-point CNN encoder (3D-53).
+    "habitat-l1-vggt-wp-dense": dict(
+        env="habitat",
+        encoder="vggt_wp_dense_cnn",
+        curriculum="L1",
+        output_dir="output/runs/r2dreamer-curriculum-l1-vggt-wp-dense",
+        wandb_name="vggt_wp_dense_cnn",
+        wandb_tags=[
+            "curriculum", "level1", "1house", "chair-only", "vggt",
+            "wp-dense", "full-res-518", "cnn", "jax", "3d-encoder",
+        ],
+    ),
+}
+
+
+def launch_run(name: str):
+    """Validate and launch the named run configuration via ``src.main.train``."""
+    if name not in RUN_CONFIGS:
+        raise KeyError(f"Unknown run {name!r}. Available: {sorted(RUN_CONFIGS)}")
+    cfg = RUN_CONFIGS[name]
+
+    # Fail fast on an encoder typo, against the canonical registry.
+    from src.r2dreamer.launch.registries import encoder_registry
+
+    if cfg["encoder"] not in encoder_registry:
+        raise KeyError(
+            f"Run {name!r} uses unknown encoder {cfg['encoder']!r}. "
+            f"Available: {sorted(encoder_registry)}"
+        )
+
+    from src.main import train
+
+    return train(**cfg)

--- a/scripts/r2dreamer/run_jax_habitat_hybrid.py
+++ b/scripts/r2dreamer/run_jax_habitat_hybrid.py
@@ -1,28 +1,8 @@
-"""L1 Hybrid shim — habitat + CNN(RGB) + gated MLP(WP/CP) hybrid encoder (3D-50/51/52)."""
-import os
-import sys
+"""L1 Hybrid shim — habitat + CNN(RGB) + gated MLP(WP/CP) hybrid encoder (3D-50/51/52).
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
-
-from src.main import train
+Run metadata lives in _run_configs.RUN_CONFIGS["habitat-l1-hybrid"].
+"""
+import _run_configs
 
 if __name__ == "__main__":
-    train(
-        env="habitat",
-        encoder="hybrid",
-        curriculum="L1",
-        output_dir="output/runs/r2dreamer-curriculum-l1-hybrid",
-        wandb_name="hybrid-cnn-vggt",
-        wandb_tags=[
-            "curriculum",
-            "level1",
-            "1house",
-            "chair-only",
-            "vggt",
-            "hybrid",
-            "cnn",
-            "wp-cp",
-            "3d-encoder",
-            "jax",
-        ],
-    )
+    _run_configs.launch_run("habitat-l1-hybrid")

--- a/scripts/r2dreamer/run_jax_habitat_vggt_wp_cp_64.py
+++ b/scripts/r2dreamer/run_jax_habitat_vggt_wp_cp_64.py
@@ -3,18 +3,10 @@
 Same MLP / camera-pose / replay setup as run_jax_habitat_vggt.py, but VGGT's
 dense point map is pooled to 64x64 (obs = 64*64*3 + 9 = 12297) instead of 37x37.
 Controlled resolution ablation vs the 37x37 WP+CP MLP run.
-"""
-import sys
-import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
-from src.main import train
+Run metadata lives in _run_configs.RUN_CONFIGS["habitat-l1-vggt-wp-cp-64"].
+"""
+import _run_configs
 
 if __name__ == "__main__":
-    train(
-        env="habitat", encoder="vggt_wp_cp_64", curriculum="L1",
-        output_dir="output/runs/r2dreamer-curriculum-l1-vggt-wp-cp-64",
-        wandb_name="wp-cp-mlp-64",
-        wandb_tags=["curriculum", "level1", "1house", "chair-only", "vggt",
-                    "wp-cp", "mlp-3layer", "wp-64", "3d-52", "jax", "3d-encoder"],
-    )
+    _run_configs.launch_run("habitat-l1-vggt-wp-cp-64")

--- a/scripts/r2dreamer/run_jax_habitat_vggt_wp_dense.py
+++ b/scripts/r2dreamer/run_jax_habitat_vggt_wp_dense.py
@@ -2,18 +2,10 @@
 
 Feeds the dense 518x518x3 VGGT world-point map (no 37x37 pooling) into a conv
 encoder that treats XYZ as a 3-channel image. Counterpart to the WP/CP MLP run.
-"""
-import sys
-import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
-from src.main import train
+Run metadata lives in _run_configs.RUN_CONFIGS["habitat-l1-vggt-wp-dense"].
+"""
+import _run_configs
 
 if __name__ == "__main__":
-    train(
-        env="habitat", encoder="vggt_wp_dense_cnn", curriculum="L1",
-        output_dir="output/runs/r2dreamer-curriculum-l1-vggt-wp-dense",
-        wandb_name="vggt_wp_dense_cnn",
-        wandb_tags=["curriculum", "level1", "1house", "chair-only", "vggt",
-                    "wp-dense", "full-res-518", "cnn", "jax", "3d-encoder"],
-    )
+    _run_configs.launch_run("habitat-l1-vggt-wp-dense")

--- a/src/r2dreamer/adapters/hybrid_adapter.py
+++ b/src/r2dreamer/adapters/hybrid_adapter.py
@@ -6,11 +6,17 @@ import jax.numpy as jnp
 import numpy as np
 
 from src.r2dreamer.adapters.obs_adapter import ObsAdapter
-from src.r2dreamer.adapters.vggt_adapter import flatten_world_points_camera_pose
+from src.r2dreamer.adapters.vggt_adapter import (
+    VGGT_FEATURE_DIM,
+    flatten_world_points_camera_pose,
+)
 from src.shared.video_utils import resize_chw_uint8
 
 
-HYBRID_FEATURE_DIM = 16404  # 12288 (3*64*64 RGB) + 4116 (world_points + camera_pose)
+# Derived, not hand-typed: RGB branch (3*64*64, flattened) + the VGGT WP/CP vector.
+# VGGT_FEATURE_DIM is the single source of truth for the 4116 term (see vggt_adapter),
+# so a grid-size ablation that changes it stays consistent here automatically.
+HYBRID_FEATURE_DIM = 3 * 64 * 64 + VGGT_FEATURE_DIM  # 12288 RGB + 4116 WP/CP = 16404
 
 
 class HybridObsAdapter(ObsAdapter):

--- a/src/r2dreamer/config.py
+++ b/src/r2dreamer/config.py
@@ -2,6 +2,15 @@ from dataclasses import dataclass, field
 from typing import Any, Tuple
 
 
+# Latent-size ablation presets (3D-50). Each maps a `--latent_preset` name to the
+# RSSM-size field overrides it applies; explicit CLI flags still win over a preset.
+# Table-driven so adding a preset is a single entry, not another if/elif branch.
+LATENT_PRESETS: dict[str, dict[str, int]] = {
+    "small": {"deter_size": 1024, "stoch_classes": 24, "stoch_discrete": 12},
+    "large": {"deter_size": 4096, "stoch_classes": 48, "stoch_discrete": 24},
+}
+
+
 @dataclass
 class R2DreamerConfig:
     # --- Environment ---
@@ -20,7 +29,7 @@ class R2DreamerConfig:
     img_layers: int = 2
 
     # --- Encoder ---
-    encoder_type: str = "cnn"  # "cnn", "vggt", "vggt_aggregator_mlp", or "hybrid"
+    encoder_type: str = "cnn"  # canonical set: encoder_registry in src.r2dreamer.launch.registries
     encoder_module_cls: Any = None  # Flax nn.Module class; sourced from EncoderSpec.module_cls
     encoder_depth: int = 16
     encoder_kernel: int = 5

--- a/src/r2dreamer/launch/_helpers.py
+++ b/src/r2dreamer/launch/_helpers.py
@@ -1,0 +1,29 @@
+"""Shared resolution helpers for the launcher entry points.
+
+DRY: `train()` and `evaluate()` both turn a ``--curriculum_path`` CLI escape
+hatch plus an optional named curriculum into a concrete JSON path. Keeping that
+logic here means a change to the curriculum-resolution rule is made once, not
+synced across two entry points. Per-env validation (habitat requires a
+curriculum; crafter forbids one) intentionally stays in the callers.
+"""
+
+from __future__ import annotations
+
+
+def resolve_curriculum_path(curriculum_path_arg: str | None, curriculum: str | None) -> str | None:
+    """Resolve a curriculum JSON path from the CLI arg or a registry name.
+
+    ``--curriculum_path`` (``curriculum_path_arg``) is the explicit escape hatch and
+    wins when set. Otherwise a named ``curriculum`` (e.g. ``"L1"``) is looked up in
+    the ``CURRICULA`` registry. Returns ``None`` when neither is supplied; the caller
+    applies the env-specific requirement.
+    """
+    from src.r2dreamer.launch.curricula import CURRICULA
+
+    if curriculum_path_arg is not None:
+        return curriculum_path_arg
+    if curriculum is not None:
+        if curriculum not in CURRICULA:
+            raise KeyError(f"Unknown curriculum {curriculum!r}. Available: {list(CURRICULA)}")
+        return str(CURRICULA[curriculum])
+    return None

--- a/src/r2dreamer/launch/evaluate.py
+++ b/src/r2dreamer/launch/evaluate.py
@@ -13,7 +13,7 @@ from scipy.spatial.transform import Rotation
 
 from src.r2dreamer.launch.parser import _build_parser_eval
 from src.r2dreamer.launch.registries import env_registry
-from src.r2dreamer.launch.curricula import CURRICULA
+from src.r2dreamer.launch._helpers import resolve_curriculum_path
 from src.r2dreamer.agent import R2DreamerAgent
 from src.r2dreamer.config import R2DreamerConfig
 from src.shared.video_utils import (
@@ -88,15 +88,8 @@ def evaluate(
             "checkpoint must be set via evaluate(..., checkpoint=...) or --checkpoint"
         )
 
-    # --- Resolve curriculum path ---
-    if args.curriculum_path is not None:
-        curriculum_path = args.curriculum_path
-    elif curriculum is not None:
-        if curriculum not in CURRICULA:
-            raise KeyError(f"Unknown curriculum {curriculum!r}. Available: {list(CURRICULA)}")
-        curriculum_path = str(CURRICULA[curriculum])
-    else:
-        curriculum_path = None
+    # --- Resolve curriculum path (shared with train via launch._helpers) ---
+    curriculum_path = resolve_curriculum_path(args.curriculum_path, curriculum)
 
     # --- Resolve output dir ---
     eff_output_dir = args.output_dir if args.output_dir is not None else output_dir

--- a/src/r2dreamer/launch/train.py
+++ b/src/r2dreamer/launch/train.py
@@ -30,8 +30,8 @@ def train(
     import jax
 
     from src.r2dreamer.agent import R2DreamerAgent
-    from src.r2dreamer.config import R2DreamerConfig
-    from src.r2dreamer.launch.curricula import CURRICULA
+    from src.r2dreamer.config import R2DreamerConfig, LATENT_PRESETS
+    from src.r2dreamer.launch._helpers import resolve_curriculum_path
     from src.r2dreamer.launch.parser import _build_parser_train
     from src.r2dreamer.launch.registries import env_registry, encoder_registry
     from src.r2dreamer.trainer import Trainer, TrainerConfig, habitat_defaults
@@ -43,16 +43,8 @@ def train(
     if env not in env_registry:
         raise KeyError(f"Unknown env {env!r}. Available: {list(env_registry)}")
 
-    # --- Resolve curriculum path ---
-    # CLI --curriculum_path is the escape hatch; otherwise use registry lookup.
-    if args.curriculum_path is not None:
-        curriculum_path = args.curriculum_path
-    elif curriculum is not None:
-        if curriculum not in CURRICULA:
-            raise KeyError(f"Unknown curriculum {curriculum!r}. Available: {list(CURRICULA)}")
-        curriculum_path = str(CURRICULA[curriculum])
-    else:
-        curriculum_path = None
+    # --- Resolve curriculum path (shared with evaluate via launch._helpers) ---
+    curriculum_path = resolve_curriculum_path(args.curriculum_path, curriculum)
 
     if env == "habitat" and curriculum_path is None:
         raise ValueError(
@@ -130,12 +122,10 @@ def train(
     if getattr(args, "train_ratio", None) is not None:
         agent_overrides["train_ratio"] = args.train_ratio
 
-    # Latent-size ablation (3D-50): preset, then explicit flags win.
+    # Latent-size ablation (3D-50): preset from the LATENT_PRESETS table, then
+    # explicit flags win.
     preset = getattr(args, "latent_preset", "default")
-    if preset == "small":
-        agent_overrides.update(deter_size=1024, stoch_classes=24, stoch_discrete=12)
-    elif preset == "large":
-        agent_overrides.update(deter_size=4096, stoch_classes=48, stoch_discrete=24)
+    agent_overrides.update(LATENT_PRESETS.get(preset, {}))
     for _name in ("deter_size", "stoch_classes", "stoch_discrete", "mlp_vggt_hidden", "mlp_vggt_layers"):
         _v = getattr(args, _name, None)
         if _v is not None:

--- a/src/r2dreamer/world_model/__init__.py
+++ b/src/r2dreamer/world_model/__init__.py
@@ -1,13 +1,21 @@
 """World-model subpackage: encoders, RSSM, head primitives, and world-model loss."""
 
 from .rssm import RMSNorm, BlockLinear, Deter, R2RSSM
-from .encoders import ConvEncoder, VGGTEncoder, VGGTAggregatorMLPEncoder, WPConvEncoder
+from .encoders import (
+    ConvEncoder,
+    VGGTEncoder,
+    VGGTAggregatorMLPEncoder,
+    WPConvEncoder,
+    HybridEncoder,
+    ConvDecoder,
+)
 from .heads import R2MLP, R2TwoHotDist, onehot_mode_st
 from .loss import world_model_loss, kl_loss
 
 __all__ = [
     "RMSNorm", "BlockLinear", "Deter", "R2RSSM",
     "ConvEncoder", "VGGTEncoder", "VGGTAggregatorMLPEncoder", "WPConvEncoder",
+    "HybridEncoder", "ConvDecoder",
     "R2MLP", "R2TwoHotDist", "onehot_mode_st",
     "world_model_loss", "kl_loss",
 ]

--- a/tests/r2dreamer/AGENTS.md
+++ b/tests/r2dreamer/AGENTS.md
@@ -60,8 +60,13 @@ selections with the same `srun` invocation.
 
 ## Conventions
 
-- **No `conftest.py`** — fixtures (`cfg`, `agent`, `rng`, `replay_batch`) are defined
-  per-file. JAX RNG keys are fixed integers for determinism (e.g. init=7, train=11).
+- **`conftest.py` (repo root) handles markers only** — it skips `@pytest.mark.gpu`
+  tests without a JAX GPU backend and gates the VGGT parity test behind
+  `RUN_VGGT_PARITY=1`. Per-test fixtures (`cfg`, `agent`, `rng`, `replay_batch`) are
+  still defined per-file today; cross-file fakes/factories (e.g. a shared
+  `FakeExtractor`, a minimal-config builder) belong in `conftest.py` or a
+  `tests/r2dreamer/_helpers.py`, not copy-pasted per file. JAX RNG keys are fixed
+  integers for determinism (e.g. init=7, train=11).
 - **Markers:** `@pytest.mark.gpu` (only `test_encoders.py::TestVGGTEncoder`),
   plus `habitat_sim` / `integration` registered but currently unused.
 - **Mocking:** `monkeypatch` + hand-rolled fake extractors (`.extract()/.reset()/

--- a/tests/r2dreamer/test_dims_consistency.py
+++ b/tests/r2dreamer/test_dims_consistency.py
@@ -1,0 +1,40 @@
+"""Guard: VGGT/hybrid feature dimensions must agree across the layers that each
+declare them.
+
+The VGGT WP/CP feature size (37*37*3 + 9 = 4116) is referenced in three different
+architectural layers that — for good coupling reasons — do not import each other:
+
+  * ``adapters.vggt_adapter.VGGT_FEATURE_DIM``     (buffer/extractor layer; canonical)
+  * ``world_model.encoders.HYBRID_VGGT_DIM``       (encoder slice size)
+  * ``config.R2DreamerConfig.vggt_feature_dim``    (config default)
+
+Importing one into the others would drag the heavy VGGT/Flax stack into the
+lightweight config/encoder modules, so instead this test pins them equal and fails
+fast if a grid-size ablation updates one but not the others. Same idea for the
+hybrid buffer layout = RGB branch + VGGT branch.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from src.r2dreamer.adapters.hybrid_adapter import HYBRID_FEATURE_DIM
+from src.r2dreamer.adapters.vggt_adapter import VGGT_FEATURE_DIM
+from src.r2dreamer.config import R2DreamerConfig
+from src.r2dreamer.world_model.encoders import HYBRID_RGB_DIM, HYBRID_VGGT_DIM
+
+
+def _field_default(cls, name: str):
+    return next(f for f in dataclasses.fields(cls) if f.name == name).default
+
+
+def test_encoder_vggt_slice_matches_adapter_feature_dim():
+    assert HYBRID_VGGT_DIM == VGGT_FEATURE_DIM
+
+
+def test_config_default_matches_adapter_feature_dim():
+    assert _field_default(R2DreamerConfig, "vggt_feature_dim") == VGGT_FEATURE_DIM
+
+
+def test_hybrid_feature_dim_is_sum_of_branches():
+    assert HYBRID_FEATURE_DIM == HYBRID_RGB_DIM + HYBRID_VGGT_DIM


### PR DESCRIPTION
## What changed
DRY + modularity cleanup surfaced by a 10-agent review of the `3d-50-hybrid-cnn-vggt` diff. Behavior-preserving — no jit'd train paths, checkpoint format, or buffer layout touched.

- **Run-shim registry** — new `scripts/r2dreamer/_run_configs.py` holds per-run kwargs as one `RUN_CONFIGS` table + `launch_run()` that validates the encoder against `encoder_registry` at launch. The 3 new shims collapse ~20 → 7 lines; files kept so `scripts/slurm/configs/*.yaml` `script:` paths stay valid.
- **Shared `resolve_curriculum_path()`** — extracted the verbatim curriculum block from `train()`/`evaluate()` into `launch/_helpers.py`.
- **`LATENT_PRESETS` table** — replaces the latent-preset `if/elif` + manual field loop.
- **Single source of truth for dims** — `HYBRID_FEATURE_DIM` now derives from `VGGT_FEATURE_DIM` (was the magic `16404`); new `tests/r2dreamer/test_dims_consistency.py` pins `VGGT_FEATURE_DIM == HYBRID_VGGT_DIM == config.vggt_feature_dim` and `HYBRID_FEATURE_DIM == RGB + VGGT` — enforcing the invariant **without** dragging the heavy VGGT stack into the lightweight encoder/config modules.
- **Exports** — `HybridEncoder`, `ConvDecoder` added to `world_model/__init__.__all__`.
- **Docs** — `tests/.../AGENTS.md` no longer claims "No conftest.py"; `config.py` encoder comment points at the registry.

Net **−21 lines** of production code + 3 new focused modules (registry, helper, guard test) and a review report.

## Why
The review's dominant finding: encoder metadata/feature dims are re-typed across encoders, adapters, config, dispatch, parser/main, registry, and shims — adding an encoder or changing a grid touches 3–5+ files with silent train-time drift on a typo. These changes remove the highest-value, lowest-risk duplication and lock the dim invariant with a test.

## Linear issue
Follow-up to **3D-50 / 3D-52 / 3D-53** (hybrid CNN+VGGT encoder). No dedicated issue; happy to file one.

## Acceptance criteria checked
- Behavior preserving: shim `train()` kwargs and SLURM `script:` paths unchanged; `RUN_CONFIGS` values verified byte-equal to the originals.
- Encoder names in `RUN_CONFIGS` validated against `encoder_registry`; bad names rejected at launch.

## Risk
**Low.** Touches launcher/config/script/doc/test surfaces only. No JIT'd module bodies, checkpoint format, or buffer layout changed.

## How to test
```
uv run pytest tests/r2dreamer/ tests/slurm/ -m "not gpu" \
  --ignore=tests/r2dreamer/test_cross_framework.py
```
→ **141 passed, 1 skipped** (GPU test). `test_cross_framework` excluded (pre-existing external-PyTorch import, untouched by this branch).

## What was intentionally NOT done (see `docs/notes/2026-06-01-dry-modularity-review.md`)
- **`--steps` default divergence** (parser 2.4M vs config 1M) — a real must-fix but it changes effective run length; left for explicit sign-off.
- **SLURM `_base` hoist** — attempted & reverted: the "universal" defaults are family-specific, and hoisting `log_every` reordered the generated sbatch flags, breaking a deliberate byte-parity test. Proper fix = an intermediate `_curriculum_base.yaml`.
- **Rejected as written:** importing `VGGT_FEATURE_DIM` into `encoders.py`/`config.py` and `list(encoder_registry)` into `main.py` — both would pull the heavy VGGT/Flax stack into widely-imported modules.
- **jit-path refactors** (`_conv_stack`, `reconstruct`/`_world_model_forward` merge, encoder-type SSOT, `HybridEncoder.rgb_shape`) — documented; need verify-under-jit + GPU.

## Agent involvement
Review fanned out across 10 reviewer subagents + a synthesizer (33 raw → 22 consolidated findings); changes applied and verified by Claude Code (Opus 4.8).

## Follow-up issues
None filed yet. Candidates: `--steps` SSOT fix; encoder-type `ENCODER_TYPES` single source of truth; SLURM curriculum-family base; test-fixture consolidation.