### PR TITLE
3D-58: Disable default in-run val and video

### DIFF
--- a/scripts/slurm/configs/l1_vggt.yaml
+++ b/scripts/slurm/configs/l1_vggt.yaml
@@ -18,12 +18,3 @@ args:
   wandb_name: vggt_jax-${SLURM_JOB_ID}
   wandb_tags: curriculum,level1,1house,chair-only,vggt,vggt_jax,jax,3d-encoder
   render_resolution: 518
-  # Scalars-only during training, shared by the whole VGGT curriculum arm
-  # (l2/l3/l4_vggt inherit via extends). video_log_every=0 disables W&B
-  # episode-video rendering; val_every=0 disables the in-run val loop AND skips
-  # building the eval habitat sim (train.py only spawns val_env when val_every
-  # > 0). Videos + eval metrics are produced later from checkpoints. Keeps the
-  # VGGT arm symmetric with the CNN baseline and drops the two heaviest habitat
-  # GL paths (video re-render + second sim instance).
-  video_log_every: 0
-  val_every: 0

--- a/scripts/slurm/configs/l2_vggt.yaml
+++ b/scripts/slurm/configs/l2_vggt.yaml
@@ -13,6 +13,5 @@ args:
   # flatten reference vggt_jax-4216462. The current default is 1 (shallow MLP),
   # so this MUST be set explicitly or the cross-level comparison is confounded.
   mlp_layers: 0
-  # Scalars-only: video_log_every=0 / val_every=0 inherited from l1_vggt.
-  # (Dropped the stale val_data / val_loss_every flags — the parser no longer
-  # accepts them; in-run eval is off and regenerated from checkpoints instead.)
+  # Scalars-only is the parser default. Stale replay-buffer val flags were
+  # dropped; videos + eval metrics are regenerated from checkpoints instead.

--- a/scripts/slurm/configs/l3_vggt.yaml
+++ b/scripts/slurm/configs/l3_vggt.yaml
@@ -13,6 +13,5 @@ args:
   # flatten reference vggt_jax-4216462. The current default is 1 (shallow MLP),
   # so this MUST be set explicitly or the cross-level comparison is confounded.
   mlp_layers: 0
-  # Scalars-only: video_log_every=0 / val_every=0 inherited from l1_vggt.
-  # (Dropped the stale val_data / val_loss_every flags — the parser no longer
-  # accepts them; in-run eval is off and regenerated from checkpoints instead.)
+  # Scalars-only is the parser default. Stale replay-buffer val flags were
+  # dropped; videos + eval metrics are regenerated from checkpoints instead.

--- a/scripts/slurm/configs/l4_cnn.yaml
+++ b/scripts/slurm/configs/l4_cnn.yaml
@@ -7,10 +7,9 @@ comments:
   - "Level 4 CNN baseline: 10 houses (4 easy, 4 medium, 2 hard) x 6 goal categories"
   - "2D-RGB CNN encoder (64x64) — baseline control for the VGGT 3D-encoder comparison"
   - "2M steps, 24h wall time (matches the VGGT arm's step budget)"
-  - "Scalars-only run: video logging + in-run eval disabled (video_log_every=0,"
-  - "val_every=0). Episode videos and held-out eval metrics are regenerated"
-  - "offline from saved checkpoints, not during training. This also avoids the"
-  - "two heaviest habitat GL paths (video re-render + second val sim instance)."
+  - "Scalars-only run: parser defaults disable video logging + in-run eval."
+  - "Episode videos and held-out eval metrics are regenerated offline from"
+  - "saved checkpoints, avoiding the two heaviest habitat GL paths."
 sbatch:
   time: "24:00:00"
 args:
@@ -22,9 +21,3 @@ args:
   wandb_project: 3d-vla-objectnav
   wandb_name: r2d-L4-cnn-${SLURM_JOB_ID}
   wandb_tags: curriculum,level4,10houses,6goals,cnn,baseline,jax,2d-rgb
-  # Scalars-only during training. video_log_every=0 disables W&B episode-video
-  # rendering; val_every=0 disables the in-run val-episode loop AND skips
-  # building the eval habitat sim (train.py only spawns val_env when val_every
-  # > 0). Videos + eval metrics are produced later from checkpoints.
-  video_log_every: 0
-  val_every: 0

--- a/scripts/slurm/configs/l4_vggt.yaml
+++ b/scripts/slurm/configs/l4_vggt.yaml
@@ -13,6 +13,5 @@ args:
   # flatten reference vggt_jax-4216462. The current default is 1 (shallow MLP),
   # so this MUST be set explicitly or the cross-level comparison is confounded.
   mlp_layers: 0
-  # Scalars-only: video_log_every=0 / val_every=0 inherited from l1_vggt.
-  # (Dropped the stale val_data / val_loss_every flags — the parser no longer
-  # accepts them; in-run eval is off and regenerated from checkpoints instead.)
+  # Scalars-only is the parser default. Stale replay-buffer val flags were
+  # dropped; videos + eval metrics are regenerated from checkpoints instead.

--- a/src/r2dreamer/launch/parser.py
+++ b/src/r2dreamer/launch/parser.py
@@ -41,9 +41,9 @@ def _build_parser_train() -> argparse.ArgumentParser:
                         "None keeps the config default (1). The experiment runs pass 3 to "
                         "match R2Dreamer's native encoder.mlp.layers (3D-52). Ignored by "
                         "the CNN/dense-WP conv encoders.")
-    # Val-Episode-Loop (3D-36). 0 disables. Default 50_000 matches the
-    # checkpoint cadence so val signals land alongside checkpoints.
-    p.add_argument("--val_every", type=int, default=50_000,
+    # Val-Episode-Loop (3D-36). Disabled by default; opt in explicitly for
+    # diagnostic runs that can afford the extra Habitat simulator.
+    p.add_argument("--val_every", type=int, default=0,
                    help="Run a deterministic val-episode loop every N steps (0 disables)")
     p.add_argument("--val_episodes", type=int, default=50,
                    help="Episodes per val-loop trigger")
@@ -54,8 +54,8 @@ def _build_parser_train() -> argparse.ArgumentParser:
     p.add_argument("--resume_from", type=str, default=None)
     p.add_argument("--wandb_id", type=str, default=None,
                    help="W&B run-id to reattach to (resume='must')")
-    p.add_argument("--video_log_every", type=int, default=25_000,
-                   help="Log one Habitat episode video every N train steps")
+    p.add_argument("--video_log_every", type=int, default=0,
+                   help="Log one Habitat episode video every N train steps (0 disables)")
     p.add_argument("--video_log_episodes", type=int, default=1,
                    help="Number of Habitat train episodes to record per interval")
     p.add_argument("--act_entropy", type=float, default=3e-2,

--- a/src/r2dreamer/trainer.py
+++ b/src/r2dreamer/trainer.py
@@ -118,12 +118,12 @@ class TrainerConfig:
     wandb_tags: list[str] = field(default_factory=lambda: ["r2dreamer"])
     # Resume an existing W&B run (e.g. "87u0l6dy"). Requires the run to exist.
     wandb_id: str | None = None
-    video_log_every: int = 25_000
+    video_log_every: int = 0
     video_log_episodes: int = 1
 
-    # Deterministic Val-Episode-Loop. val_every=0 disables. Requires a
-    # val_env to be passed to Trainer.
-    val_every: int = 50_000
+    # Deterministic Val-Episode-Loop. Disabled by default; val_every > 0
+    # requires a val_env to be passed to Trainer.
+    val_every: int = 0
     val_episodes: int = 50
     val_video_episodes: int = 1
     val_max_episode_steps: int = 500
@@ -749,4 +749,3 @@ class Trainer:
             f"sr={sr_str} spl={spl_str} softspl={soft_str} dtg={dtg_str}m "
             f"({tcfg.val_episodes} eps in {elapsed:.1f}s)"
         )
-

--- a/tests/r2dreamer/launch/test_parser.py
+++ b/tests/r2dreamer/launch/test_parser.py
@@ -9,3 +9,19 @@ def test_train_parser_does_not_expose_wandb_notes_file():
 
     assert not hasattr(args, "wandb_notes_file")
     assert "--wandb_notes_file" not in parser.format_help()
+
+
+def test_train_parser_defaults_disable_in_run_val_and_video():
+    parser = _build_parser_train()
+    args = parser.parse_args([])
+
+    assert args.val_every == 0
+    assert args.video_log_every == 0
+
+
+def test_train_parser_allows_explicit_val_and_video_opt_in():
+    parser = _build_parser_train()
+    args = parser.parse_args(["--val_every", "50000", "--video_log_every", "25000"])
+
+    assert args.val_every == 50_000
+    assert args.video_log_every == 25_000

--- a/tests/r2dreamer/test_trainer.py
+++ b/tests/r2dreamer/test_trainer.py
@@ -37,6 +37,13 @@ class _DummyEnv:
         pass
 
 
+def test_trainer_config_defaults_disable_in_run_val_and_video():
+    tcfg = TrainerConfig()
+
+    assert tcfg.val_every == 0
+    assert tcfg.video_log_every == 0
+
+
 class TestConvertBatch:
     """convert_batch turns replay buffer output into agent-ready batches."""
 

--- a/tests/slurm/test_launch.py
+++ b/tests/slurm/test_launch.py
@@ -71,23 +71,14 @@ def test_l1_vggt_dry_run_matches_legacy_sbatch() -> None:
 
     assert result.returncode == 0, result.stderr
     expected = (ROOT / LEGACY_SBATCH / "train_curriculum_l1_vggt.sbatch").read_text()
-    # _base / l1_vggt have since gained three intentional changes the frozen
+    # _base / l1_vggt have since gained two intentional changes the frozen
     # legacy script predates: (1) the GL-teardown hard-exit env var (so every
-    # habitat variant exits 0 on completion), (2) multi-partition auto-select
-    # (gpu_h100_il,gpu_h100), and (3) the scalars-only flags video_log_every=0 /
-    # val_every=0 (videos + eval regenerated from checkpoints, not during
-    # training). Normalise all three back out before the byte-equality check so
-    # the rest of the contract still holds.
+    # habitat variant exits 0 on completion), and (2) multi-partition
+    # auto-select (gpu_h100_il,gpu_h100). Normalise both back out before the
+    # byte-equality check so the rest of the contract still holds.
     rendered = result.stdout.replace('export R2DREAMER_HARD_EXIT_ON_FINISH="1"\n\n', "", 1)
     rendered = rendered.replace(
         "#SBATCH --partition=gpu_h100_il,gpu_h100", "#SBATCH --partition=gpu_h100", 1
-    )
-    rendered = rendered.replace(
-        "    --render_resolution 518 \\\n"
-        "    --video_log_every 0 \\\n"
-        "    --val_every 0",
-        "    --render_resolution 518",
-        1,
     )
     assert rendered == expected
 
@@ -170,18 +161,21 @@ def test_curriculum_variants_match_legacy_args(variant: str, legacy: str) -> Non
     assert r_python == l_python == "uv run python"
     assert r_script == l_script
 
-    # Intentional divergence from the frozen legacy sbatch: the VGGT arm is now
-    # scalars-only — video + in-run eval disabled (video_log_every=0 /
-    # val_every=0, inherited from l1_vggt), and the stale replay-buffer val
-    # flags (val_data / val_loss_every) dropped since the parser rejects them.
-    # Videos + eval metrics are regenerated from checkpoints. Normalise those
-    # four out, then assert the rest of the training command still matches.
-    assert r_flags["--video_log_every"] == "0"
-    assert r_flags["--val_every"] == "0"
+    # Intentional divergences from the frozen legacy sbatch: scalars-only is now
+    # the parser default; stale replay-buffer val flags (val_data /
+    # val_loss_every) were dropped since the parser rejects them; and the VGGT
+    # L2-L4 arm pins the flatten/bare-linear WP+CP readout with mlp_layers=0
+    # plus explicit W&B names/tags. Normalise those out, then assert the rest
+    # of the command still matches.
+    assert "--video_log_every" not in r_flags
+    assert "--val_every" not in r_flags
     assert "--val_data" not in r_flags
     assert "--val_loss_every" not in r_flags
+    assert r_flags["--mlp_layers"] == "0"
+    assert "flatten" in r_flags["--wandb_name"]
+    assert "flatten,wp-cp" in r_flags["--wandb_tags"]
 
-    intentional = {"--video_log_every", "--val_every", "--val_data", "--val_loss_every"}
+    intentional = {"--val_data", "--val_loss_every", "--mlp_layers", "--wandb_name", "--wandb_tags"}
     r_common = {k: v for k, v in r_flags.items() if k not in intentional}
     l_common = {k: v for k, v in l_flags.items() if k not in intentional}
     assert r_common == l_common
@@ -194,9 +188,9 @@ def test_extends_chain_is_recursive() -> None:
     # Inherited from _base via l1_vggt:
     assert config.sbatch.gres == "gpu:1"
     assert config.args["render_resolution"] == 518
-    # Scalars-only flags inherited from l1_vggt (videos/eval regenerated offline):
-    assert config.args["video_log_every"] == 0
-    assert config.args["val_every"] == 0
+    # Scalars-only is now the parser default, not YAML inheritance:
+    assert "video_log_every" not in config.args
+    assert "val_every" not in config.args
     # Own override:
     assert config.script.endswith("run_jax_habitat_l2_vggt.py")
     # The stale replay-buffer val flags were dropped (parser no longer accepts them):
@@ -292,6 +286,8 @@ def test_3d56_prod_configs_render(variant: str, script: str, wandb_name: str) ->
     assert flags["--wandb_name"] == wandb_name
     assert "3d-56" in flags["--wandb_tags"]
     assert "set -euo pipefail" in rendered
+    assert "--video_log_every" not in flags
+    assert "--val_every" not in flags
 
 
 def test_3d56_raw_configs_use_conservative_resources() -> None:


### PR DESCRIPTION
## What changed
- Set train-parser defaults to `--val_every 0` and `--video_log_every 0`.
- Aligned `TrainerConfig` defaults with the parser so direct trainer construction is also scalars-only by default.
- Removed YAML-level `val_every: 0` / `video_log_every: 0` overrides from curriculum configs; configs now only opt in when they need non-default behavior.
- Updated parser, trainer, and SLURM launcher tests for the default-based behavior.

## Why
Long production training runs should not inherit expensive in-run validation or W&B video rendering unless a run explicitly opts in. This keeps the 3D-56 aggregator runs from spawning extra Habitat/VGGT rollout work and video encoding by default.

## Linear issue
3D-58

## Acceptance criteria checked
- Parser defaults disable in-run validation: `val_every=0`.
- Parser defaults disable train video logging: `video_log_every=0`.
- `TrainerConfig` defaults match parser defaults.
- 3D-56 production dry-run render for `agg_raw_mlp_v1`, `hybrid_agg_pooled_v1`, and `hybrid_agg_raw_v1` does not include YAML-level `--val_every` or `--video_log_every` flags; the parser supplies disabled defaults.
- Explicit opt-in remains available through CLI/YAML args.

## Screenshots, Loom, or preview URL
Not applicable.

## Risk
Low. This changes defaults, so runs that relied on implicit periodic val/video must now opt in explicitly with positive `--val_every` / `--video_log_every` values.

## How to test
- `MPLCONFIGDIR=/tmp/codex-mpl PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/r2dreamer/launch/test_parser.py tests/r2dreamer/test_trainer.py tests/slurm/test_launch.py -q`
- `scripts/slurm/launch.sh agg_raw_mlp_v1 hybrid_agg_pooled_v1 hybrid_agg_raw_v1 --prod --dry-run` with a guard that fails if `--val_every` or `--video_log_every` appears.
- Direct parser/trainer assertion that both defaults are `0`.
- `git diff --check`

## What was intentionally not done
- Did not add `val_every: 0` or `video_log_every: 0` to the 3D-56 YAML files; per the issue follow-up, this behavior now lives in argument defaults.
- Did not remove explicit opt-in val settings from diagnostic scripts such as the 3D-35 metrics verifier.

## Agent involvement
Implemented by Codex in a dedicated 3D-58 worktree. Human clarification changed the design from YAML-level disables to parser/trainer defaults.

## Follow-up issues created
None.