### PR TITLE
3D-63: Add L1 replay capacity ablations

### DIFF
--- a/scripts/slurm/configs/l1_agg_mlp_cap500k.yaml
+++ b/scripts/slurm/configs/l1_agg_mlp_cap500k.yaml
@@ -1,6 +1,8 @@
 extends: aggregator_mlp_v1
 job_name: l1-agg-mlp-cap500k
 output_dir: output/r2dreamer-l1-replay-capacity/agg-mlp-cap500k
+setup:
+  - ./scripts/slurm/hooks/link_external.sh
 comments:
   - "3D-63: L1 VGGT aggregator-MLP replay-capacity ablation at 500k transitions."
   - "Keeps aggregator batch_size=4, seq_len=32, train_ratio=128; only replay capacity changes."

--- a/scripts/slurm/configs/l1_agg_mlp_cap500k.yaml
+++ b/scripts/slurm/configs/l1_agg_mlp_cap500k.yaml
@@ -1,0 +1,19 @@
+extends: aggregator_mlp_v1
+job_name: l1-agg-mlp-cap500k
+output_dir: output/r2dreamer-l1-replay-capacity/agg-mlp-cap500k
+comments:
+  - "3D-63: L1 VGGT aggregator-MLP replay-capacity ablation at 500k transitions."
+  - "Keeps aggregator batch_size=4, seq_len=32, train_ratio=128; only replay capacity changes."
+args:
+  output_dir: output/r2dreamer-l1-replay-capacity/agg-mlp-cap500k/run-${SLURM_JOB_ID}
+  seed: 42
+  buffer_capacity: 500000
+  wandb_name: l1-agg-mlp-cap500k-${SLURM_JOB_ID}
+  wandb_tags: replay-capacity,3d-63,l1,vggt,aggregator-mlp,cap-500k,seed-42,sr-ablation
+  video_log_every: 0
+  val_every: 0
+smoke:
+  args:
+    output_dir: output/r2dreamer-l1-replay-capacity/agg-mlp-cap500k/smoke-${TIMESTAMP}
+    wandb_name: l1-agg-mlp-cap500k-smoke-${TIMESTAMP}
+    wandb_tags: replay-capacity,3d-63,l1,vggt,aggregator-mlp,cap-500k,seed-42,smoke

--- a/scripts/slurm/configs/l1_cnn_cap100k.yaml
+++ b/scripts/slurm/configs/l1_cnn_cap100k.yaml
@@ -1,0 +1,23 @@
+extends: _base
+job_name: l1-cnn-cap100k
+output_dir: output/r2dreamer-l1-replay-capacity/cnn-cap100k
+run_id: habitat-l1-cnn
+curriculum_check: data/curriculum/level1_1house_1goal.json
+comments:
+  - "3D-63: L1 CNN replay-capacity ablation at 100k transitions."
+  - "Fixed seed 42; compare post-training ObjectNav SR against the CNN baseline."
+sbatch:
+  time: "24:00:00"
+args:
+  steps: 2000000
+  prefill: 5000
+  checkpoint_every: 100000
+  output_dir: output/r2dreamer-l1-replay-capacity/cnn-cap100k/run-${SLURM_JOB_ID}
+  seed: 42
+  log_every: 250
+  buffer_capacity: 100000
+  wandb_project: 3d-vla-objectnav
+  wandb_name: l1-cnn-cap100k-${SLURM_JOB_ID}
+  wandb_tags: replay-capacity,3d-63,l1,cnn,cap-100k,seed-42,sr-ablation
+  video_log_every: 0
+  val_every: 0

--- a/scripts/slurm/configs/l1_cnn_cap10k.yaml
+++ b/scripts/slurm/configs/l1_cnn_cap10k.yaml
@@ -1,0 +1,23 @@
+extends: _base
+job_name: l1-cnn-cap10k
+output_dir: output/r2dreamer-l1-replay-capacity/cnn-cap10k
+run_id: habitat-l1-cnn
+curriculum_check: data/curriculum/level1_1house_1goal.json
+comments:
+  - "3D-63: L1 CNN replay-capacity ablation at 10k transitions."
+  - "Fixed seed 42; stress-tests recent-data-only replay with post-training SR."
+sbatch:
+  time: "24:00:00"
+args:
+  steps: 2000000
+  prefill: 5000
+  checkpoint_every: 100000
+  output_dir: output/r2dreamer-l1-replay-capacity/cnn-cap10k/run-${SLURM_JOB_ID}
+  seed: 42
+  log_every: 250
+  buffer_capacity: 10000
+  wandb_project: 3d-vla-objectnav
+  wandb_name: l1-cnn-cap10k-${SLURM_JOB_ID}
+  wandb_tags: replay-capacity,3d-63,l1,cnn,cap-10k,seed-42,sr-ablation
+  video_log_every: 0
+  val_every: 0

--- a/scripts/slurm/configs/l1_cnn_cap1m.yaml
+++ b/scripts/slurm/configs/l1_cnn_cap1m.yaml
@@ -1,0 +1,23 @@
+extends: _base
+job_name: l1-cnn-cap1m
+output_dir: output/r2dreamer-l1-replay-capacity/cnn-cap1m
+run_id: habitat-l1-cnn
+curriculum_check: data/curriculum/level1_1house_1goal.json
+comments:
+  - "3D-63: L1 CNN replay-capacity baseline control at 1M transitions."
+  - "Fixed seed 42; matches 500k/100k/10k configs except for replay capacity."
+sbatch:
+  time: "24:00:00"
+args:
+  steps: 2000000
+  prefill: 5000
+  checkpoint_every: 100000
+  output_dir: output/r2dreamer-l1-replay-capacity/cnn-cap1m/run-${SLURM_JOB_ID}
+  seed: 42
+  log_every: 250
+  buffer_capacity: 1000000
+  wandb_project: 3d-vla-objectnav
+  wandb_name: l1-cnn-cap1m-${SLURM_JOB_ID}
+  wandb_tags: replay-capacity,3d-63,l1,cnn,cap-1m,seed-42,sr-ablation
+  video_log_every: 0
+  val_every: 0

--- a/scripts/slurm/configs/l1_cnn_cap500k.yaml
+++ b/scripts/slurm/configs/l1_cnn_cap500k.yaml
@@ -1,0 +1,23 @@
+extends: _base
+job_name: l1-cnn-cap500k
+output_dir: output/r2dreamer-l1-replay-capacity/cnn-cap500k
+run_id: habitat-l1-cnn
+curriculum_check: data/curriculum/level1_1house_1goal.json
+comments:
+  - "3D-63: L1 CNN replay-capacity baseline control at 500k transitions."
+  - "Fixed seed 42; matches 1M/100k/10k configs except for replay capacity."
+sbatch:
+  time: "24:00:00"
+args:
+  steps: 2000000
+  prefill: 5000
+  checkpoint_every: 100000
+  output_dir: output/r2dreamer-l1-replay-capacity/cnn-cap500k/run-${SLURM_JOB_ID}
+  seed: 42
+  log_every: 250
+  buffer_capacity: 500000
+  wandb_project: 3d-vla-objectnav
+  wandb_name: l1-cnn-cap500k-${SLURM_JOB_ID}
+  wandb_tags: replay-capacity,3d-63,l1,cnn,cap-500k,seed-42,sr-ablation
+  video_log_every: 0
+  val_every: 0

--- a/scripts/slurm/configs/l1_vggt_wpcp37_cap500k.yaml
+++ b/scripts/slurm/configs/l1_vggt_wpcp37_cap500k.yaml
@@ -1,0 +1,14 @@
+extends: wp_cp_mlp
+job_name: l1-wpcp37-cap500k
+output_dir: output/r2dreamer-l1-replay-capacity/wpcp37-cap500k
+comments:
+  - "3D-63: L1 VGGT WP/CP 37x37 replay-capacity ablation at 500k transitions."
+  - "Same encoder/run as wp_cp_mlp; only replay capacity is reduced from 1M to 500k."
+args:
+  output_dir: output/r2dreamer-l1-replay-capacity/wpcp37-cap500k/run-${SLURM_JOB_ID}
+  seed: 42
+  buffer_capacity: 500000
+  wandb_name: l1-wpcp37-cap500k-${SLURM_JOB_ID}
+  wandb_tags: replay-capacity,3d-63,l1,vggt,wp-cp,wp-37,cap-500k,seed-42,sr-ablation
+  video_log_every: 0
+  val_every: 0

--- a/scripts/slurm/configs/l1_vggt_wpcp37_cap500k.yaml
+++ b/scripts/slurm/configs/l1_vggt_wpcp37_cap500k.yaml
@@ -1,6 +1,8 @@
 extends: wp_cp_mlp
 job_name: l1-wpcp37-cap500k
 output_dir: output/r2dreamer-l1-replay-capacity/wpcp37-cap500k
+setup:
+  - ./scripts/slurm/hooks/link_external.sh
 comments:
   - "3D-63: L1 VGGT WP/CP 37x37 replay-capacity ablation at 500k transitions."
   - "Same encoder/run as wp_cp_mlp; only replay capacity is reduced from 1M to 500k."

--- a/scripts/slurm/configs/l1_vggt_wpcp64_cap500k.yaml
+++ b/scripts/slurm/configs/l1_vggt_wpcp64_cap500k.yaml
@@ -1,6 +1,8 @@
 extends: wp_cp_mlp_64
 job_name: l1-wpcp64-cap500k
 output_dir: output/r2dreamer-l1-replay-capacity/wpcp64-cap500k
+setup:
+  - ./scripts/slurm/hooks/link_external.sh
 comments:
   - "3D-63: L1 VGGT WP/CP 64x64 replay-capacity ablation at 500k transitions."
   - "Same encoder/run as wp_cp_mlp_64; only replay capacity is reduced from 1M to 500k."

--- a/scripts/slurm/configs/l1_vggt_wpcp64_cap500k.yaml
+++ b/scripts/slurm/configs/l1_vggt_wpcp64_cap500k.yaml
@@ -1,0 +1,14 @@
+extends: wp_cp_mlp_64
+job_name: l1-wpcp64-cap500k
+output_dir: output/r2dreamer-l1-replay-capacity/wpcp64-cap500k
+comments:
+  - "3D-63: L1 VGGT WP/CP 64x64 replay-capacity ablation at 500k transitions."
+  - "Same encoder/run as wp_cp_mlp_64; only replay capacity is reduced from 1M to 500k."
+args:
+  output_dir: output/r2dreamer-l1-replay-capacity/wpcp64-cap500k/run-${SLURM_JOB_ID}
+  seed: 42
+  buffer_capacity: 500000
+  wandb_name: l1-wpcp64-cap500k-${SLURM_JOB_ID}
+  wandb_tags: replay-capacity,3d-63,l1,vggt,wp-cp,wp-64,cap-500k,seed-42,sr-ablation
+  video_log_every: 0
+  val_every: 0

--- a/src/r2dreamer/launch/parser.py
+++ b/src/r2dreamer/launch/parser.py
@@ -97,6 +97,8 @@ def _add_loss_override_train_args(p: argparse.ArgumentParser) -> None:
     p.add_argument("--train_ratio", type=int, default=None,
                    help="Override cfg.train_ratio (production default 512). Lower "
                         "values bound train_step count for short smoke runs.")
+    p.add_argument("--buffer_capacity", "--buffer-capacity", type=int, default=None,
+                   help="Override cfg.buffer_capacity for replay-capacity ablations.")
 
 
 def _add_latent_decoder_train_args(p: argparse.ArgumentParser) -> None:

--- a/src/r2dreamer/launch/train.py
+++ b/src/r2dreamer/launch/train.py
@@ -107,6 +107,8 @@ def _agent_overrides_from_args(args: Any, encoder_spec: Any, latent_presets: dic
         agent_overrides["vggt_mlp_layers"] = args.mlp_layers
     if getattr(args, "train_ratio", None) is not None:
         agent_overrides["train_ratio"] = args.train_ratio
+    if getattr(args, "buffer_capacity", None) is not None:
+        agent_overrides["buffer_capacity"] = args.buffer_capacity
 
     # Latent-size ablation (3D-50): preset from the LATENT_PRESETS table, then
     # explicit flags win.

--- a/tests/r2dreamer/launch/test_parser.py
+++ b/tests/r2dreamer/launch/test_parser.py
@@ -1,6 +1,9 @@
 """Parser behavior tests for r2dreamer train launch flags."""
 
+from types import SimpleNamespace
+
 from src.r2dreamer.launch.parser import _build_parser_train
+from src.r2dreamer.launch.train import _agent_overrides_from_args
 
 
 def test_train_parser_does_not_expose_wandb_notes_file():
@@ -17,3 +20,22 @@ def test_mlp_layers_help_matches_conv_encoder_guard():
     assert "Only valid for VGGT MLP encoders" in help_text
     assert "CNN/dense-WP conv encoders require the default value (1)" in help_text
     assert "Ignored by the CNN/dense-WP conv encoders" not in help_text
+
+
+def test_buffer_capacity_override_accepts_hyphen_and_underscore_aliases():
+    parser = _build_parser_train()
+
+    hyphen = parser.parse_args(["--buffer-capacity", "500000"])
+    underscore = parser.parse_args(["--buffer_capacity", "100000"])
+
+    assert hyphen.buffer_capacity == 500_000
+    assert underscore.buffer_capacity == 100_000
+
+
+def test_buffer_capacity_override_wins_over_encoder_default():
+    args = _build_parser_train().parse_args(["--buffer-capacity", "500000"])
+    encoder_spec = SimpleNamespace(agent_overrides={"buffer_capacity": 1_000_000})
+
+    overrides = _agent_overrides_from_args(args, encoder_spec, latent_presets={})
+
+    assert overrides["buffer_capacity"] == 500_000

--- a/tests/slurm/test_launch.py
+++ b/tests/slurm/test_launch.py
@@ -318,6 +318,8 @@ def test_aggregator_prod_is_strict_bash() -> None:
 @pytest.mark.parametrize(
     "variant,run_id,capacity,tag",
     [
+        ("l1_cnn_cap1m", "habitat-l1-cnn", "1000000", "cap-1m"),
+        ("l1_cnn_cap500k", "habitat-l1-cnn", "500000", "cap-500k"),
         ("l1_cnn_cap100k", "habitat-l1-cnn", "100000", "cap-100k"),
         ("l1_cnn_cap10k", "habitat-l1-cnn", "10000", "cap-10k"),
         ("l1_vggt_wpcp37_cap500k", "habitat-l1-vggt", "500000", "cap-500k"),

--- a/tests/slurm/test_launch.py
+++ b/tests/slurm/test_launch.py
@@ -349,3 +349,17 @@ def test_l1_aggregator_capacity_ablation_keeps_encoder_batch_defaults() -> None:
     assert "--batch_size" not in flags
     assert "--seq_len" not in flags
     assert "--train_ratio" not in flags
+
+
+@pytest.mark.parametrize(
+    "variant",
+    [
+        "l1_vggt_wpcp37_cap500k",
+        "l1_vggt_wpcp64_cap500k",
+        "l1_agg_mlp_cap500k",
+    ],
+)
+def test_l1_vggt_capacity_ablation_links_external_repos(variant: str) -> None:
+    rendered = launch.render_sbatch(launch.load_config(variant), mode="smoke")
+
+    assert "./scripts/slurm/hooks/link_external.sh" in rendered

--- a/tests/slurm/test_launch.py
+++ b/tests/slurm/test_launch.py
@@ -313,3 +313,39 @@ def test_aggregator_smoke_overrides() -> None:
 def test_aggregator_prod_is_strict_bash() -> None:
     rendered = launch.render_sbatch(launch.load_config("aggregator_mlp_v1"), mode="prod")
     assert "set -euo pipefail" in rendered
+
+
+@pytest.mark.parametrize(
+    "variant,run_id,capacity,tag",
+    [
+        ("l1_cnn_cap100k", "habitat-l1-cnn", "100000", "cap-100k"),
+        ("l1_cnn_cap10k", "habitat-l1-cnn", "10000", "cap-10k"),
+        ("l1_vggt_wpcp37_cap500k", "habitat-l1-vggt", "500000", "cap-500k"),
+        ("l1_vggt_wpcp64_cap500k", "habitat-l1-vggt-wp-cp-64", "500000", "cap-500k"),
+        ("l1_agg_mlp_cap500k", "habitat-l1-vggt-aggregator-mlp", "500000", "cap-500k"),
+    ],
+)
+def test_l1_replay_capacity_ablation_configs(
+    variant: str, run_id: str, capacity: str, tag: str,
+) -> None:
+    rendered = launch.render_sbatch(launch.load_config(variant), mode="prod")
+    _, script, rendered_run_id, flags = training_command(rendered)
+
+    assert script.endswith("run.py")
+    assert rendered_run_id == run_id
+    assert flags["--seed"] == "42"
+    assert flags["--buffer_capacity"] == capacity
+    assert tag in flags["--wandb_tags"]
+    assert "3d-63" in flags["--wandb_tags"]
+    assert flags["--video_log_every"] == "0"
+    assert flags["--val_every"] == "0"
+
+
+def test_l1_aggregator_capacity_ablation_keeps_encoder_batch_defaults() -> None:
+    rendered = launch.render_sbatch(launch.load_config("l1_agg_mlp_cap500k"), mode="prod")
+    _, _, _, flags = training_command(rendered)
+
+    assert flags["--buffer_capacity"] == "500000"
+    assert "--batch_size" not in flags
+    assert "--seq_len" not in flags
+    assert "--train_ratio" not in flags


### PR DESCRIPTION
## What changed

- Added `--buffer_capacity` / `--buffer-capacity` as a train-time replay buffer override.
- Added focused L1 replay-capacity SLURM configs for one seed (`42`):
  - CNN baseline at `100_000`
  - CNN baseline at `10_000`
  - VGGT_WP_CP37 at `500_000`
  - VGGT_WP_CP64 at `500_000`
  - `vggt_aggregator_mlp` at `500_000`
- Added VGGT external-link setup hooks for the worktree-based VGGT jobs.
- Added parser and SLURM render tests for the new flag/config behavior.

## Why

This gives a clean L1-only replay-capacity comparison using downstream ObjectNav SR as the primary metric, while keeping architecture, seed, step budget, and encoder batch settings unchanged except for replay capacity.

## Linear issue

3D-63: L1 replay capacity ablation

## Acceptance criteria checked

- L1 only.
- One seed: `42`.
- CNN baseline runs at capacities `100_000` and `10_000`.
- VGGT_WP_CP variants run at capacity `500_000`.
- `vggt_aggregator_mlp` runs at capacity `500_000`.
- Aggregator keeps existing `aggregator_mlp_v1` batch defaults (`batch_size=4`, `seq_len=32`, `train_ratio=128`).
- Comparison target remains post-training SR.

## Submitted jobs

| Variant | Capacity | Smoke job | Smoke status | Production job | Production status |
|---|---:|---:|---|---:|---|
| CNN baseline | 100,000 | 4930764 | COMPLETED, exit 0 | 4930767 | PENDING, Priority |
| CNN baseline | 10,000 | 4930768 | COMPLETED, exit 0 | 4930769 | PENDING, Priority |
| VGGT_WP_CP37 | 500,000 | 4931245 | COMPLETED, exit 0 | 4931246 | PENDING, Priority |
| VGGT_WP_CP64 | 500,000 | 4931247 | COMPLETED, exit 0 | 4931248 | PENDING, Priority |
| `vggt_aggregator_mlp` | 500,000 | 4931251 | COMPLETED, exit 0 | 4931252 | PENDING, Priority |

## Verification

- `.venv/bin/python -m pytest tests/r2dreamer/launch/test_parser.py`
- `.venv/bin/python -m pytest tests/slurm/test_launch.py`
- `git diff --check`
- `scripts/slurm/launch.sh l1_cnn_cap100k l1_cnn_cap10k l1_vggt_wpcp37_cap500k l1_vggt_wpcp64_cap500k l1_agg_mlp_cap500k --smoke --dry-run`
- Smoke-then-prod submission completed; all five smoke jobs passed.

## Risk

Low code risk: the replay capacity override is opt-in and defaults to no override. Experiment risk remains until production jobs finish and final SR is collected.

## How to test

Render any new config with `scripts/slurm/launch.sh <config> --smoke --dry-run` and confirm the generated command includes `--buffer_capacity` with the expected value. Run the focused parser and SLURM launcher tests above.

## What was intentionally not done

- Did not change replay buffer internals.
- Did not change model architecture.
- Did not change SR/eval metric logic.
- Did not add extra seeds or levels beyond L1.
- Did not mark this ready for merge before production SR results are available.

## Agent involvement

Implemented and submitted by Codex in the dedicated `3d-63-l1-replay-capacity-ablation` worktree.

## W&B result audit before merge

Checked via W&B project `sailer-luca-university-ulm/3d-vla-objectnav` and local SLURM logs before marking this PR ready.

| Variant | Job / W&B run | State | Last step | SR | SPL | Note |
|---|---|---:|---:|---:|---:|---|
| CNN cap 100k | 4930767 / o8bbt8br | finished | 1,999,967 | 0.43 | 0.2926 | full run |
| CNN cap 10k | 4930769 / f2jt7us5 | finished | 1,999,964 | 0.24 | 0.1844 | full run |
| WP/CP37 cap 500k | 4931246 / rx29922r | timeout/crashed | 1,630,528 | 0.54 | 0.3932 | partial run; not claimed fully converged |
| WP/CP64 cap 500k | 4931248 / i0ex1vws | timeout/crashed | 1,466,797 | 0.56 | 0.3916 | partial run; not claimed fully converged |
| Aggregator MLP cap 500k | 4931252 / 5959vo44 | timeout/crashed | 1,599,462 | 0.60 | 0.4618 | partial run; not claimed fully converged |

Merge-readiness decision: this PR primarily adds the replay-capacity override and launcher configs. The code path is opt-in and the targeted tests/smokes passed. The VGGT/Aggregator experiment results exist in W&B but are partial timeout snapshots, so downstream analysis should treat them as interim evidence rather than completed 2M-step production results.
