### PR TITLE
3D-65: Add normalized fixed-scale hybrid ablation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,8 @@ worktrees/
 *.aux
 *.log
 
-# external repos — cloned locally, not committed
-external/*/
+# external repos — cloned or symlinked locally, not committed
+external/*
 !external/.gitkeep
 
 # uv lockfile

--- a/scripts/r2dreamer/_run_configs.py
+++ b/scripts/r2dreamer/_run_configs.py
@@ -110,6 +110,18 @@ RUN_CONFIGS: dict[str, dict[str, Any]] = {
             "hybrid", "cnn", "wp-cp", "3d-encoder", "jax",
         ],
     ),
+    # L1 Hybrid fixed-scale normalization ablation (3D-65).
+    "habitat-l1-hybrid-norm-fixed": dict(
+        env="habitat",
+        encoder="hybrid_norm_fixed",
+        curriculum="L1",
+        output_dir="output/runs/r2dreamer-curriculum-l1-hybrid-norm-fixed",
+        wandb_name="hybrid-norm-fixed",
+        wandb_tags=[
+            "curriculum", "level1", "1house", "chair-only", "vggt",
+            "hybrid", "cnn", "wp-cp", "norm-fixed", "3d-65", "3d-encoder", "jax",
+        ],
+    ),
     # L1 VGGT — WP+CP MLP at a 64x64 world-point grid (3D-52/3D-53).
     "habitat-l1-vggt-wp-cp-64": dict(
         env="habitat",

--- a/scripts/slurm/configs/hybrid_norm_fixed.yaml
+++ b/scripts/slurm/configs/hybrid_norm_fixed.yaml
@@ -1,0 +1,35 @@
+extends: _base
+job_name: hybrid-norm-fixed
+output_dir: output/runs/r2dreamer-curriculum-l1-hybrid-norm-fixed
+run_id: habitat-l1-hybrid-norm-fixed
+curriculum_check: data/curriculum/level1_1house_1goal.json
+comments:
+  - "3D-65 hybrid ablation: CNN(RGB_64) + fixed-scale RMS-normalized MLP(WP/CP 4116)"
+  - "Keeps the default hybrid input layout but removes the learned zero-init VGGT gate."
+  - "Logs hybrid/{gate,cnn_frac,vggt_frac}; hybrid/gate is fixed at 1.0 for this run."
+env:
+  R2DREAMER_HARD_EXIT_ON_FINISH: "1"
+args:
+  steps: 2000000
+  prefill: 5000
+  checkpoint_every: 100000
+  output_dir: output/runs/r2dreamer-curriculum-l1-hybrid-norm-fixed/run-${SLURM_JOB_ID}
+  seed: ${SLURM_JOB_ID}
+  log_every: 250
+  wandb_project: 3d-vla-objectnav
+  wandb_name: hybrid-norm-fixed-${SLURM_JOB_ID}
+  wandb_tags: curriculum,level1,1house,chair-only,hybrid,cnn,wp-cp,norm-fixed,3d-65,jax,3d-encoder
+  render_resolution: 518
+smoke:
+  time: "00:20:00"
+  args:
+    steps: 800
+    prefill: 200
+    batch_size: 4
+    seq_len: 16
+    train_ratio: 16
+    log_every: 50
+    checkpoint_every: 10000
+    output_dir: output/smoke/hybrid-norm-fixed-${TIMESTAMP}
+    wandb_name: hybrid-norm-fixed-smoke-${TIMESTAMP}
+    wandb_tags: hybrid,smoke,cnn+vggt,norm-fixed,3d-65

--- a/scripts/slurm/configs/hybrid_norm_fixed.yaml
+++ b/scripts/slurm/configs/hybrid_norm_fixed.yaml
@@ -7,6 +7,8 @@ comments:
   - "3D-65 hybrid ablation: CNN(RGB_64) + fixed-scale RMS-normalized MLP(WP/CP 4116)"
   - "Keeps the default hybrid input layout but removes the learned zero-init VGGT gate."
   - "Logs hybrid/{gate,cnn_frac,vggt_frac}; hybrid/gate is fixed at 1.0 for this run."
+setup:
+  - bash scripts/slurm/hooks/link_external.sh
 env:
   R2DREAMER_HARD_EXIT_ON_FINISH: "1"
 args:

--- a/scripts/slurm/launch.py
+++ b/scripts/slurm/launch.py
@@ -187,8 +187,9 @@ def _format_arg(name: str, value: Any, arg_style: str) -> str:
 
 
 def _python_cmd(config: LaunchConfig, mode: Mode) -> str:
-    # Skip the (slow) dependency resync for the default uv interpreter on smokes.
-    if mode == "smoke" and config.python == "uv run python":
+    # Slurm jobs share the worktree .venv symlink; never let concurrent jobs
+    # mutate it while starting.
+    if config.python == "uv run python":
         return "uv run --no-sync python"
     return config.python
 
@@ -256,7 +257,7 @@ def render_sbatch(config: LaunchConfig, *, mode: Mode = "prod") -> str:
             "# Generate curriculum configs if not present",
             f"if [ ! -f {config.curriculum_check} ]; then",
             '    echo "Generating curriculum configs..."',
-            "    uv run python scripts/environments/generate_curriculum.py",
+            "    uv run --no-sync python scripts/environments/generate_curriculum.py",
             "fi",
             "",
         ])

--- a/src/main.py
+++ b/src/main.py
@@ -35,7 +35,10 @@ def _build_parser() -> argparse.ArgumentParser:
     train_parser.add_argument(
         "--encoder",
         default="cnn",
-        choices=["cnn", "vggt", "vggt_aggregator_mlp", "vggt_wp_dense_cnn", "vggt_wp_cp_64", "hybrid"],
+        choices=[
+            "cnn", "vggt", "vggt_aggregator_mlp", "vggt_wp_dense_cnn",
+            "vggt_wp_cp_64", "hybrid", "hybrid_norm_fixed",
+        ],
     )
     train_parser.add_argument("--curriculum", default=None)
 
@@ -44,7 +47,10 @@ def _build_parser() -> argparse.ArgumentParser:
     eval_parser.add_argument(
         "--encoder",
         default="cnn",
-        choices=["cnn", "vggt", "vggt_aggregator_mlp", "vggt_wp_dense_cnn", "vggt_wp_cp_64", "hybrid"],
+        choices=[
+            "cnn", "vggt", "vggt_aggregator_mlp", "vggt_wp_dense_cnn",
+            "vggt_wp_cp_64", "hybrid", "hybrid_norm_fixed",
+        ],
     )
     eval_parser.add_argument("--curriculum", default=None)
     eval_parser.add_argument("--checkpoint", default=None)

--- a/src/r2dreamer/agent.py
+++ b/src/r2dreamer/agent.py
@@ -31,6 +31,7 @@ from .world_model.encoders import (
     WPConvEncoder,
     ConvDecoder,
     HybridEncoder as WMHybridEncoder,
+    HybridNormFixedEncoder as WMHybridNormFixedEncoder,
     VGGTEncoder as WMVGGTEncoder,
     VGGTAggregatorMLPEncoder as WMVGGTAggregatorMLPEncoder,
     HYBRID_RGB_DIM,
@@ -44,6 +45,8 @@ from .behavior.loss import behavior_loss
 from .representation.barlow import Projector
 from .representation.loss import representation_loss
 from src.shared.optim import laprop, agc
+
+HYBRID_ENCODER_TYPES = ("hybrid", "hybrid_norm_fixed")
 
 # Re-export internal helpers so test_cross_framework.py keeps working.
 __all__ = [
@@ -123,6 +126,7 @@ def _resolve_encoder_cls(cfg: R2DreamerConfig):
             "vggt_aggregator_mlp": WMVGGTAggregatorMLPEncoder,
             "vggt_wp_dense_cnn": WPConvEncoder,
             "hybrid": WMHybridEncoder,
+            "hybrid_norm_fixed": WMHybridNormFixedEncoder,
         }.get(cfg.encoder_type)
         if cls is None:
             raise ValueError(f"unknown encoder_type {cfg.encoder_type!r}")
@@ -160,8 +164,8 @@ def _make_wp_conv_encoder(cfg: R2DreamerConfig):
     )
 
 
-def _make_hybrid_encoder(cfg: R2DreamerConfig):
-    # CNN(RGB) + gated MLP(WP/CP) fused into one embed (3D-50/51/52).
+def _make_hybrid_encoder(cfg: R2DreamerConfig, cls=WMHybridEncoder):
+    # CNN(RGB) + MLP(WP/CP) fused into one embed (3D-50/51/52/65).
     # Guard the buffer-layout contract: the encoder splits obs at
     # HYBRID_RGB_DIM, while the decoder/loss derive the RGB slice as
     # obs_shape[0] - vggt_feature_dim. Both must agree, or the RGB target
@@ -176,7 +180,7 @@ def _make_hybrid_encoder(cfg: R2DreamerConfig):
             f"{HYBRID_VGGT_DIM}, got obs_shape={cfg.obs_shape}, "
             f"vggt_feature_dim={cfg.vggt_feature_dim}"
         )
-    return WMHybridEncoder(
+    kwargs = dict(
         cnn_depth=cfg.encoder_depth,
         cnn_kernel=cfg.encoder_kernel,
         cnn_mults=cfg.encoder_mults,
@@ -184,6 +188,9 @@ def _make_hybrid_encoder(cfg: R2DreamerConfig):
         mlp_hidden=cfg.mlp_vggt_hidden,
         mlp_layers=cfg.mlp_vggt_layers,
     )
+    if cls is WMHybridNormFixedEncoder:
+        kwargs["fixed_vggt_scale"] = cfg.hybrid_fixed_scale
+    return cls(**kwargs)
 
 
 def _make_mlp_encoder(cfg: R2DreamerConfig, cls):
@@ -202,8 +209,8 @@ def _make_encoder(cfg: R2DreamerConfig):
         return _make_conv_encoder(cfg)
     if cls is WPConvEncoder:
         return _make_wp_conv_encoder(cfg)
-    if cls is WMHybridEncoder:
-        return _make_hybrid_encoder(cfg)
+    if cls in (WMHybridEncoder, WMHybridNormFixedEncoder):
+        return _make_hybrid_encoder(cfg, cls)
     return _make_mlp_encoder(cfg, cls)
 
 
@@ -249,14 +256,18 @@ def _add_hybrid_contribution_metrics(
     T: int,
 ) -> None:
     # Reuse the already-computed fused embed instead of a second encoder
-    # forward: embed == concat([cnn_e, gate * vggt_mlp(...)]), so the
-    # leading cnn_dim columns are the CNN branch and the rest are the
-    # gated VGGT branch. The raw gate scalar is read straight from params.
+    # forward: embed == concat([cnn_e, vggt_branch]), so the leading cnn_dim
+    # columns are the CNN branch and the rest are the VGGT branch. The learned
+    # hybrid reads a trainable gate param; fixed-scale variants log their config
+    # scale under the same key for W&B chart comparability.
     embed_flat = forward["embed"].reshape(B * T, -1)
     cnn_dim = embed_flat.shape[-1] - cfg.vggt_embed_dim
     cnn_e = embed_flat[:, :cnn_dim]
     vggt_e = embed_flat[:, cnn_dim:]
-    gate = params["encoder"]["params"]["gate"]
+    encoder_params = params["encoder"].get("params", {})
+    gate = encoder_params.get("gate")
+    if gate is None:
+        gate = jnp.asarray(cfg.hybrid_fixed_scale, dtype=embed_flat.dtype)
     cnn_l2 = jnp.sqrt(jnp.mean(jnp.sum(cnn_e ** 2, axis=-1)))
     vggt_l2 = jnp.sqrt(jnp.mean(jnp.sum(vggt_e ** 2, axis=-1)))
     denom = cnn_l2 + vggt_l2 + 1e-8
@@ -381,9 +392,10 @@ class R2DreamerAgent:
         self.decoder_mod = None
         dec_params = None
         if config.decoder:
-            if config.encoder_type not in ("cnn", "hybrid"):
+            if config.encoder_type not in ("cnn", *HYBRID_ENCODER_TYPES):
                 raise ValueError(
-                    "decoder=True requires encoder_type in {'cnn', 'hybrid'} — the "
+                    "decoder=True requires encoder_type in {'cnn', 'hybrid', "
+                    "'hybrid_norm_fixed'} — the "
                     "ConvDecoder reconstructs an RGB image, but "
                     f"{config.encoder_type!r} carries no RGB modality to reconstruct."
                 )
@@ -465,7 +477,7 @@ class R2DreamerAgent:
         Returns:
             Integer action in [0, num_actions).
         """
-        if self.cfg.encoder_type == "hybrid":
+        if self.cfg.encoder_type in HYBRID_ENCODER_TYPES:
             # Hybrid: the adapter pre-builds the flat [rgb_norm | wp_cp] vector
             # under "hybrid" (already float32, RGB already /255). The encoder
             # slices it back into the CNN and WP/CP branches.
@@ -553,7 +565,7 @@ class R2DreamerAgent:
         feat = self.rssm_mod.apply(
             params["rssm"], post_stochs, post_deters, method=self.rssm_mod.get_feat)
         recon = self.decoder_mod.apply(params["decoder"], feat.reshape(B * T, -1))
-        if self.cfg.encoder_type == "hybrid":
+        if self.cfg.encoder_type in HYBRID_ENCODER_TYPES:
             rgb_dim = self.cfg.obs_shape[0] - self.cfg.vggt_feature_dim
             target = obs_flat[:, :rgb_dim].reshape(B * T, 3, 64, 64)
         else:
@@ -720,10 +732,10 @@ class R2DreamerAgent:
 
         # ---- Hybrid contribution diagnostics (3D-50) ----
         # Re-split the fused embed into its CNN and gated-VGGT branches via the
-        # encoder's `branches` method (shares params with the forward pass) and
-        # log how much each modality drives the latent. `gate` starts at 0 and
-        # opens over training; `*_frac` is each branch's share of the embed norm.
-        if cfg.encoder_type == "hybrid":
+        # encoder's fused embed and log how much each modality drives the latent.
+        # Learned-gate hybrid logs its trainable scalar; fixed-scale ablations log
+        # their configured constant. `*_frac` is each branch's share of embed norm.
+        if cfg.encoder_type in HYBRID_ENCODER_TYPES:
             _add_hybrid_contribution_metrics(
                 metrics, cfg=cfg, params=params, forward=forward, B=B, T=T,
             )

--- a/src/r2dreamer/config.py
+++ b/src/r2dreamer/config.py
@@ -47,6 +47,7 @@ class R2DreamerConfig:
     # above governs the standalone vggt/aggregator encoders).
     mlp_vggt_hidden: int = 1024   # hidden width of the hybrid VGGT-branch MLP
     mlp_vggt_layers: int = 2      # depth of the hybrid VGGT-branch MLP
+    hybrid_fixed_scale: float = 1.0  # fixed VGGT branch scale for 3D-65 ablations
     # --- Co-trained decoder (image reconstruction; OFF by default; 3D-51) ---
     # When False (default) no decoder params are built and no reconstruction
     # term is added, so CNN/VGGT runs are byte-for-byte unchanged.

--- a/src/r2dreamer/encoders/__init__.py
+++ b/src/r2dreamer/encoders/__init__.py
@@ -227,6 +227,24 @@ class HybridEncoder(VGGTEncoder):
         return HybridObsAdapter(self._extractor)
 
 
+class HybridNormFixedEncoder(HybridEncoder):
+    """CNN(RGB 64) + fixed-scale normalized MLP(WP+CP) ablation (3D-65)."""
+
+    encoder_type = "hybrid_norm_fixed"
+    module_cls = wm_encoders.HybridNormFixedEncoder
+    agent_overrides = {
+        "buffer_capacity": 100_000,
+        "hybrid_fixed_scale": 1.0,
+    }
+    design_notes = (
+        "3D-65 hybrid ablation: same input layout as the default hybrid "
+        "([64x64 RGB | 4116-dim VGGT world_points+camera_pose]) but both branch "
+        "embeddings are parameter-free RMS-normalized before concatenation. The "
+        "VGGT branch uses a fixed scale of 1.0 instead of a learned zero-init gate, "
+        "so the run tests whether the learned gate caused bad branch-scale dynamics."
+    )
+
+
 class VGGTWPCP64Encoder(VGGTEncoder):
     """WP+CP MLP at a finer 64x64 world-point grid (3D-52/3D-53 follow-up).
 
@@ -264,5 +282,6 @@ __all__ = [
     "VGGTAggregatorMLPEncoder",
     "VGGTDenseWPEncoder",
     "HybridEncoder",
+    "HybridNormFixedEncoder",
     "VGGTWPCP64Encoder",
 ]

--- a/src/r2dreamer/launch/evaluate.py
+++ b/src/r2dreamer/launch/evaluate.py
@@ -96,10 +96,10 @@ def _make_eval_env(*, args, curriculum_path: str | None, eff_encoder: str):
     from src.shared.configs import DreamerConfig
     from src.environments.habitat import HabitatObjectNavEnv
 
-    # All VGGT readouts (wp_cp, aggregator, dense-WP CNN) AND the hybrid encoder
+    # All VGGT readouts (wp_cp, aggregator, dense-WP CNN) AND hybrid encoders
     # need 518x518 frames; the plain CNN baseline uses 64. Everything else is
     # driven off the EncoderSpec below.
-    needs_hires = eff_encoder.startswith("vggt") or eff_encoder == "hybrid"
+    needs_hires = eff_encoder.startswith("vggt") or eff_encoder.startswith("hybrid")
     default_resolution = 518 if needs_hires else 64
     render_resolution = (
         args.render_resolution if args.render_resolution is not None else default_resolution

--- a/src/r2dreamer/launch/parser.py
+++ b/src/r2dreamer/launch/parser.py
@@ -30,9 +30,9 @@ def _add_basic_train_args(p: argparse.ArgumentParser) -> None:
 
 
 def _add_val_train_args(p: argparse.ArgumentParser) -> None:
-    # Val-Episode-Loop (3D-36). 0 disables. Default 50_000 matches the
-    # checkpoint cadence so val signals land alongside checkpoints.
-    p.add_argument("--val_every", type=int, default=50_000,
+    # Val-Episode-Loop (3D-36). Disabled by default; opt in explicitly for
+    # diagnostic runs that can afford the extra Habitat simulator.
+    p.add_argument("--val_every", type=int, default=0,
                    help="Run a deterministic val-episode loop every N steps (0 disables)")
     p.add_argument("--val_episodes", type=int, default=50,
                    help="Episodes per val-loop trigger")
@@ -46,8 +46,8 @@ def _add_resume_video_train_args(p: argparse.ArgumentParser) -> None:
     p.add_argument("--resume_from", type=str, default=None)
     p.add_argument("--wandb_id", type=str, default=None,
                    help="W&B run-id to reattach to (resume='must')")
-    p.add_argument("--video_log_every", type=int, default=25_000,
-                   help="Log one Habitat episode video every N train steps")
+    p.add_argument("--video_log_every", type=int, default=0,
+                   help="Log one Habitat episode video every N train steps (0 disables)")
     p.add_argument("--video_log_episodes", type=int, default=1,
                    help="Number of Habitat train episodes to record per interval")
     p.add_argument("--act_entropy", type=float, default=3e-2,

--- a/src/r2dreamer/launch/parser.py
+++ b/src/r2dreamer/launch/parser.py
@@ -140,7 +140,10 @@ def _build_parser_eval() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(add_help=True)
     p.add_argument("--checkpoint", type=str, default=None)
     p.add_argument("--encoder", type=str, default=None,
-                   choices=["cnn", "vggt", "vggt_aggregator_mlp", "vggt_wp_dense_cnn", "vggt_wp_cp_64", "hybrid"])
+                   choices=[
+                       "cnn", "vggt", "vggt_aggregator_mlp", "vggt_wp_dense_cnn",
+                       "vggt_wp_cp_64", "hybrid", "hybrid_norm_fixed",
+                   ])
     p.add_argument("--random", action="store_true",
                    help="Use random agent instead of a checkpoint")
     p.add_argument("--episodes", type=int, default=10)

--- a/src/r2dreamer/launch/registries.py
+++ b/src/r2dreamer/launch/registries.py
@@ -10,6 +10,7 @@ from src.r2dreamer.encoders import (
     VGGTDenseWPEncoder,
     VGGTWPCP64Encoder,
     HybridEncoder,
+    HybridNormFixedEncoder,
 )
 from src.r2dreamer.launch.habitat_setup import make_habitat_env
 
@@ -27,6 +28,7 @@ encoder_registry: dict[str, type[Encoder]] = {
     "vggt_wp_dense_cnn": VGGTDenseWPEncoder,
     "vggt_wp_cp_64": VGGTWPCP64Encoder,
     "hybrid": HybridEncoder,
+    "hybrid_norm_fixed": HybridNormFixedEncoder,
 }
 
 env_registry: dict[str, Callable] = {

--- a/src/r2dreamer/trainer.py
+++ b/src/r2dreamer/trainer.py
@@ -118,12 +118,12 @@ class TrainerConfig:
     wandb_tags: list[str] = field(default_factory=lambda: ["r2dreamer"])
     # Resume an existing W&B run (e.g. "87u0l6dy"). Requires the run to exist.
     wandb_id: str | None = None
-    video_log_every: int = 25_000
+    video_log_every: int = 0
     video_log_episodes: int = 1
 
-    # Deterministic Val-Episode-Loop. val_every=0 disables. Requires a
-    # val_env to be passed to Trainer.
-    val_every: int = 50_000
+    # Deterministic Val-Episode-Loop. Disabled by default; val_every > 0
+    # requires a val_env to be passed to Trainer.
+    val_every: int = 0
     val_episodes: int = 50
     val_video_episodes: int = 1
     val_max_episode_steps: int = 500

--- a/src/r2dreamer/world_model/__init__.py
+++ b/src/r2dreamer/world_model/__init__.py
@@ -7,6 +7,7 @@ from .encoders import (
     VGGTAggregatorMLPEncoder,
     WPConvEncoder,
     HybridEncoder,
+    HybridNormFixedEncoder,
     ConvDecoder,
 )
 from .heads import R2MLP, R2TwoHotDist, onehot_mode_st
@@ -15,7 +16,7 @@ from .loss import world_model_loss, kl_loss
 __all__ = [
     "RMSNorm", "BlockLinear", "Deter", "R2RSSM",
     "ConvEncoder", "VGGTEncoder", "VGGTAggregatorMLPEncoder", "WPConvEncoder",
-    "HybridEncoder", "ConvDecoder",
+    "HybridEncoder", "HybridNormFixedEncoder", "ConvDecoder",
     "R2MLP", "R2TwoHotDist", "onehot_mode_st",
     "world_model_loss", "kl_loss",
 ]

--- a/src/r2dreamer/world_model/encoders.py
+++ b/src/r2dreamer/world_model/encoders.py
@@ -34,6 +34,12 @@ def _symlog(x: jnp.ndarray) -> jnp.ndarray:
     return jnp.sign(x) * jnp.log1p(jnp.abs(x))
 
 
+def _unit_rms(x: jnp.ndarray, eps: float = 1e-4) -> jnp.ndarray:
+    """Parameter-free RMS normalization for branch-scale ablations."""
+    rms = jnp.sqrt(jnp.mean(x ** 2, axis=-1, keepdims=True) + eps)
+    return x / rms
+
+
 class ConvEncoder(nn.Module):
     """Convolutional encoder ported from R2-Dreamer.
 
@@ -260,6 +266,55 @@ class HybridEncoder(nn.Module):
         """
         cnn_e, vggt_e = self._branches(obs)
         return cnn_e, vggt_e, self.gate
+
+
+class HybridNormFixedEncoder(nn.Module):
+    """Hybrid encoder with normalized branches and a fixed-open VGGT scale (3D-65).
+
+    This is an ablation of ``HybridEncoder`` that keeps the same input layout and
+    branch architectures but removes the learned scalar gate. Both branch embeddings
+    are parameter-free RMS-normalized before fusion, then the VGGT branch is scaled
+    by ``fixed_vggt_scale`` (default 1.0). The goal is to test whether the learned
+    zero-init gate created bad scale dynamics without changing the RGB/VGGT inputs.
+    """
+    cnn_depth: int = 16
+    cnn_kernel: int = 5
+    cnn_mults: tuple = (2, 3, 4, 4)
+    vggt_embed_dim: int = 1024
+    mlp_hidden: int = 1024
+    mlp_layers: int = 2
+    fixed_vggt_scale: float = 1.0
+    rgb_dim: int = HYBRID_RGB_DIM
+    vggt_dim: int = HYBRID_VGGT_DIM
+
+    def setup(self):
+        self.cnn = ConvEncoder(
+            depth=self.cnn_depth, kernel_size=self.cnn_kernel, mults=self.cnn_mults
+        )
+        self.vggt_mlp = R2MLP(
+            hidden=self.mlp_hidden, layers=self.mlp_layers, out_dim=self.vggt_embed_dim
+        )
+
+    def _branches(self, obs):
+        if obs.ndim != 2 or obs.shape[-1] != self.rgb_dim + self.vggt_dim:
+            raise ValueError(
+                f"expected (B, {self.rgb_dim + self.vggt_dim}) hybrid-norm-fixed "
+                f"features, got {obs.shape}"
+            )
+        rgb = obs[..., : self.rgb_dim].reshape(obs.shape[0], 3, 64, 64)
+        wp_cp = obs[..., self.rgb_dim :]
+        cnn_e = _unit_rms(self.cnn(rgb))
+        vggt_e = self.fixed_vggt_scale * _unit_rms(self.vggt_mlp(wp_cp))
+        return cnn_e, vggt_e
+
+    def __call__(self, obs):
+        cnn_e, vggt_e = self._branches(obs)
+        return jnp.concatenate([cnn_e, vggt_e], axis=-1)
+
+    def branches(self, obs):
+        cnn_e, vggt_e = self._branches(obs)
+        gate = jnp.asarray(self.fixed_vggt_scale, dtype=obs.dtype)
+        return cnn_e, vggt_e, gate
 
 
 class HybridAggPooledModule(nn.Module):

--- a/src/r2dreamer/world_model/loss.py
+++ b/src/r2dreamer/world_model/loss.py
@@ -95,7 +95,7 @@ def world_model_loss(*, forward, params, batch, modules, cfg, twohot):
     # are identical to the decoder-free baseline. 3D-51 visual-verification head.
     if cfg.decoder:
         recon = modules["decoder"].apply(params["decoder"], feat_flat)  # (BT,3,64,64)
-        if cfg.encoder_type == "hybrid":
+        if cfg.encoder_type.startswith("hybrid"):
             # Hybrid obs is [ rgb (rgb_dim) | wp_cp (vggt_feature_dim) ]; the RGB
             # slice is already normalised to [0, 1] by the adapter.
             rgb_dim = cfg.obs_shape[0] - cfg.vggt_feature_dim  # 16404 - 4116 = 12288

--- a/tests/r2dreamer/launch/test_encoders.py
+++ b/tests/r2dreamer/launch/test_encoders.py
@@ -11,6 +11,7 @@ from src.r2dreamer.encoders import (
     CNNEncoder,
     EncoderSpec,
     HybridEncoder,
+    HybridNormFixedEncoder,
     VGGTEncoder,
     VGGTAggregatorMLPEncoder,
     VGGTDenseWPEncoder,
@@ -319,6 +320,33 @@ class TestHybridEncoder:
         assert spec.obs_shape == (16404,)
         assert spec.env_render_resolution == 518
         assert spec.module_cls is wm_encoders.HybridEncoder
+
+    def test_hybrid_norm_fixed_encoder_exposes_spec(self, monkeypatch):
+        class FakeExtractor:
+            aggregator_feature_shape = (1374, 1024)
+
+            def __init__(self, **kwargs):
+                pass
+
+            def reset(self):
+                pass
+
+        monkeypatch.setattr(
+            "src.r2dreamer.encoders.VGGTFeatureExtractor",
+            FakeExtractor,
+        )
+
+        spec = HybridNormFixedEncoder().spec()
+        assert isinstance(spec, EncoderSpec)
+        assert spec.encoder_type == "hybrid_norm_fixed"
+        assert spec.obs_shape == (16404,)
+        assert spec.env_render_resolution == 518
+        assert spec.module_cls is wm_encoders.HybridNormFixedEncoder
+        assert spec.agent_overrides == {
+            "buffer_capacity": 100_000,
+            "hybrid_fixed_scale": 1.0,
+        }
+        assert "fixed scale of 1.0" in spec.design_notes
 
     def test_hybrid_adapter_builds_rgb_wp_cp_layout(self):
         # Fake VGGT extractor: extract() -> world_points (37,37,3) + camera_pose (9,)

--- a/tests/r2dreamer/launch/test_parser.py
+++ b/tests/r2dreamer/launch/test_parser.py
@@ -11,6 +11,22 @@ def test_train_parser_does_not_expose_wandb_notes_file():
     assert "--wandb_notes_file" not in parser.format_help()
 
 
+def test_train_parser_defaults_disable_in_run_val_and_video():
+    parser = _build_parser_train()
+    args = parser.parse_args([])
+
+    assert args.val_every == 0
+    assert args.video_log_every == 0
+
+
+def test_train_parser_allows_explicit_val_and_video_opt_in():
+    parser = _build_parser_train()
+    args = parser.parse_args(["--val_every", "50000", "--video_log_every", "25000"])
+
+    assert args.val_every == 50_000
+    assert args.video_log_every == 25_000
+
+
 def test_mlp_layers_help_matches_conv_encoder_guard():
     help_text = " ".join(_build_parser_train().format_help().split())
 

--- a/tests/r2dreamer/launch/test_presets.py
+++ b/tests/r2dreamer/launch/test_presets.py
@@ -10,6 +10,7 @@ PRESETS = [
     ("habitat", "cnn",  "L4"),
     ("habitat", "vggt", "L1"),
     ("habitat", "hybrid", "L1"),
+    ("habitat", "hybrid_norm_fixed", "L1"),
     ("crafter", "cnn",  None),
 ]
 

--- a/tests/r2dreamer/launch/test_registries.py
+++ b/tests/r2dreamer/launch/test_registries.py
@@ -3,7 +3,7 @@
 import inspect
 import pytest
 
-from src.r2dreamer.encoders import Encoder, HybridEncoder
+from src.r2dreamer.encoders import Encoder, HybridEncoder, HybridNormFixedEncoder
 from src.r2dreamer.launch.registries import encoder_registry, env_registry
 from src.r2dreamer.launch.curricula import CURRICULA
 
@@ -29,9 +29,11 @@ class TestEncoderRegistry:
         assert "vggt_aggregator_mlp" in encoder_registry
         assert "vggt_wp_dense_cnn" in encoder_registry
         assert "hybrid" in encoder_registry
+        assert "hybrid_norm_fixed" in encoder_registry
 
     def test_hybrid_key_resolves_to_hybrid_spec_class(self):
         assert encoder_registry["hybrid"] is HybridEncoder
+        assert encoder_registry["hybrid_norm_fixed"] is HybridNormFixedEncoder
 
 
 class TestEnvRegistry:

--- a/tests/r2dreamer/test_trainer.py
+++ b/tests/r2dreamer/test_trainer.py
@@ -136,6 +136,12 @@ class TestResume:
     def cfg(self):
         return R2DreamerConfig(obs_shape=(3, 64, 64), num_actions=4)
 
+    def test_trainer_config_defaults_disable_in_run_val_and_video(self):
+        tcfg = TrainerConfig()
+
+        assert tcfg.val_every == 0
+        assert tcfg.video_log_every == 0
+
     @pytest.fixture
     def saved_agent(self, cfg, tmp_path):
         """Build an agent, save its checkpoint, return (agent, ckpt_path, step)."""

--- a/tests/r2dreamer/world_model/test_hybrid_encoder.py
+++ b/tests/r2dreamer/world_model/test_hybrid_encoder.py
@@ -11,6 +11,7 @@ import pytest
 from src.r2dreamer.world_model.encoders import (
     ConvDecoder,
     HybridEncoder,
+    HybridNormFixedEncoder,
     HYBRID_RGB_DIM,
     HYBRID_VGGT_DIM,
 )
@@ -77,6 +78,38 @@ class TestHybridEncoder:
         assert jnp.allclose(fused, expected)
 
 
+class TestHybridNormFixedEncoder:
+    def test_branches_are_normalized_and_fixed_scaled(self, rng):
+        vggt_embed_dim = 8
+        enc = HybridNormFixedEncoder(
+            vggt_embed_dim=vggt_embed_dim,
+            mlp_hidden=8,
+            mlp_layers=2,
+            fixed_vggt_scale=0.5,
+        )
+        obs = jax.random.normal(rng, (4, HYBRID_RGB_DIM + HYBRID_VGGT_DIM))
+        params = enc.init(rng, obs)
+
+        cnn_e, vggt_e, gate = enc.apply(params, obs, method=enc.branches)
+
+        assert "gate" not in params["params"]
+        assert float(gate) == 0.5
+        assert cnn_e.shape == (4, _cnn_dim())
+        assert vggt_e.shape == (4, vggt_embed_dim)
+        assert jnp.allclose(jnp.sqrt(jnp.mean(cnn_e ** 2, axis=-1)), 1.0, atol=1e-3)
+        assert jnp.allclose(jnp.sqrt(jnp.mean(vggt_e ** 2, axis=-1)), 0.5, atol=1e-3)
+
+    def test_call_concatenates_normalized_branches(self, rng):
+        enc = HybridNormFixedEncoder(vggt_embed_dim=8, mlp_hidden=8, mlp_layers=2)
+        obs = jax.random.normal(rng, (4, HYBRID_RGB_DIM + HYBRID_VGGT_DIM))
+        params = enc.init(rng, obs)
+
+        fused = enc.apply(params, obs)
+        cnn_e, vggt_e, _ = enc.apply(params, obs, method=enc.branches)
+
+        assert jnp.allclose(fused, jnp.concatenate([cnn_e, vggt_e], axis=-1))
+
+
 class TestDecoderGuard:
     """decoder=True requires an RGB modality (cnn or hybrid); else fail fast."""
 
@@ -103,6 +136,8 @@ class TestDecoderGuard:
         assert "decoder" in a.params
         b = R2DreamerAgent(self._cfg("hybrid", (16404,)), jax.random.PRNGKey(0))
         assert "decoder" in b.params
+        c = R2DreamerAgent(self._cfg("hybrid_norm_fixed", (16404,)), jax.random.PRNGKey(0))
+        assert "decoder" in c.params
 
     def test_hybrid_split_mismatch_raises_value_error(self):
         import jax

--- a/tests/slurm/test_launch.py
+++ b/tests/slurm/test_launch.py
@@ -313,3 +313,32 @@ def test_aggregator_smoke_overrides() -> None:
 def test_aggregator_prod_is_strict_bash() -> None:
     rendered = launch.render_sbatch(launch.load_config("aggregator_mlp_v1"), mode="prod")
     assert "set -euo pipefail" in rendered
+
+
+def test_hybrid_norm_fixed_prod_args() -> None:
+    rendered = launch.render_sbatch(launch.load_config("hybrid_norm_fixed"), mode="prod")
+    python_cmd, script, run_id, flags = training_command(rendered)
+
+    assert python_cmd == "uv run python"
+    assert script.endswith("run.py")
+    assert run_id == "habitat-l1-hybrid-norm-fixed"
+    assert flags["--steps"] == "2000000"
+    assert flags["--prefill"] == "5000"
+    assert flags["--checkpoint_every"] == "100000"
+    assert flags["--wandb_name"] == "hybrid-norm-fixed-${SLURM_JOB_ID}"
+    assert flags["--wandb_project"] == "3d-vla-objectnav"
+    assert flags["--render_resolution"] == "518"
+    assert "norm-fixed" in flags["--wandb_tags"]
+
+
+def test_hybrid_norm_fixed_smoke_reaches_training_early() -> None:
+    rendered = launch.render_sbatch(launch.load_config("hybrid_norm_fixed"), mode="smoke")
+    _, _, run_id, flags = training_command(rendered)
+
+    assert run_id == "habitat-l1-hybrid-norm-fixed"
+    assert flags["--steps"] == "800"
+    assert flags["--prefill"] == "200"
+    assert flags["--batch_size"] == "4"
+    assert flags["--seq_len"] == "16"
+    assert flags["--train_ratio"] == "16"
+    assert flags["--wandb_project"] == "3d-vla-objectnav-smoke"

--- a/tests/slurm/test_launch.py
+++ b/tests/slurm/test_launch.py
@@ -83,14 +83,16 @@ def test_l1_vggt_dry_run_matches_legacy_sbatch() -> None:
 
     assert result.returncode == 0, result.stderr
     expected = (ROOT / LEGACY_SBATCH / "train_curriculum_l1_vggt.sbatch").read_text()
-    # _base / l1_vggt have since gained three intentional changes the frozen
+    # _base / l1_vggt have since gained four intentional changes the frozen
     # legacy script predates: (1) the GL-teardown hard-exit env var (so every
     # habitat variant exits 0 on completion), (2) multi-partition auto-select
     # (gpu_h100_il,gpu_h100), and (3) the scalars-only flags video_log_every=0 /
     # val_every=0 (videos + eval regenerated from checkpoints, not during
-    # training). Normalise all three back out before the byte-equality check so
+    # training), and (4) uv --no-sync for shared-worktree jobs. Normalise these
+    # back out before the byte-equality check so
     # the rest of the contract still holds.
     rendered = result.stdout.replace('export R2DREAMER_HARD_EXIT_ON_FINISH="1"\n\n', "", 1)
+    rendered = rendered.replace("uv run --no-sync python", "uv run python")
     # The entrypoint migrated to the single run.py dispatcher (run id positional);
     # the frozen legacy sbatch still names the old per-run shim. Map it back.
     rendered = rendered.replace(
@@ -190,7 +192,8 @@ def test_curriculum_variants_match_legacy_args(variant: str, run_id: str, legacy
     r_python, r_script, r_run_id, r_flags = training_command(rendered)
     l_python, l_script, _l_run_id, l_flags = training_command((ROOT / legacy).read_text())
 
-    assert r_python == l_python == "uv run python"
+    assert r_python == "uv run --no-sync python"
+    assert l_python == "uv run python"
     assert r_script.endswith("run.py")
     assert r_run_id == run_id
 
@@ -285,7 +288,7 @@ def test_aggregator_prod_args() -> None:
     rendered = launch.render_sbatch(launch.load_config("aggregator_mlp_v1"), mode="prod")
     python_cmd, script, run_id, flags = training_command(rendered)
 
-    assert python_cmd == "uv run python"
+    assert python_cmd == "uv run --no-sync python"
     assert script.endswith("run.py")
     assert run_id == "habitat-l1-vggt-aggregator-mlp"
     assert flags["--steps"] == "2000000"
@@ -319,7 +322,7 @@ def test_hybrid_norm_fixed_prod_args() -> None:
     rendered = launch.render_sbatch(launch.load_config("hybrid_norm_fixed"), mode="prod")
     python_cmd, script, run_id, flags = training_command(rendered)
 
-    assert python_cmd == "uv run python"
+    assert python_cmd == "uv run --no-sync python"
     assert script.endswith("run.py")
     assert run_id == "habitat-l1-hybrid-norm-fixed"
     assert flags["--steps"] == "2000000"


### PR DESCRIPTION
## What changed
- Added a `hybrid_norm_fixed` encoder variant for 3D-65.
- The variant keeps the default hybrid input layout, `[64x64 RGB | VGGT WP/CP]`, but RMS-normalizes both branch embeddings before concatenation.
- Replaced the learned zero-init VGGT gate with a fixed VGGT branch scale of `1.0` for this ablation; `hybrid/gate` logs that constant for W&B comparability.
- Added `habitat-l1-hybrid-norm-fixed` and `scripts/slurm/configs/hybrid_norm_fixed.yaml`.
- Set train/parser and `TrainerConfig` defaults to disable in-run validation and video logging by default; explicit `--val_every` / `--video_log_every` opt-in still works.
- Render default Slurm Python invocations as `uv run --no-sync python` for both smoke and prod so parallel worktree jobs do not mutate the shared `.venv` during startup.

## Why
The production hybrid run showed a tiny learned `hybrid/gate` while `hybrid/vggt_frac` still became large, suggesting scale compensation in the VGGT MLP. This ablation tests whether normalized branch embeddings plus a fixed-open VGGT scale produce cleaner branch dynamics, compared against a matched learned-gate/learned-scale baseline.

## Linear issue
3D-65

## Acceptance criteria checked
- Existing `hybrid` encoder and run config are unchanged.
- New launcher-visible `hybrid_norm_fixed` variant uses the same hybrid adapter and WP/CP extractor.
- New variant has no trainable `gate` parameter and logs fixed `hybrid/gate = 1.0`.
- Branch contribution metrics still log `hybrid/{gate,cnn_frac,vggt_frac}`.
- L1 SLURM config renders and submits through the standard launcher.
- In-run validation and video logging are disabled by default for reruns; explicit opt-in is covered by parser tests.
- Parallel Slurm reruns avoid `uv` dependency sync against the shared worktree `.venv`.

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/r2dreamer/world_model/test_hybrid_encoder.py tests/r2dreamer/launch/test_encoders.py tests/r2dreamer/launch/test_registries.py tests/r2dreamer/launch/test_presets.py tests/slurm/test_launch.py -q` - 55 passed, 2 skipped
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/r2dreamer/launch/test_shim_invocation.py -q` - 17 passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/r2dreamer/test_agent.py tests/r2dreamer/test_dims_consistency.py -q` - 8 passed
- `.venv/bin/python -m py_compile ...` on touched Python files - passed
- `git diff --check` - passed
- `scripts/slurm/launch.sh hybrid_norm_fixed --dry-run` - rendered expected `run.py habitat-l1-hybrid-norm-fixed`
- After adding the external-link setup hook: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/slurm/test_launch.py::test_hybrid_norm_fixed_prod_args tests/slurm/test_launch.py::test_hybrid_norm_fixed_smoke_reaches_training_early -q` - 2 passed
- After disabling in-run val/video defaults: `MPLCONFIGDIR=/tmp/codex-mpl PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/r2dreamer/launch/test_parser.py tests/r2dreamer/test_trainer.py tests/slurm/test_launch.py::test_hybrid_norm_fixed_prod_args tests/slurm/test_launch.py::test_hybrid_norm_fixed_smoke_reaches_training_early -q` - 18 passed
- After the no-sync Slurm fix: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/slurm/test_launch.py -q` - 14 passed
- After the no-sync Slurm fix: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/r2dreamer/launch/test_parser.py tests/r2dreamer/test_trainer.py -q` - 16 passed
- `scripts/slurm/launch.sh hybrid_norm_fixed --prod --dry-run` - renders `uv run --no-sync python` and no `--val_every` / `--video_log_every`
- `scripts/slurm/launch.sh hybrid_v1 --prod --dry-run` - renders `uv run --no-sync python` and no `--val_every` / `--video_log_every`
- Static/norm-fixed smoke `4960950` - completed, reached training step 800, checkpoint saved
- Learned-gate/learned-scale smoke `4960952` - completed, reached training step 800, checkpoint saved

## SLURM jobs
- Superseded production: `4943465` cancelled after old defaults produced in-run validation/video overhead.
- Static/norm-fixed rerun: smoke `4960950` completed; production `4960951` running.
- Learned-gate/learned-scale baseline: smoke `4960952` completed; production `4960953` failed before training due concurrent `uv` sync on the shared `.venv`; fixed by `c8e7ddd` and relaunched as production `4960997`.
- Watch current production jobs: `squeue -j 4960951,4960997`
- Superseded attempt: smoke `4943449` failed before training because the worktree lacked linked external VGGT repos; production `4943450` was cancelled by dependency. Fixed by commit `7501275`.

## Risk
Medium for this new ablation only. The default `hybrid` path is preserved, but the new variant changes branch scale semantics and should be evaluated by SR/SPL and `hybrid/*` metrics before drawing conclusions.

## How to test
Run the focused pytest commands above, then inspect the rerun metrics for `hybrid/gate`, `hybrid/cnn_frac`, `hybrid/vggt_frac`, SR, and SPL. Use `hybrid_norm_fixed` against `hybrid_v1`; `hybrid_agg_raw` is intentionally not part of this comparison.

## What was intentionally not done
- Did not change the existing `hybrid` learned-gate baseline.
- Did not make the fixed scale user-configurable from the CLI; this PR adds one concrete ablation run at scale `1.0`.
- Did not compare against `hybrid_agg_raw`; this issue is scoped to static/fixed gate versus learned gate.

## Agent involvement
Implemented and verified by Codex in a dedicated `3D-65` worktree.

## Follow-up issues created
None.