### PR TITLE
3D-58: Add WP/CP MLP level configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ data/
 *.log
 
 # external repos — cloned locally, not committed
-external/*/
+external/*
 !external/.gitkeep
 
 # uv lockfile

--- a/scripts/slurm/configs/l2_wpcp_mlp.yaml
+++ b/scripts/slurm/configs/l2_wpcp_mlp.yaml
@@ -1,0 +1,12 @@
+extends: l2_vggt
+job_name: r2d-L2-wpcp-mlp
+output_dir: output/r2dreamer-curriculum-l2-vggt-wp-cp-mlp
+comments:
+  - "Level 2 with VGGT WP/CP readout and depth-3 MLP encoder"
+  - "Matches the L1 wp_cp_mlp variant: 37x37 world points + camera pose"
+  - "No in-run validation or train videos; regenerate eval/video from checkpoints"
+args:
+  output_dir: output/r2dreamer-curriculum-l2-vggt-wp-cp-mlp/run-${SLURM_JOB_ID}
+  wandb_name: r2d-L2-wpcp-mlp-${SLURM_JOB_ID}
+  wandb_tags: curriculum,level2,1house,6goals,vggt,jax,3d-encoder,wp-cp,mlp-3layer
+  mlp_layers: 3

--- a/scripts/slurm/configs/l3_wpcp_mlp.yaml
+++ b/scripts/slurm/configs/l3_wpcp_mlp.yaml
@@ -1,0 +1,12 @@
+extends: l3_vggt
+job_name: r2d-L3-wpcp-mlp
+output_dir: output/r2dreamer-curriculum-l3-vggt-wp-cp-mlp
+comments:
+  - "Level 3 with VGGT WP/CP readout and depth-3 MLP encoder"
+  - "Matches the L1 wp_cp_mlp variant: 37x37 world points + camera pose"
+  - "No in-run validation or train videos; regenerate eval/video from checkpoints"
+args:
+  output_dir: output/r2dreamer-curriculum-l3-vggt-wp-cp-mlp/run-${SLURM_JOB_ID}
+  wandb_name: r2d-L3-wpcp-mlp-${SLURM_JOB_ID}
+  wandb_tags: curriculum,level3,10houses,chair-only,vggt,jax,3d-encoder,wp-cp,mlp-3layer
+  mlp_layers: 3

--- a/scripts/slurm/configs/l4_wpcp_mlp.yaml
+++ b/scripts/slurm/configs/l4_wpcp_mlp.yaml
@@ -1,0 +1,12 @@
+extends: l4_vggt
+job_name: r2d-L4-wpcp-mlp
+output_dir: output/r2dreamer-curriculum-l4-vggt-wp-cp-mlp
+comments:
+  - "Level 4 with VGGT WP/CP readout and depth-3 MLP encoder"
+  - "Matches the L1 wp_cp_mlp variant: 37x37 world points + camera pose"
+  - "No in-run validation or train videos; regenerate eval/video from checkpoints"
+args:
+  output_dir: output/r2dreamer-curriculum-l4-vggt-wp-cp-mlp/run-${SLURM_JOB_ID}
+  wandb_name: r2d-L4-wpcp-mlp-${SLURM_JOB_ID}
+  wandb_tags: curriculum,level4,10houses,6goals,vggt,jax,3d-encoder,wp-cp,mlp-3layer
+  mlp_layers: 3


### PR DESCRIPTION
## What changed

- Add L2, L3, and L4 SLURM configs for the VGGT WP/CP readout with the depth-3 MLP encoder.
- Route each level to its own output directory and W&B run name.
- Keep W&B tags focused on curriculum/encoder details, without `noval` or `novideo` tags.
- Broaden the external repo ignore rule from `external/*/` to `external/*` so symlinked external checkouts are ignored too.

## Why

These configs let us run the promising L1 WP/CP MLP setup across curriculum levels 2-4 and compare training SR against CNN baselines without in-run validation or training-video overhead.

## Validation

- `git diff --check`
- `scripts/slurm/launch.sh l2_wpcp_mlp l3_wpcp_mlp l4_wpcp_mlp --dry-run`
- Earlier smoke submissions for L2/L3/L4 completed with `Smoke PASS` before this commit; those runs were launched from the same config shape before the tag cleanup.

## Base branch note

The original 3D-58 branch was pruned from GitHub after being merged into `lucasailerls/3d-56-aggregator-runs`, so this PR targets that stack branch rather than `main`. Targeting `main` directly would include unrelated stacked experiment changes.

## Intentionally not done

- Did not add in-run validation or video logging.
- Did not modify the existing L1 `wp_cp_mlp` config.
- Did not retarget this directly to `main`; this stacks on the current aggregator/3D-58 experiment branch.