### PR TITLE
3D-72: Add modality-aware replay buffer layout

### DIFF
--- a/scripts/r2dreamer/profile_modal_replay.py
+++ b/scripts/r2dreamer/profile_modal_replay.py
@@ -1,0 +1,273 @@
+"""Profile flat vs modality-aware replay layouts.
+
+This isolates the 3D-72 replay change without running Habitat or online VGGT:
+
+* ``flat_hybrid`` emulates the old replay layout:
+  one float32 vector ``[rgb64_normalized_flat | wp_cp]``.
+* ``modal_hybrid`` uses the new replay layout:
+  ``{"image": uint8 RGB64, "wp_cp": float32}``.
+
+Both feed the same HybridEncoder after the agent packs observations at the JAX
+boundary, so timing differences are attributable to replay layout and packing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+def _pct(values: list[float], p: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    idx = min(len(ordered) - 1, max(0, int(round((p / 100.0) * (len(ordered) - 1)))))
+    return ordered[idx]
+
+
+def _summ(values: list[float]) -> dict[str, float]:
+    return {
+        "n": len(values),
+        "mean_ms": statistics.fmean(values) if values else 0.0,
+        "median_ms": statistics.median(values) if values else 0.0,
+        "p90_ms": _pct(values, 90),
+        "p95_ms": _pct(values, 95),
+        "min_ms": min(values) if values else 0.0,
+        "max_ms": max(values) if values else 0.0,
+    }
+
+
+def _block_tree(tree: Any) -> None:
+    import jax
+
+    for value in jax.tree_util.tree_leaves(tree):
+        try:
+            value.block_until_ready()
+        except AttributeError:
+            pass
+
+
+def _fill_common(buffer, capacity: int, rng: np.random.Generator) -> None:
+    buffer.actions[:] = rng.integers(0, 4, size=capacity, dtype=np.int32)
+    buffer.rewards[:] = rng.standard_normal(capacity).astype(np.float32)
+    buffer.dones[:] = False
+    buffer.terminals[:] = False
+    buffer.size = capacity
+    buffer.idx = 0
+
+
+def _make_buffer(kind: str, capacity: int, rng: np.random.Generator):
+    from src.buffer.replay_buffer import BufferConfig, ReplayBuffer
+
+    if kind == "wpcp":
+        cfg = BufferConfig(
+            capacity=capacity,
+            obs_shape=(4116,),
+            obs_dtype="float32",
+            normalize_obs=False,
+        )
+        buffer = ReplayBuffer(cfg)
+        buffer.obs[:] = rng.standard_normal((capacity, 4116), dtype=np.float32)
+    elif kind == "flat_hybrid":
+        cfg = BufferConfig(
+            capacity=capacity,
+            obs_shape=(16404,),
+            obs_dtype="float32",
+            normalize_obs=False,
+        )
+        buffer = ReplayBuffer(cfg)
+        image = rng.integers(0, 256, size=(capacity, 3, 64, 64), dtype=np.uint8)
+        wp_cp = rng.standard_normal((capacity, 4116), dtype=np.float32)
+        rgb = image.astype(np.float32).reshape(capacity, -1) / 255.0
+        buffer.obs[:] = np.concatenate([rgb, wp_cp], axis=-1).astype(np.float32)
+    elif kind == "modal_hybrid":
+        cfg = BufferConfig(
+            capacity=capacity,
+            obs_shape={"image": (3, 64, 64), "wp_cp": (4116,)},
+            obs_dtype={"image": "uint8", "wp_cp": "float32"},
+            normalize_obs={"image": False, "wp_cp": False},
+        )
+        buffer = ReplayBuffer(cfg)
+        buffer.obs["image"][:] = rng.integers(
+            0, 256, size=(capacity, 3, 64, 64), dtype=np.uint8
+        )
+        buffer.obs["wp_cp"][:] = rng.standard_normal((capacity, 4116), dtype=np.float32)
+    else:
+        raise ValueError(kind)
+
+    _fill_common(buffer, capacity, rng)
+    return buffer
+
+
+def _make_agent(kind: str, seed: int):
+    import jax
+
+    from src.r2dreamer.agent import R2DreamerAgent
+    from src.r2dreamer.config import R2DreamerConfig
+    from src.r2dreamer.world_model.encoders import HybridEncoder, VGGTEncoder
+
+    common = dict(
+        num_actions=4,
+        batch_size=16,
+        seq_len=64,
+        train_ratio=512,
+        buffer_capacity=100_000,
+        seed=seed,
+        decoder=False,
+    )
+    if kind == "wpcp_mlp3":
+        cfg = R2DreamerConfig(
+            encoder_type="vggt",
+            encoder_module_cls=VGGTEncoder,
+            obs_shape=(4116,),
+            vggt_mlp_layers=3,
+            **common,
+        )
+    elif kind == "hybrid":
+        cfg = R2DreamerConfig(
+            encoder_type="hybrid",
+            encoder_module_cls=HybridEncoder,
+            obs_shape=(16404,),
+            **common,
+        )
+    else:
+        raise ValueError(kind)
+    return cfg, R2DreamerAgent(cfg, jax.random.PRNGKey(seed))
+
+
+def _measure_sample_convert(buffer, convert_batch, iters: int, warmup: int) -> dict[str, float]:
+    times: list[float] = []
+    for i in range(iters + warmup):
+        t0 = time.perf_counter()
+        batch = convert_batch(buffer.sample(16, 64), 4)
+        _block_tree(batch)
+        dt = (time.perf_counter() - t0) * 1000.0
+        if i >= warmup:
+            times.append(dt)
+    return _summ(times)
+
+
+def _measure_train_step(agent, batch, iters: int, warmup: int) -> dict[str, float]:
+    import jax
+
+    _block_tree(batch)
+    times: list[float] = []
+    for i in range(iters + warmup):
+        key = jax.random.PRNGKey(1000 + i)
+        t0 = time.perf_counter()
+        metrics = agent.train_step(batch, key)
+        _ = metrics.get("total_loss", 0.0)
+        dt = (time.perf_counter() - t0) * 1000.0
+        if i >= warmup:
+            times.append(dt)
+    return _summ(times)
+
+
+def _measure_combined(buffer, agent, convert_batch, iters: int, warmup: int) -> dict[str, float]:
+    import jax
+
+    times: list[float] = []
+    for i in range(iters + warmup):
+        key = jax.random.PRNGKey(2000 + i)
+        t0 = time.perf_counter()
+        batch = convert_batch(buffer.sample(16, 64), 4)
+        metrics = agent.train_step(batch, key)
+        _ = metrics.get("total_loss", 0.0)
+        dt = (time.perf_counter() - t0) * 1000.0
+        if i >= warmup:
+            times.append(dt)
+    return _summ(times)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--capacity", type=int, default=8192)
+    parser.add_argument("--sample-iters", type=int, default=40)
+    parser.add_argument("--train-iters", type=int, default=15)
+    parser.add_argument("--combined-iters", type=int, default=15)
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--output", type=str, default="output/profiles/modal_replay_profile.json")
+    args = parser.parse_args()
+
+    cwd = Path.cwd()
+    sys.path.insert(0, str(cwd))
+
+    import jax
+    from src.r2dreamer.trainer import convert_batch
+
+    rng = np.random.default_rng(72)
+    buffers = {
+        kind: _make_buffer(kind, args.capacity, rng)
+        for kind in ("wpcp", "flat_hybrid", "modal_hybrid")
+    }
+    agents = {
+        "wpcp_mlp3": _make_agent("wpcp_mlp3", seed=72),
+        "flat_hybrid": _make_agent("hybrid", seed=73),
+        "modal_hybrid": _make_agent("hybrid", seed=74),
+    }
+
+    results: dict[str, Any] = {
+        "meta": {
+            "cwd": str(cwd),
+            "jax_devices": [str(d) for d in jax.devices()],
+            "capacity": args.capacity,
+            "sample_iters": args.sample_iters,
+            "train_iters": args.train_iters,
+            "combined_iters": args.combined_iters,
+            "warmup": args.warmup,
+            "batch_size": 16,
+            "seq_len": 64,
+            "batch_env_steps": 1024,
+            "storage_bytes_per_transition": {
+                "wpcp": 4116 * 4,
+                "flat_hybrid": 16404 * 4,
+                "modal_hybrid": (3 * 64 * 64) + (4116 * 4),
+            },
+        },
+        "runs": {},
+    }
+
+    for kind, buffer in buffers.items():
+        results["runs"].setdefault(kind, {})["sample_convert"] = _measure_sample_convert(
+            buffer, convert_batch, args.sample_iters, args.warmup,
+        )
+
+    prepared_batches = {
+        "wpcp_mlp3": convert_batch(buffers["wpcp"].sample(16, 64), 4),
+        "flat_hybrid": convert_batch(buffers["flat_hybrid"].sample(16, 64), 4),
+        "modal_hybrid": convert_batch(buffers["modal_hybrid"].sample(16, 64), 4),
+    }
+    for label, (_, agent) in agents.items():
+        results["runs"].setdefault(label, {})["train_step"] = _measure_train_step(
+            agent, prepared_batches[label], args.train_iters, args.warmup,
+        )
+
+    combined = {
+        "wpcp_mlp3": ("wpcp", "wpcp_mlp3"),
+        "flat_hybrid": ("flat_hybrid", "flat_hybrid"),
+        "modal_hybrid": ("modal_hybrid", "modal_hybrid"),
+    }
+    for label, (buffer_kind, agent_kind) in combined.items():
+        _, agent = agents[agent_kind]
+        results["runs"].setdefault(label, {})["sample_convert_train"] = _measure_combined(
+            buffers[buffer_kind], agent, convert_batch, args.combined_iters, args.warmup,
+        )
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(results, indent=2), encoding="utf-8")
+    print(json.dumps(results, indent=2))
+    print(f"wrote {output}")
+
+
+if __name__ == "__main__":
+    os.environ.setdefault("XLA_PYTHON_CLIENT_PREALLOCATE", "false")
+    main()

--- a/src/buffer/replay_buffer.py
+++ b/src/buffer/replay_buffer.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 
 import numpy as np
 import jax.numpy as jnp
+
+
+ObsShape = tuple[int, ...] | Mapping[str, tuple[int, ...]]
+ObsDType = str | Mapping[str, str]
+ObsNormalize = bool | Mapping[str, bool]
 
 
 @dataclass(frozen=True)
@@ -14,25 +20,37 @@ class BufferConfig:
 
     Args:
         capacity: Maximum number of transitions to store.
-        obs_shape: Shape of a single observation, e.g. (3, 64, 64) or (4116,).
-        obs_dtype: Storage dtype — "uint8" for images, "float32" for features.
-        normalize_obs: If True and obs_dtype is "uint8", divide by 255.0 on sample.
+        obs_shape: Shape of one observation, or a mapping of named fields to
+            shapes for multi-modal observations such as hybrid image+WP/CP.
+        obs_dtype: Storage dtype, either one dtype for single-observation
+            buffers or a mapping keyed like ``obs_shape``.
+        normalize_obs: If True and obs_dtype is "uint8", divide by 255.0 on
+            sample. Mapping configs can choose this per field.
     """
     capacity: int
-    obs_shape: tuple[int, ...]
-    obs_dtype: str = "uint8"
-    normalize_obs: bool = True
+    obs_shape: ObsShape
+    obs_dtype: ObsDType = "uint8"
+    normalize_obs: ObsNormalize = True
+
+
+@dataclass(frozen=True)
+class _FieldSpec:
+    shape: tuple[int, ...]
+    dtype: str
+    normalize: bool
+    keep_uint8_on_sample: bool
 
 
 def _gather_sequence_batch(
     starts: np.ndarray,
     seq_len: int,
-    obs: np.ndarray,
+    obs: np.ndarray | Mapping[str, np.ndarray],
     actions: np.ndarray,
     rewards: np.ndarray,
     dones: np.ndarray,
     terminals: np.ndarray,
-    normalize: bool,
+    normalize: bool | Mapping[str, bool],
+    keep_uint8_on_sample: bool | Mapping[str, bool],
 ) -> dict[str, jnp.ndarray]:
     """Gather length-``seq_len`` windows at ``starts`` and pack a batch dict.
 
@@ -42,7 +60,6 @@ def _gather_sequence_batch(
     on the previous step; ``obs`` is divided by 255 when ``normalize`` is set.
     """
     indices = starts[:, None] + np.arange(seq_len)[None, :]  # (B, T)
-    obs_b = obs[indices]
     actions_b = actions[indices]
     rewards_b = rewards[indices]
     dones_b = dones[indices]
@@ -52,18 +69,105 @@ def _gather_sequence_batch(
     is_first[:, 0] = True
     is_first[:, 1:] = dones_b[:, :-1]
 
-    obs_jnp = jnp.array(obs_b, dtype=jnp.float32)
-    if normalize:
-        obs_jnp = obs_jnp / 255.0
-
     return {
-        "obs": obs_jnp,
+        "obs": _gather_obs(obs, indices, normalize, keep_uint8_on_sample),
         "actions": jnp.array(actions_b, dtype=jnp.int32),
         "rewards": jnp.array(rewards_b, dtype=jnp.float32),
         "dones": jnp.array(dones_b, dtype=jnp.float32),
         "terminals": jnp.array(terminals_b, dtype=jnp.float32),
         "is_first": jnp.array(is_first, dtype=jnp.float32),
     }
+
+
+def _np_dtype(name: str) -> type:
+    if name == "uint8":
+        return np.uint8
+    if name == "float16":
+        return np.float16
+    return np.float32
+
+
+def _single_field_spec(config: BufferConfig) -> _FieldSpec:
+    if not isinstance(config.obs_shape, tuple):
+        raise TypeError("single-field BufferConfig requires tuple obs_shape")
+    if not isinstance(config.obs_dtype, str):
+        raise TypeError("single-field BufferConfig requires string obs_dtype")
+    if not isinstance(config.normalize_obs, bool):
+        raise TypeError("single-field BufferConfig requires bool normalize_obs")
+    return _FieldSpec(
+        shape=config.obs_shape,
+        dtype=config.obs_dtype,
+        normalize=config.normalize_obs and config.obs_dtype == "uint8",
+        keep_uint8_on_sample=False,
+    )
+
+
+def _mapping_value(mapping_or_scalar, key: str, default):
+    if isinstance(mapping_or_scalar, Mapping):
+        return mapping_or_scalar.get(key, default)
+    return mapping_or_scalar
+
+
+def _field_specs(config: BufferConfig) -> dict[str, _FieldSpec] | None:
+    if not isinstance(config.obs_shape, Mapping):
+        return None
+    specs: dict[str, _FieldSpec] = {}
+    for key, shape in config.obs_shape.items():
+        dtype = _mapping_value(config.obs_dtype, key, "float32")
+        normalize = bool(_mapping_value(config.normalize_obs, key, False))
+        specs[key] = _FieldSpec(
+            shape=tuple(shape),
+            dtype=str(dtype),
+            normalize=normalize and dtype == "uint8",
+            keep_uint8_on_sample=(dtype == "uint8" and not normalize),
+        )
+    return specs
+
+
+def _to_jax_obs(
+    obs_b: np.ndarray,
+    normalize: bool,
+    keep_uint8_on_sample: bool,
+) -> jnp.ndarray:
+    """Convert sampled replay storage to the dtype expected downstream.
+
+    Feature observations always leave replay as float32, even when stored as
+    float16. The only deferred-cast case is a modal uint8 image field: hybrid
+    training normalizes that image later in obs_batch, after the modalities are
+    still inspectable as separate fields.
+    """
+    if normalize:
+        return jnp.array(obs_b, dtype=jnp.float32) / 255.0
+    if keep_uint8_on_sample:
+        return jnp.asarray(obs_b)
+    return jnp.array(obs_b, dtype=jnp.float32)
+
+
+def _gather_obs(
+    obs: np.ndarray | Mapping[str, np.ndarray],
+    indices: np.ndarray,
+    normalize: bool | Mapping[str, bool],
+    keep_uint8_on_sample: bool | Mapping[str, bool],
+) -> jnp.ndarray | dict[str, jnp.ndarray]:
+    """Gather observation windows and apply each field's sample conversion."""
+    if isinstance(obs, Mapping):
+        if not isinstance(normalize, Mapping):
+            raise TypeError("mapping observations require mapping normalize flags")
+        if not isinstance(keep_uint8_on_sample, Mapping):
+            raise TypeError("mapping observations require mapping uint8 sample flags")
+        return {
+            key: _to_jax_obs(
+                value[indices],
+                bool(normalize.get(key, False)),
+                bool(keep_uint8_on_sample.get(key, False)),
+            )
+            for key, value in obs.items()
+        }
+    if not isinstance(normalize, bool):
+        raise TypeError("single observations require a bool normalize flag")
+    if not isinstance(keep_uint8_on_sample, bool):
+        raise TypeError("single observations require a bool uint8 sample flag")
+    return _to_jax_obs(obs[indices], normalize, keep_uint8_on_sample)
 
 
 class ReplayBuffer:
@@ -80,25 +184,48 @@ class ReplayBuffer:
                 obs_shape=config.obs_shape,
             )
         cap = config.capacity
-        if config.obs_dtype == "uint8":
-            np_dtype = np.uint8
-        elif config.obs_dtype == "float16":
-            np_dtype = np.float16
+        field_specs = _field_specs(config)
+        if field_specs is None:
+            spec = _single_field_spec(config)
+            self.obs = np.zeros((cap, *spec.shape), dtype=_np_dtype(spec.dtype))
+            self._normalize: bool | dict[str, bool] = spec.normalize
+            self._keep_uint8_on_sample: bool | dict[str, bool] = (
+                spec.keep_uint8_on_sample
+            )
         else:
-            np_dtype = np.float32
-        self.obs = np.zeros((cap, *config.obs_shape), dtype=np_dtype)
+            self.obs = {
+                key: np.zeros((cap, *spec.shape), dtype=_np_dtype(spec.dtype))
+                for key, spec in field_specs.items()
+            }
+            self._normalize = {
+                key: spec.normalize for key, spec in field_specs.items()
+            }
+            self._keep_uint8_on_sample = {
+                key: spec.keep_uint8_on_sample for key, spec in field_specs.items()
+            }
         self.actions = np.zeros(cap, dtype=np.int32)
         self.rewards = np.zeros(cap, dtype=np.float32)
         self.dones = np.zeros(cap, dtype=np.bool_)
         self.terminals = np.zeros(cap, dtype=np.bool_)
-        self._normalize = config.normalize_obs and config.obs_dtype == "uint8"
         self.capacity = cap
         self.idx = 0
         self.size = 0
 
-    def add(self, obs: np.ndarray, action: int, reward: float, done: bool,
+    def add(self, obs: np.ndarray | Mapping[str, np.ndarray],
+            action: int, reward: float, done: bool,
             terminal: bool = False) -> None:
-        self.obs[self.idx] = obs
+        if isinstance(self.obs, Mapping):
+            if not isinstance(obs, Mapping):
+                raise TypeError("mapping replay buffer requires mapping obs")
+            missing = set(self.obs) - set(obs)
+            if missing:
+                raise KeyError(f"obs missing replay fields: {sorted(missing)}")
+            for key, storage in self.obs.items():
+                storage[self.idx] = obs[key]
+        else:
+            if isinstance(obs, Mapping):
+                raise TypeError("single replay buffer requires array obs")
+            self.obs[self.idx] = obs
         self.actions[self.idx] = action
         self.rewards[self.idx] = reward
         self.dones[self.idx] = done
@@ -110,7 +237,7 @@ class ReplayBuffer:
         starts = self._sample_starts(batch_size, seq_len)
         return _gather_sequence_batch(
             starts, seq_len, self.obs, self.actions, self.rewards,
-            self.dones, self.terminals, self._normalize,
+            self.dones, self.terminals, self._normalize, self._keep_uint8_on_sample,
         )
 
     def _sample_starts(self, batch_size: int, seq_len: int) -> np.ndarray:
@@ -185,7 +312,7 @@ class ValReplayDataset:
         starts = ep_starts + offsets
         return _gather_sequence_batch(
             starts, seq_len, self.obs, self.actions, self.rewards,
-            self.dones, self.terminals, self._normalize,
+            self.dones, self.terminals, self._normalize, False,
         )
 
 

--- a/src/r2dreamer/AGENTS.md
+++ b/src/r2dreamer/AGENTS.md
@@ -91,7 +91,7 @@ entry in `scripts/r2dreamer/_run_configs.py` (launched via `run.py <run-id>`) an
 ## Data flow
 
 ```
-env obs ──ObsAdapter──> buffer(uint8 RGB | float32 VGGT/hybrid)
+env obs ──ObsAdapter──> buffer(uint8 RGB | float32 VGGT | hybrid image+WP/CP fields)
         │
 train_step(batch):
   encoder(obs) -> embed
@@ -141,9 +141,11 @@ srun --partition=dev_gpu_h100 --gres=gpu:1 --time=00:30:00 \
 
 - **`is_first` must be truthful.** The RSSM zeroes `stoch`/`deter` on episode boundaries;
   a mislabelled buffer silently diverges. `act()` resets internal state on `is_first`.
-- **Encoder ↔ adapter ↔ obs_shape must agree.** Hybrid expects
-  `(HYBRID_RGB_DIM + HYBRID_VGGT_DIM,) = (16404,)`; the CNN encoder rejects `vggt_mlp_layers != 1`.
-  Mismatches surface as shape assertions in `_make_encoder()`.
+- **Encoder ↔ adapter ↔ obs_shape must agree.** Hybrid replay stores explicit
+  `image` and `wp_cp` fields, but the agent packs them into
+  `(HYBRID_RGB_DIM + HYBRID_VGGT_DIM,) = (16404,)` before the encoder; the CNN
+  encoder rejects `vggt_mlp_layers != 1`. Mismatches surface as shape checks in
+  `_make_encoder()` or `obs_batch`.
 - **KL is asymmetric (DreamerV3).** Dynamics KL detaches the posterior (trains the prior);
   representation KL detaches the prior (trains the encoder). Both clipped to `cfg.kl_free`.
 - **Imagination is fully detached** — reward/cont/RSSM are read under `stop_gradient`; the

--- a/src/r2dreamer/adapters/hybrid_adapter.py
+++ b/src/r2dreamer/adapters/hybrid_adapter.py
@@ -10,6 +10,7 @@ from src.r2dreamer.adapters.vggt_adapter import (
     VGGT_FEATURE_DIM,
     flatten_world_points_camera_pose,
 )
+from src.r2dreamer.obs_batch import HYBRID_IMAGE_KEY, HYBRID_WP_CP_KEY
 from src.shared.video_utils import resize_chw_uint8
 
 
@@ -17,37 +18,42 @@ from src.shared.video_utils import resize_chw_uint8
 # VGGT_FEATURE_DIM is the single source of truth for the 4116 term (see vggt_adapter),
 # so a grid-size ablation that changes it stays consistent here automatically.
 HYBRID_FEATURE_DIM = 3 * 64 * 64 + VGGT_FEATURE_DIM  # 12288 RGB + 4116 WP/CP = 16404
+HYBRID_IMAGE_SHAPE = (3, 64, 64)
 
 
 class HybridObsAdapter(ObsAdapter):
-    """Builds the flat hybrid buffer vector ``[ rgb (12288) | wp_cp (4116) ]``.
+    """Builds the hybrid replay fields ``{"image": rgb64, "wp_cp": wp_cp}``.
 
     The env renders 518x518 CHW uint8 (for VGGT). Each step we run VGGT once to
     obtain world_points + camera_pose, downsample the same frame to 64x64 for the
-    CNN branch, and concatenate the normalised RGB ([0,1]) with the wp/cp vector.
-    RGB is already divided by 255 here, so ``normalize_on_sample=False``.
+    CNN branch, and store both modalities under explicit replay keys. The agent
+    still packs them into the legacy flat encoder input at the JAX boundary.
     """
 
     def __init__(self, extractor):
         super().__init__(
-            buffer_dtype="float32",
-            buffer_shape=(HYBRID_FEATURE_DIM,),
-            normalize_on_sample=False,
+            buffer_dtype={HYBRID_IMAGE_KEY: "uint8", HYBRID_WP_CP_KEY: "float32"},
+            buffer_shape={
+                HYBRID_IMAGE_KEY: HYBRID_IMAGE_SHAPE,
+                HYBRID_WP_CP_KEY: (VGGT_FEATURE_DIM,),
+            },
+            normalize_on_sample={HYBRID_IMAGE_KEY: False, HYBRID_WP_CP_KEY: False},
+            agent_obs_shape=(HYBRID_FEATURE_DIM,),
             on_episode_reset=extractor.reset,
         )
         self._extractor = extractor
 
-    def transform(self, obs_dict: dict) -> tuple[np.ndarray, dict]:
+    def transform(self, obs_dict: dict) -> tuple[dict[str, np.ndarray], dict]:
         out = self._extractor.extract(obs_dict["image"])  # image is 518 CHW uint8
         wp_cp = flatten_world_points_camera_pose(out)  # jnp (4116,)
         img64 = resize_chw_uint8(obs_dict["image"], 64)  # (3,64,64) uint8
-        rgb = (img64.astype(np.float32) / 255.0).reshape(-1)  # (12288,) [0,1]
-        replay = np.concatenate(
-            [rgb, np.asarray(wp_cp, dtype=np.float32)]
-        ).astype(np.float32)  # (16404,)
+        replay = {
+            HYBRID_IMAGE_KEY: img64,
+            HYBRID_WP_CP_KEY: np.asarray(wp_cp, dtype=np.float32),
+        }
         agent_obs = {
-            "hybrid": jnp.asarray(replay),
-            "image": img64,
+            HYBRID_IMAGE_KEY: img64,
+            HYBRID_WP_CP_KEY: jnp.asarray(replay[HYBRID_WP_CP_KEY]),
             "is_first": obs_dict.get("is_first", False),
         }
         return replay, agent_obs

--- a/src/r2dreamer/adapters/obs_adapter.py
+++ b/src/r2dreamer/adapters/obs_adapter.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Callable
 
 import numpy as np
+
+
+BufferShape = tuple[int, ...] | Mapping[str, tuple[int, ...]]
+BufferDType = str | Mapping[str, str]
+BufferNormalize = bool | Mapping[str, bool]
 
 
 @dataclass
@@ -15,11 +21,23 @@ class ObsAdapter:
     Default: extracts obs["image"] for buffer (uint8), passes obs dict
     through to agent unchanged.
     """
-    buffer_dtype: str = "uint8"
-    buffer_shape: tuple[int, ...] = (3, 64, 64)
-    normalize_on_sample: bool = True
+    buffer_dtype: BufferDType = "uint8"
+    buffer_shape: BufferShape = (3, 64, 64)
+    normalize_on_sample: BufferNormalize = True
+    agent_obs_shape: tuple[int, ...] | None = None
     on_episode_reset: Callable[[], None] | None = None
 
-    def transform(self, obs_dict: dict) -> tuple[np.ndarray, dict]:
+    @property
+    def encoder_obs_shape(self) -> tuple[int, ...]:
+        """Shape consumed by the agent encoder after any adapter/batch packing."""
+        if self.agent_obs_shape is not None:
+            return self.agent_obs_shape
+        if isinstance(self.buffer_shape, Mapping):
+            raise ValueError(
+                "multi-field adapters must set agent_obs_shape for the encoder"
+            )
+        return self.buffer_shape
+
+    def transform(self, obs_dict: dict) -> tuple[np.ndarray | dict[str, np.ndarray], dict]:
         """Returns (buffer_obs, agent_obs_dict)."""
         return obs_dict["image"], obs_dict

--- a/src/r2dreamer/agent.py
+++ b/src/r2dreamer/agent.py
@@ -43,6 +43,12 @@ from .behavior.imagination import _imagine, _lambda_return
 from .behavior.loss import behavior_loss
 from .representation.barlow import Projector
 from .representation.loss import representation_loss
+from .obs_batch import (
+    decoder_rgb_target,
+    encoder_obs_from_agent_obs,
+    encoder_obs_from_batch,
+    obs_leading_shape,
+)
 from src.shared.optim import laprop, agc
 
 # Re-export internal helpers so test_cross_framework.py keeps working.
@@ -162,10 +168,9 @@ def _make_wp_conv_encoder(cfg: R2DreamerConfig):
 
 def _make_hybrid_encoder(cfg: R2DreamerConfig):
     # CNN(RGB) + gated MLP(WP/CP) fused into one embed (3D-50/51/52).
-    # Guard the buffer-layout contract: the encoder splits obs at
-    # HYBRID_RGB_DIM, while the decoder/loss derive the RGB slice as
-    # obs_shape[0] - vggt_feature_dim. Both must agree, or the RGB target
-    # and the encoder's RGB slice would silently diverge.
+    # Guard the packed encoder-layout contract: replay may store modalities in
+    # separate fields, but obs_batch packs them into this flat shape before the
+    # Flax encoder and decoder see them.
     if not (
         cfg.obs_shape == (HYBRID_RGB_DIM + HYBRID_VGGT_DIM,)
         and cfg.obs_shape[0] - cfg.vggt_feature_dim == HYBRID_RGB_DIM
@@ -457,27 +462,17 @@ class R2DreamerAgent:
         """Select an action for a single environment step.
 
         Args:
-            obs_dict: {"image": uint8 (C,H,W), "is_first": bool} for CNN, or
-                      {"features": float32 (D,), "is_first": bool} for VGGT.
+            obs_dict: {"image": uint8 (C,H,W), "is_first": bool} for CNN,
+                      {"features": float32 (D,), "is_first": bool} for VGGT,
+                      or {"image": uint8 (3,64,64), "wp_cp": float32 (4116,)}
+                      for hybrid.
             rng_key: PRNG key.
             training: if False, use argmax (greedy).
 
         Returns:
             Integer action in [0, num_actions).
         """
-        if self.cfg.encoder_type == "hybrid":
-            # Hybrid: the adapter pre-builds the flat [rgb_norm | wp_cp] vector
-            # under "hybrid" (already float32, RGB already /255). The encoder
-            # slices it back into the CNN and WP/CP branches.
-            obs = jnp.asarray(obs_dict["hybrid"])[None]
-        elif self.cfg.encoder_type in ("vggt", "vggt_aggregator_mlp", "vggt_wp_dense_cnn", "vggt_wp_cp_64"):
-            # All VGGT readouts arrive pre-extracted under "features" (the dense
-            # WP map is already a float32 (3, H, W) array). No /255: the values
-            # are VGGT features / metric XYZ, not raw uint8 pixels.
-            obs = jnp.asarray(obs_dict["features"])[None]
-        else:
-            image = obs_dict["image"].astype(np.float32) / 255.0
-            obs = jnp.array(image[None])
+        obs = encoder_obs_from_agent_obs(obs_dict, self.cfg)
 
         is_first = bool(obs_dict["is_first"])
         if is_first:
@@ -540,8 +535,8 @@ class R2DreamerAgent:
         if not self.cfg.decoder or self.decoder_mod is None:
             return None
         params = self.params
-        B, T = batch["obs"].shape[0], batch["obs"].shape[1]
-        obs_flat = batch["obs"].reshape(B * T, *self.cfg.obs_shape)
+        B, T = obs_leading_shape(batch["obs"])
+        obs_flat = encoder_obs_from_batch(batch, self.cfg)
         embed = self.encoder_mod.apply(params["encoder"], obs_flat).reshape(B, T, -1)
         stoch0, deter0 = self.rssm_mod.apply(
             params["rssm"], B, method=self.rssm_mod.initial_state)
@@ -553,11 +548,7 @@ class R2DreamerAgent:
         feat = self.rssm_mod.apply(
             params["rssm"], post_stochs, post_deters, method=self.rssm_mod.get_feat)
         recon = self.decoder_mod.apply(params["decoder"], feat.reshape(B * T, -1))
-        if self.cfg.encoder_type == "hybrid":
-            rgb_dim = self.cfg.obs_shape[0] - self.cfg.vggt_feature_dim
-            target = obs_flat[:, :rgb_dim].reshape(B * T, 3, 64, 64)
-        else:
-            target = obs_flat.reshape(B * T, 3, 64, 64)
+        target = decoder_rgb_target(batch, self.cfg)
         return np.asarray(target), np.asarray(recon)
 
     # ------------------------------------------------------------------
@@ -639,9 +630,9 @@ class R2DreamerAgent:
         `barlow_stop_grad` toggle would no longer mean what it claims.
         """
         cfg = self.cfg
-        B, T = batch["obs"].shape[0], batch["obs"].shape[1]
+        B, T = obs_leading_shape(batch["obs"])
 
-        obs_flat = batch["obs"].reshape(B * T, *cfg.obs_shape)
+        obs_flat = encoder_obs_from_batch(batch, cfg)
         embed = self.encoder_mod.apply(params["encoder"], obs_flat).reshape(B, T, -1)
 
         stoch0, deter0 = self.rssm_mod.apply(
@@ -684,7 +675,7 @@ class R2DreamerAgent:
             returns used for the post-step `ReturnEMA` update.
         """
         cfg = self.cfg
-        B, T = batch["obs"].shape[0], batch["obs"].shape[1]
+        B, T = obs_leading_shape(batch["obs"])
 
         rng_key, k_fwd = jax.random.split(rng_key)
         forward = self._world_model_forward(params, batch, k_fwd)

--- a/src/r2dreamer/encoders/specs.py
+++ b/src/r2dreamer/encoders/specs.py
@@ -200,7 +200,7 @@ class Encoder(ABC):
             )
         adapter = self.make_adapter()
         return EncoderSpec(
-            obs_shape=adapter.buffer_shape,
+            obs_shape=adapter.encoder_obs_shape,
             env_render_resolution=self.env_render_resolution,
             encoder_type=self.encoder_type,
             module_cls=self.module_cls,

--- a/src/r2dreamer/heldout_eval.py
+++ b/src/r2dreamer/heldout_eval.py
@@ -31,6 +31,8 @@ from typing import Any, Iterable
 import jax
 import jax.numpy as jnp
 
+from src.r2dreamer.obs_batch import obs_leading_shape
+
 
 def _reward_mse(agent: Any, batch: dict, rng_key: jnp.ndarray) -> float:
     """One batch -> scalar reward MSE between the head's mean and the GT reward.
@@ -40,7 +42,7 @@ def _reward_mse(agent: Any, batch: dict, rng_key: jnp.ndarray) -> float:
     """
     params = agent.params
     forward = agent._world_model_forward(params, batch, rng_key)
-    B, T = batch["obs"].shape[0], batch["obs"].shape[1]
+    B, T = obs_leading_shape(batch["obs"])
     feat = forward["feat"]
     rew_logits = agent._modules["reward"].apply(
         params["reward"], feat.reshape(B * T, -1),

--- a/src/r2dreamer/obs_batch.py
+++ b/src/r2dreamer/obs_batch.py
@@ -1,0 +1,104 @@
+"""Helpers for modality-aware replay observations.
+
+Replay storage may keep modalities under explicit keys, while the current
+Flax encoders still consume a single tensor. This module is the narrow bridge
+between those two contracts.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import jax.numpy as jnp
+
+
+HYBRID_IMAGE_KEY = "image"
+HYBRID_WP_CP_KEY = "wp_cp"
+
+
+def obs_leading_shape(obs: Any) -> tuple[int, int]:
+    """Return the ``(B, T)`` prefix of a replay observation batch."""
+    if isinstance(obs, Mapping):
+        first = next(iter(obs.values()))
+        return first.shape[0], first.shape[1]
+    return obs.shape[0], obs.shape[1]
+
+
+def normalize_image_obs(image: Any) -> jnp.ndarray:
+    """Return CHW image observations as float32 in ``[0, 1]``.
+
+    Direct unit tests often pass already-normalized float arrays, while replay
+    can now pass compact uint8 images. Branch on dtype so both inputs work.
+    """
+    image = jnp.asarray(image)
+    if image.dtype == jnp.uint8:
+        return image.astype(jnp.float32) / 255.0
+    return image.astype(jnp.float32)
+
+
+def _hybrid_features(obs: Mapping[str, Any]) -> Any:
+    if HYBRID_WP_CP_KEY in obs:
+        return obs[HYBRID_WP_CP_KEY]
+    if "features" in obs:
+        return obs["features"]
+    raise KeyError(
+        f"hybrid obs must contain {HYBRID_WP_CP_KEY!r} or 'features'"
+    )
+
+
+def pack_hybrid_obs(obs: Any) -> jnp.ndarray:
+    """Pack hybrid dict observations into the legacy flat encoder tensor."""
+    if not isinstance(obs, Mapping):
+        return jnp.asarray(obs, dtype=jnp.float32)
+    image = normalize_image_obs(obs[HYBRID_IMAGE_KEY])
+    features = jnp.asarray(_hybrid_features(obs), dtype=jnp.float32)
+    prefix = image.shape[:-3]
+    image_flat = image.reshape(*prefix, -1)
+    features_flat = features.reshape(*features.shape[:-1], -1)
+    return jnp.concatenate([image_flat, features_flat], axis=-1)
+
+
+def encoder_obs_from_batch(batch: dict[str, Any], cfg: Any) -> jnp.ndarray:
+    """Return flattened per-step observations consumed by ``agent.encoder_mod``."""
+    obs = batch["obs"]
+    B, T = obs_leading_shape(obs)
+    if cfg.encoder_type == "hybrid":
+        obs = pack_hybrid_obs(obs)
+    elif cfg.encoder_type == "cnn":
+        obs = normalize_image_obs(obs)
+    else:
+        obs = jnp.asarray(obs, dtype=jnp.float32)
+    return obs.reshape(B * T, *cfg.obs_shape)
+
+
+def encoder_obs_from_agent_obs(obs_dict: Mapping[str, Any], cfg: Any) -> jnp.ndarray:
+    """Return one-step encoder input for acting."""
+    if cfg.encoder_type == "hybrid":
+        if "hybrid" in obs_dict:
+            obs = jnp.asarray(obs_dict["hybrid"], dtype=jnp.float32)
+        else:
+            obs = pack_hybrid_obs(obs_dict)
+    elif cfg.encoder_type in (
+        "vggt", "vggt_aggregator_mlp", "vggt_wp_dense_cnn", "vggt_wp_cp_64",
+    ):
+        obs = jnp.asarray(obs_dict["features"], dtype=jnp.float32)
+    else:
+        obs = normalize_image_obs(obs_dict["image"])
+    return obs[None]
+
+
+def decoder_rgb_target(batch: dict[str, Any], cfg: Any) -> jnp.ndarray:
+    """Return decoder RGB targets as ``(B*T, 3, 64, 64)`` in ``[0, 1]``."""
+    obs = batch["obs"]
+    B, T = obs_leading_shape(obs)
+    if cfg.encoder_type == "hybrid":
+        if isinstance(obs, Mapping):
+            image = normalize_image_obs(obs[HYBRID_IMAGE_KEY])
+            return image.reshape(B * T, 3, 64, 64)
+        rgb_dim = cfg.obs_shape[0] - cfg.vggt_feature_dim
+        return jnp.asarray(obs, dtype=jnp.float32).reshape(B * T, -1)[
+            :, :rgb_dim
+        ].reshape(B * T, 3, 64, 64)
+    image = normalize_image_obs(obs)
+    return image.reshape(B * T, 3, 64, 64)

--- a/src/r2dreamer/trainer.py
+++ b/src/r2dreamer/trainer.py
@@ -382,7 +382,7 @@ class Trainer:
     # Train loop
     # ------------------------------------------------------------------
 
-    def _reset_train_episode(self) -> tuple[dict, np.ndarray, dict]:
+    def _reset_train_episode(self) -> tuple[dict, np.ndarray | dict[str, np.ndarray], dict]:
         obs = self.env.reset()
         if self.obs_adapter.on_episode_reset:
             self.obs_adapter.on_episode_reset()
@@ -402,7 +402,7 @@ class Trainer:
     def _record_train_transition(
         self,
         *,
-        buffer_obs: np.ndarray,
+        buffer_obs: np.ndarray | dict[str, np.ndarray],
         action: int,
         next_obs: dict,
     ) -> None:
@@ -425,7 +425,14 @@ class Trainer:
         video_recording: dict[str, Any] | None,
         video_next_step: int,
     ) -> tuple[
-        dict, np.ndarray, dict, float, int, np.ndarray, dict[str, Any] | None, int
+        dict,
+        np.ndarray | dict[str, np.ndarray],
+        dict,
+        float,
+        int,
+        np.ndarray,
+        dict[str, Any] | None,
+        int,
     ]:
         self._on_episode_end(
             last_obs, episode_reward, episode_steps, action_counts, step, writer, f,

--- a/src/r2dreamer/world_model/encoders.py
+++ b/src/r2dreamer/world_model/encoders.py
@@ -10,10 +10,11 @@ import flax.linen as nn
 from .heads import R2MLP
 from .rssm import RMSNorm
 
-# Hybrid buffer layout (see HybridObsAdapter): a single flat float32 vector
-# ``[ rgb_normalised_flat (HYBRID_RGB_DIM) | wp_cp (HYBRID_VGGT_DIM) ]``.
+# Hybrid encoder input layout. Replay stores the modalities under explicit
+# fields (see HybridObsAdapter); src.r2dreamer.obs_batch packs them into this
+# flat tensor right before the Flax encoder boundary.
 HYBRID_RGB_DIM = 3 * 64 * 64  # 12288 — the CNN branch's 64x64 RGB, flattened
-HYBRID_VGGT_DIM = 4116        # world_points 37*37*3 + camera_pose 9
+HYBRID_VGGT_DIM = 4116        # WP/CP width: world_points 37*37*3 + camera_pose 9
 
 # Aggregator readouts (3D-50 follow-up). Defined here (small ints) rather than
 # imported from adapters.vggt_adapter so importing the world-model encoders stays
@@ -197,10 +198,12 @@ class WPConvEncoder(nn.Module):
 class HybridEncoder(nn.Module):
     """Hybrid encoder feeding the latent BOTH modalities at once (3D-50/51/52).
 
-    Input is the flat hybrid buffer vector ``[ rgb (HYBRID_RGB_DIM) | wp_cp
-    (HYBRID_VGGT_DIM) ]``. The RGB slice is reshaped to ``(B, 3, 64, 64)`` and
-    run through the standard ``ConvEncoder``; the WP/CP slice is run through an
-    MLP (the Linear->MLP upgrade of 3D-52). The two branch embeddings are
+    Input is the packed WP/CP hybrid encoder vector ``[ rgb (HYBRID_RGB_DIM) |
+    wp_cp (HYBRID_VGGT_DIM) ]``. Replay stores the fields separately as
+    ``{"image": uint8 RGB64, "wp_cp": float32}``, and obs_batch packs them
+    before this Flax module runs. The RGB slice is reshaped to ``(B, 3, 64, 64)``
+    and run through the standard ``ConvEncoder``; the WP/CP slice is run through
+    an MLP (the Linear->MLP upgrade of 3D-52). The two branch embeddings are
     concatenated to form the ``embed`` that conditions the RSSM posterior.
 
     The VGGT branch is multiplied by a single learnable scalar ``gate``

--- a/src/r2dreamer/world_model/loss.py
+++ b/src/r2dreamer/world_model/loss.py
@@ -9,6 +9,8 @@ import jax
 import jax.numpy as jnp
 import optax
 
+from src.r2dreamer.obs_batch import decoder_rgb_target
+
 
 def kl_loss(post_logits, prior_logits, stoch_classes, stoch_discrete, kl_free):
     """DreamerV3-style KL losses with free nats.
@@ -63,7 +65,7 @@ def world_model_loss(*, forward, params, batch, modules, cfg, twohot):
         (losses, metrics) — losses has keys {dyn, rep, rew, con}; metrics
         contains latent entropy/KL diagnostics.
     """
-    B, T = batch["obs"].shape[0], batch["obs"].shape[1]
+    B, T = forward["embed"].shape[0], forward["embed"].shape[1]
     losses, metrics = {}, {}
 
     # ---- KL losses ----
@@ -95,14 +97,7 @@ def world_model_loss(*, forward, params, batch, modules, cfg, twohot):
     # are identical to the decoder-free baseline. 3D-51 visual-verification head.
     if cfg.decoder:
         recon = modules["decoder"].apply(params["decoder"], feat_flat)  # (BT,3,64,64)
-        if cfg.encoder_type == "hybrid":
-            # Hybrid obs is [ rgb (rgb_dim) | wp_cp (vggt_feature_dim) ]; the RGB
-            # slice is already normalised to [0, 1] by the adapter.
-            rgb_dim = cfg.obs_shape[0] - cfg.vggt_feature_dim  # 16404 - 4116 = 12288
-            rgb_target = batch["obs"].reshape(B * T, -1)[:, :rgb_dim].reshape(B * T, 3, 64, 64)
-        else:
-            # CNN path: obs is already (B, T, 3, 64, 64), normalised to [0, 1].
-            rgb_target = batch["obs"].reshape(B * T, 3, 64, 64)
+        rgb_target = decoder_rgb_target(batch, cfg)
         losses["decoder"] = jnp.mean((recon - rgb_target) ** 2)
         metrics["decoder/recon_mse"] = losses["decoder"]
 

--- a/tests/buffer/test_replay_buffer.py
+++ b/tests/buffer/test_replay_buffer.py
@@ -116,6 +116,72 @@ class TestReplayBufferFloat32:
         # terminals should be stored and returned
         assert batch["terminals"].dtype == jnp.float32
 
+    def test_float16_storage_samples_as_float32(self):
+        cfg = BufferConfig(capacity=10, obs_shape=(8,),
+                           obs_dtype="float16", normalize_obs=False)
+        buf = ReplayBuffer(cfg)
+        for _ in range(4):
+            buf.add(np.ones(8, dtype=np.float16), 0, 0.0, False)
+
+        batch = buf.sample(batch_size=1, seq_len=2)
+        assert batch["obs"].dtype == jnp.float32
+
+
+class TestReplayBufferMappingObs:
+    """Test ReplayBuffer with explicit multi-modal observation fields."""
+
+    @pytest.fixture
+    def buf(self):
+        cfg = BufferConfig(
+            capacity=50,
+            obs_shape={"image": (3, 4, 4), "wp_cp": (6,)},
+            obs_dtype={"image": "uint8", "wp_cp": "float32"},
+            normalize_obs={"image": False, "wp_cp": False},
+        )
+        return ReplayBuffer(cfg)
+
+    def test_add_and_sample_fields(self, buf):
+        for i in range(20):
+            obs = {
+                "image": np.full((3, 4, 4), i, dtype=np.uint8),
+                "wp_cp": np.full((6,), float(i), dtype=np.float32),
+            }
+            buf.add(obs, i % 4, float(i), done=(i == 9))
+
+        batch = buf.sample(batch_size=4, seq_len=5)
+        assert set(batch["obs"]) == {"image", "wp_cp"}
+        assert batch["obs"]["image"].shape == (4, 5, 3, 4, 4)
+        assert batch["obs"]["image"].dtype == jnp.uint8
+        assert batch["obs"]["wp_cp"].shape == (4, 5, 6)
+        assert batch["obs"]["wp_cp"].dtype == jnp.float32
+        assert batch["actions"].shape == (4, 5)
+        assert batch["is_first"].shape == (4, 5)
+
+    def test_missing_field_raises(self, buf):
+        obs = {"image": np.zeros((3, 4, 4), dtype=np.uint8)}
+        with pytest.raises(KeyError, match="missing replay fields"):
+            buf.add(obs, action=0, reward=0.0, done=False)
+
+    def test_mapping_field_normalization_is_per_field(self):
+        cfg = BufferConfig(
+            capacity=10,
+            obs_shape={"image": (1,), "features": (1,)},
+            obs_dtype={"image": "uint8", "features": "float32"},
+            normalize_obs={"image": True, "features": False},
+        )
+        buf = ReplayBuffer(cfg)
+        obs = {
+            "image": np.array([255], dtype=np.uint8),
+            "features": np.array([255.0], dtype=np.float32),
+        }
+        for _ in range(4):
+            buf.add(obs, action=0, reward=0.0, done=False)
+
+        batch = buf.sample(batch_size=1, seq_len=2)
+        assert jnp.allclose(batch["obs"]["image"], 1.0)
+        assert batch["obs"]["image"].dtype == jnp.float32
+        assert jnp.allclose(batch["obs"]["features"], 255.0)
+
 
 class TestWriteHeadSafety:
     """Verify sampled sequences never cross the write-head boundary."""

--- a/tests/r2dreamer/launch/test_encoders.py
+++ b/tests/r2dreamer/launch/test_encoders.py
@@ -8,6 +8,7 @@ import pytest
 
 from src.r2dreamer.adapters import ObsAdapter, VGGTObsAdapter
 from src.r2dreamer.adapters.hybrid_adapter import HybridObsAdapter
+from src.r2dreamer.obs_batch import HYBRID_IMAGE_KEY, HYBRID_WP_CP_KEY
 from src.r2dreamer.encoders import (
     CNNEncoder,
     EncoderSpec,
@@ -368,9 +369,19 @@ class TestHybridEncoder:
 
         adapter = HybridObsAdapter(FakeExtractor())
         assert isinstance(adapter, ObsAdapter)
-        assert adapter.buffer_shape == (16404,)
-        assert adapter.buffer_dtype == "float32"
-        assert adapter.normalize_on_sample is False
+        assert adapter.buffer_shape == {
+            HYBRID_IMAGE_KEY: (3, 64, 64),
+            HYBRID_WP_CP_KEY: (4116,),
+        }
+        assert adapter.buffer_dtype == {
+            HYBRID_IMAGE_KEY: "uint8",
+            HYBRID_WP_CP_KEY: "float32",
+        }
+        assert adapter.normalize_on_sample == {
+            HYBRID_IMAGE_KEY: False,
+            HYBRID_WP_CP_KEY: False,
+        }
+        assert adapter.encoder_obs_shape == (16404,)
 
         rng = np.random.default_rng(0)
         image = rng.integers(0, 256, size=(3, 518, 518), dtype=np.uint8)
@@ -378,24 +389,24 @@ class TestHybridEncoder:
 
         replay, agent_obs = adapter.transform(obs_dict)
 
-        assert replay.shape == (16404,)
-        assert replay.dtype == np.float32
+        assert set(replay) == {HYBRID_IMAGE_KEY, HYBRID_WP_CP_KEY}
+        assert replay[HYBRID_IMAGE_KEY].shape == (3, 64, 64)
+        assert replay[HYBRID_IMAGE_KEY].dtype == np.uint8
+        assert replay[HYBRID_WP_CP_KEY].shape == (4116,)
+        assert replay[HYBRID_WP_CP_KEY].dtype == np.float32
 
-        # RGB slice: normalized 64x64 resize of the input, in [0, 1].
+        # RGB field: raw 64x64 uint8 resize of the input.
         img64 = resize_chw_uint8(image, 64)  # (3,64,64) uint8
-        expected_rgb = (img64.astype(np.float32) / 255.0).reshape(-1)
-        assert replay[:12288].min() >= 0.0
-        assert replay[:12288].max() <= 1.0
-        np.testing.assert_allclose(replay[:12288], expected_rgb)
+        np.testing.assert_array_equal(replay[HYBRID_IMAGE_KEY], img64)
 
-        # WP/CP slice: flattened world_points then camera_pose.
+        # WP/CP field: flattened world_points then camera_pose.
         expected_wp_cp = np.concatenate(
             [world_points.reshape(-1), camera_pose]
         ).astype(np.float32)
-        np.testing.assert_allclose(replay[12288:], expected_wp_cp)
+        np.testing.assert_allclose(replay[HYBRID_WP_CP_KEY], expected_wp_cp)
 
-        assert np.asarray(agent_obs["hybrid"]).shape == (16404,)
         assert agent_obs["image"].shape == (3, 64, 64)
+        assert np.asarray(agent_obs[HYBRID_WP_CP_KEY]).shape == (4116,)
 
 
 @pytest.mark.gpu

--- a/tests/r2dreamer/test_agent.py
+++ b/tests/r2dreamer/test_agent.py
@@ -6,6 +6,8 @@ import pytest
 
 from src.r2dreamer.config import R2DreamerConfig
 from src.r2dreamer.agent import R2DreamerAgent
+from src.r2dreamer.adapters.hybrid_adapter import HYBRID_FEATURE_DIM
+from src.r2dreamer.adapters.vggt_adapter import VGGT_FEATURE_DIM
 
 
 @pytest.fixture
@@ -72,6 +74,55 @@ def make_deterministic_batch(cfg, B=2, T=4):
         "is_first": is_first,
         "is_last": is_last,
         "is_terminal": is_terminal,
+    }
+
+
+def make_small_hybrid_cfg():
+    return R2DreamerConfig(
+        encoder_type="hybrid",
+        obs_shape=(HYBRID_FEATURE_DIM,),
+        num_actions=4,
+        deter_size=32,
+        hidden_size=16,
+        stoch_classes=4,
+        stoch_discrete=4,
+        blocks=4,
+        encoder_depth=4,
+        encoder_kernel=3,
+        encoder_mults=(1, 1),
+        vggt_embed_dim=16,
+        mlp_vggt_hidden=16,
+        mlp_vggt_layers=1,
+        mlp_units=16,
+        mlp_layers_reward=1,
+        mlp_layers_cont=1,
+        mlp_layers_actor=1,
+        mlp_layers_critic=1,
+        twohot_bins=21,
+        imagination_horizon=3,
+        horizon=20,
+        lr=1e-3,
+        warmup_steps=0,
+    )
+
+
+def make_hybrid_mapping_batch(cfg, B=1, T=4):
+    image_values = np.arange(B * T * 3 * 64 * 64, dtype=np.uint32) % 256
+    image = image_values.astype(np.uint8).reshape(B, T, 3, 64, 64)
+    wp_cp = np.linspace(
+        -1.0, 1.0, B * T * VGGT_FEATURE_DIM, dtype=np.float32
+    ).reshape(B, T, VGGT_FEATURE_DIM)
+    action_ids = jnp.arange(B * T).reshape(B, T) % cfg.num_actions
+    return {
+        "obs": {
+            "image": jnp.asarray(image),
+            "wp_cp": jnp.asarray(wp_cp),
+        },
+        "actions": jax.nn.one_hot(action_ids, cfg.num_actions, dtype=jnp.float32),
+        "rewards": jnp.zeros((B, T), dtype=jnp.float32),
+        "is_first": jnp.zeros((B, T), dtype=jnp.float32).at[:, 0].set(1.0),
+        "is_last": jnp.zeros((B, T), dtype=jnp.float32),
+        "is_terminal": jnp.zeros((B, T), dtype=jnp.float32),
     }
 
 
@@ -151,3 +202,16 @@ class TestR2DreamerAgent:
             + cfg.scale_repval * metrics_a["loss/repval"]
         )
         assert metrics_a["total_loss"] == pytest.approx(expected_total, rel=1e-6)
+
+    def test_hybrid_train_step_accepts_mapping_obs(self):
+        cfg = make_small_hybrid_cfg()
+        agent = R2DreamerAgent(cfg, jax.random.PRNGKey(5))
+        batch = make_hybrid_mapping_batch(cfg)
+
+        metrics = agent.train_step(batch, jax.random.PRNGKey(6))
+
+        assert metrics["nan_skipped"] == 0.0
+        assert "hybrid/gate" in metrics
+        assert "hybrid/cnn_frac" in metrics
+        assert "hybrid/vggt_frac" in metrics
+        assert np.isfinite(metrics["total_loss"])

--- a/tests/r2dreamer/test_trainer.py
+++ b/tests/r2dreamer/test_trainer.py
@@ -10,6 +10,7 @@ import pytest
 
 from src.r2dreamer.config import R2DreamerConfig
 from src.r2dreamer.agent import R2DreamerAgent
+from src.r2dreamer.adapters import ObsAdapter
 from src.r2dreamer.trainer import (
     Trainer,
     TrainerConfig,
@@ -35,6 +36,22 @@ class _DummyEnv:
 
     def close(self) -> None:
         pass
+
+
+class _MappingObsAdapter(ObsAdapter):
+    def __init__(self):
+        super().__init__(
+            buffer_dtype={"image": "uint8", "wp_cp": "float32"},
+            buffer_shape={"image": (3, 64, 64), "wp_cp": (4116,)},
+            normalize_on_sample={"image": False, "wp_cp": False},
+            agent_obs_shape=(16404,),
+        )
+
+    def transform(self, obs_dict: dict) -> tuple[dict[str, np.ndarray], dict]:
+        return {
+            "image": obs_dict["image"],
+            "wp_cp": np.ones((4116,), dtype=np.float32),
+        }, obs_dict
 
 
 class TestConvertBatch:
@@ -198,3 +215,35 @@ class TestResume:
             Trainer(
                 agent=agent, env=_DummyEnv(), agent_config=cfg, trainer_config=tcfg,
             )
+
+
+class TestTrainerMappingReplay:
+    def test_trainer_builds_and_records_mapping_obs_buffer(self, tmp_path):
+        cfg = R2DreamerConfig(obs_shape=(16404,), num_actions=4, buffer_capacity=8)
+        tcfg = TrainerConfig(
+            output_dir=str(tmp_path / "logdir"),
+            total_steps=1,
+            wandb_project=None,
+        )
+        trainer = Trainer(
+            agent=object(),
+            env=_DummyEnv(),
+            agent_config=cfg,
+            trainer_config=tcfg,
+            obs_adapter=_MappingObsAdapter(),
+        )
+
+        buffer_obs, _ = trainer.obs_adapter.transform(_DummyEnv().reset())
+        trainer._record_train_transition(
+            buffer_obs=buffer_obs,
+            action=1,
+            next_obs={"reward": 1.0, "done": False, "success": 0.0},
+        )
+
+        assert trainer.buffer.size == 1
+        batch = trainer.buffer.sample(batch_size=1, seq_len=1)
+        assert set(batch["obs"]) == {"image", "wp_cp"}
+        assert batch["obs"]["image"].shape == (1, 1, 3, 64, 64)
+        assert batch["obs"]["image"].dtype == jnp.uint8
+        assert batch["obs"]["wp_cp"].shape == (1, 1, 4116)
+        assert batch["obs"]["wp_cp"].dtype == jnp.float32


### PR DESCRIPTION
## What changed

- Extended `ReplayBuffer`/`BufferConfig` to support either a single observation array or explicit named observation fields.
- Switched hybrid replay storage from one flat RGB+WP/CP vector to modal fields: `image` as compact uint8 RGB64 and `wp_cp` as float32 features.
- Added `src/r2dreamer/obs_batch.py` as the narrow bridge that normalizes images, packs hybrid dict observations for the existing encoder boundary, and extracts decoder RGB targets.
- Updated agent, trainer, world-model loss, heldout eval, encoder specs, and hybrid adapter wiring to consume the modality-aware replay layout.
- Added/updated tests for image-only, VGGT-only, float16 storage, and hybrid mapping observations.
- Added `scripts/r2dreamer/profile_modal_replay.py` for replay/training timing comparisons.

## Why

Hybrid runs were storing RGB and WP/CP together as one large flat float32 vector. That made replay heavier than necessary and obscured which part of the observation came from the image path versus the VGGT feature path. Keeping modalities separate in replay makes the data layout clearer and reduces sampling/conversion overhead while preserving the existing encoder input contract.

## Linear issue

[3D-72](https://linear.app/3d-wm-objectnav/issue/3D-72/add-modality-aware-replay-buffer-layout-for-hybrid-observations)

## Acceptance criteria checked

- Scene/CNN-only replay path remains covered.
- VGGT-only replay path remains covered.
- Hybrid replay path stores image and WP/CP separately and packs them before the encoder.
- Float16 feature storage still samples as float32, while only modal uint8 image fields stay uint8 until `obs_batch.py` normalizes them.
- Hybrid train step accepts mapping observations.

## Verification

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/buffer/test_replay_buffer.py tests/r2dreamer/test_trainer.py tests/r2dreamer/test_agent.py tests/r2dreamer/launch/test_encoders.py tests/r2dreamer/world_model/test_hybrid_encoder.py -m 'not gpu' -q` -> `65 passed, 2 deselected`
- `.venv/bin/python -m py_compile src/buffer/replay_buffer.py src/r2dreamer/obs_batch.py src/r2dreamer/agent.py src/r2dreamer/trainer.py src/r2dreamer/world_model/loss.py src/r2dreamer/heldout_eval.py src/r2dreamer/world_model/encoders.py src/r2dreamer/encoders/specs.py scripts/r2dreamer/profile_modal_replay.py` -> passed
- `git diff --check` -> passed
- H100 profiler before final review renaming: `scripts/r2dreamer/profile_modal_replay.py` wrote `/tmp/3d72_modal_replay_timing.html`; modal hybrid reduced sample+convert from 13.274 ms to 3.788 ms versus flat hybrid in that run.

## Risk

Medium: the replay sample contract now allows `batch["obs"]` to be a mapping for hybrid configs. The bridge module keeps existing encoder modules on flat tensors, and targeted tests cover agent/trainer/loss wiring.

## How to test

Recommended smoke set before merge:

```bash
bash scripts/slurm/launch.sh l4_cnn wp_cp_mlp hybrid_v1 --smoke --dry-run
bash scripts/slurm/launch.sh l4_cnn wp_cp_mlp hybrid_v1 --smoke
```

Optional extra for the real float16 replay path:

```bash
bash scripts/slurm/launch.sh wp_dense_cnn --smoke
```

## What was intentionally not done

- Did not change the Flax hybrid encoder module to consume a dict directly; `obs_batch.py` keeps that boundary flat for now.
- Did not launch the SLURM smokes yet in this PR turn.

## Agent involvement

Implemented, tested, profiled, and published with Codex in a dedicated worktree.

## Follow-up issues created

None.
## Smoke gate before merge (2026-06-11)

Branch was first updated with `origin/main` and pushed (`a2f7401`). CPU checks and the SLURM smoke gate were then run from the PR worktree.

CPU/local checks:

```text
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/buffer/test_replay_buffer.py tests/r2dreamer/test_trainer.py tests/r2dreamer/test_agent.py tests/r2dreamer/launch/test_encoders.py tests/r2dreamer/world_model/test_hybrid_encoder.py -m 'not gpu' -q
65 passed, 2 deselected in 150.66s (0:02:30)

.venv/bin/python -m py_compile src/buffer/replay_buffer.py src/r2dreamer/obs_batch.py src/r2dreamer/agent.py src/r2dreamer/trainer.py src/r2dreamer/world_model/loss.py src/r2dreamer/heldout_eval.py src/r2dreamer/world_model/encoders.py src/r2dreamer/encoders/specs.py scripts/r2dreamer/profile_modal_replay.py
passed

git diff --check
passed

bash scripts/slurm/launch.sh l4_cnn wp_cp_mlp hybrid_v1 --smoke --dry-run
passed; rendered all three smoke scripts
```

SLURM smoke jobs:

```text
4995687 smoke-r2d-L4-cnn              COMPLETED 0:0 00:04:04
4995749 smoke-wp-cp-mlp               COMPLETED 0:0 00:08:40
4995750 smoke-hybrid-cnn-vggt-v1      COMPLETED 0:0 00:06:51
```

Relevant smoke output:

```text
# l4_cnn, job 4995687
[step     1499] reward=-2.77 steps=500 SR=0.000
=== Smoke PASS ===
metrics.csv lines: 347
Output: output/r2dreamer-curriculum-l4/run-4995687

# wp_cp_mlp, job 4995749
[step     1499] reward=-3.90 steps=500 SR=0.000
=== Smoke PASS ===
metrics.csv lines: 341
Output: output/r2dreamer-curriculum-l1-vggt-wp-cp-mlp/run-4995749

# hybrid_v1, job 4995750
[step      750/800] total=121.819 dyn=2.942 rew=5.161 policy=-0.023 fps=5
=== Smoke PASS ===
metrics.csv lines: 332
Output: output/smoke/hybrid-20260611-164736
```

Note: the first VGGT smoke submissions (`4995688`, `4995689`) failed before training because the worktree lacked the ignored `external/InfiniteVGGT` checkout (`ModuleNotFoundError: streamvggt`). I linked the existing main-checkout `external/InfiniteVGGT` into the worktree and reran the VGGT/hybrid smokes above successfully; this was an environment bootstrap issue, not a PR code failure.
