### PR TITLE
Add SR last and mean episode summaries

### DIFF
--- a/src/shared/wandb_utils.py
+++ b/src/shared/wandb_utils.py
@@ -48,7 +48,7 @@ def init_run(
 
 
 class EpisodeTracker:
-    """Track per-episode metrics with rolling averages and per-category breakdown."""
+    """Track per-episode metrics with rolling and cumulative summaries."""
 
     # Per-category metric streams. Adding a new one is a one-line change here.
     _PER_CAT_KEYS: tuple[str, ...] = ("success", "spl", "reward")
@@ -64,6 +64,8 @@ class EpisodeTracker:
         # informative in the deterministic val setting.
         self._track_collision_rate = track_collision_rate
         self._global: dict[str, deque[float]] = defaultdict(self._new_window)
+        self._global_totals: dict[str, float] = defaultdict(float)
+        self._global_counts: dict[str, int] = defaultdict(int)
         self._per_cat: dict[str, dict[str, deque[float]]] = defaultdict(
             lambda: defaultdict(self._new_window)
         )
@@ -97,7 +99,10 @@ class EpisodeTracker:
             samples["collision_rate"] = collision_rate
 
         for k, v in samples.items():
-            self._global[k].append(v)
+            value = float(v)
+            self._global[k].append(value)
+            self._global_totals[k] += value
+            self._global_counts[k] += 1
         for k in self._PER_CAT_KEYS:
             self._per_cat[category][k].append(samples[k])
 
@@ -110,8 +115,13 @@ class EpisodeTracker:
         }
         for k, v in samples.items():
             metrics[f"episode/{k}"] = v
+        metrics["metrics/sr_last"] = float(success)
         for k, dq in self._global.items():
-            metrics[f"metrics/{self._OUTPUT_RENAME.get(k, k)}"] = float(np.mean(dq))
+            out_key = self._OUTPUT_RENAME.get(k, k)
+            metrics[f"metrics/{out_key}"] = float(np.mean(dq))
+            metrics[f"metrics/{out_key}_mean"] = (
+                self._global_totals[k] / self._global_counts[k]
+            )
         for cat, per in self._per_cat.items():
             for k, dq in per.items():
                 metrics[f"goal/{cat}/{self._OUTPUT_RENAME.get(k, k)}"] = float(np.mean(dq))

--- a/tests/shared/test_episode_tracker.py
+++ b/tests/shared/test_episode_tracker.py
@@ -42,6 +42,32 @@ def test_per_category_spl_uses_rolling_window():
     assert out["goal/chair/spl"] == pytest.approx(1.0 / 3.0)
 
 
+def test_success_rate_logs_last_rolling_and_cumulative_mean():
+    tracker = EpisodeTracker(window=2)
+    tracker.record(**_make_episode("chair", spl=0.0, success=1.0))
+    tracker.record(**_make_episode("chair", spl=0.0, success=0.0))
+    out = tracker.record(**_make_episode("chair", spl=0.0, success=0.0))
+
+    assert out["episode/success"] == pytest.approx(0.0)
+    assert out["metrics/sr_last"] == pytest.approx(0.0)
+    # Existing training curve: rolling window over the last two episodes.
+    assert out["metrics/sr"] == pytest.approx(0.0)
+    # Paper/report summary: cumulative mean over all completed episodes.
+    assert out["metrics/sr_mean"] == pytest.approx(1.0 / 3.0)
+
+
+def test_cumulative_metric_mean_is_not_limited_by_rolling_window():
+    tracker = EpisodeTracker(window=2)
+    tracker.record(**_make_episode("chair", reward=1.0, spl=1.0))
+    tracker.record(**_make_episode("chair", reward=1.0, spl=1.0))
+    out = tracker.record(**_make_episode("chair", reward=4.0, spl=0.0))
+
+    assert out["metrics/reward"] == pytest.approx(2.5)
+    assert out["metrics/reward_mean"] == pytest.approx(2.0)
+    assert out["metrics/spl"] == pytest.approx(0.5)
+    assert out["metrics/spl_mean"] == pytest.approx(2.0 / 3.0)
+
+
 def test_collision_rate_only_emitted_when_flag_enabled():
     train_tracker = EpisodeTracker(window=100, track_collision_rate=False)
     val_tracker = EpisodeTracker(window=100, track_collision_rate=True)


### PR DESCRIPTION
## What changed

- Added `metrics/sr_last` for the latest completed episode success value.
- Added cumulative `metrics/*_mean` summaries, including `metrics/sr_mean`, alongside the existing rolling `metrics/sr` curve.
- Added focused `EpisodeTracker` tests covering last, rolling, and cumulative summary behavior.

## Why

The existing W&B/run summary for `metrics/sr` reflects the last logged rolling window value. That is still useful for training curves, but it can be misleading as a scalar summary when success rate fluctuates. Keeping `metrics/sr` unchanged preserves existing plots, while `metrics/sr_last` and `metrics/sr_mean` make the summary fields explicit.

## Linear issue

None linked for this small follow-up.

## Acceptance criteria checked

- Existing rolling `metrics/sr` behavior is unchanged.
- Latest episode success is available as `metrics/sr_last`.
- Full-run episode mean is available as `metrics/sr_mean`.
- Other global episode metrics also get cumulative `metrics/*_mean` summaries.

## Risk

Low. This only adds new emitted metric keys and keeps existing metric names intact.

## How to test

- `.venv/bin/python -m pytest tests/shared/test_episode_tracker.py -q`
- `git diff --check`

The pytest run emitted a JAX CUDA initialization warning on this CPU-only path, but the focused tests passed.

## What was intentionally not done

- Did not rename `metrics/sr`, so existing dashboards and scripts keep working.
- Did not update historical W&B runs or local database snapshots; the new fields apply to future metric emission.

## Agent involvement

Implemented and verified with Codex in a dedicated worktree.

## Follow-up issues created

None.