### PR TITLE
perf(r2dreamer): remove in-run val and video

### DIFF
--- a/scripts/slurm/configs/l1_agg_mlp_cap500k.yaml
+++ b/scripts/slurm/configs/l1_agg_mlp_cap500k.yaml
@@ -12,8 +12,6 @@ args:
   buffer_capacity: 500000
   wandb_name: l1-agg-mlp-cap500k-${SLURM_JOB_ID}
   wandb_tags: replay-capacity,3d-63,l1,vggt,aggregator-mlp,cap-500k,seed-42,sr-ablation
-  video_log_every: 0
-  val_every: 0
 smoke:
   args:
     output_dir: output/r2dreamer-l1-replay-capacity/agg-mlp-cap500k/smoke-${TIMESTAMP}

--- a/scripts/slurm/configs/l1_cnn_cap100k.yaml
+++ b/scripts/slurm/configs/l1_cnn_cap100k.yaml
@@ -19,5 +19,3 @@ args:
   wandb_project: 3d-vla-objectnav
   wandb_name: l1-cnn-cap100k-${SLURM_JOB_ID}
   wandb_tags: replay-capacity,3d-63,l1,cnn,cap-100k,seed-42,sr-ablation
-  video_log_every: 0
-  val_every: 0

--- a/scripts/slurm/configs/l1_cnn_cap10k.yaml
+++ b/scripts/slurm/configs/l1_cnn_cap10k.yaml
@@ -19,5 +19,3 @@ args:
   wandb_project: 3d-vla-objectnav
   wandb_name: l1-cnn-cap10k-${SLURM_JOB_ID}
   wandb_tags: replay-capacity,3d-63,l1,cnn,cap-10k,seed-42,sr-ablation
-  video_log_every: 0
-  val_every: 0

--- a/scripts/slurm/configs/l1_cnn_cap1m.yaml
+++ b/scripts/slurm/configs/l1_cnn_cap1m.yaml
@@ -19,5 +19,3 @@ args:
   wandb_project: 3d-vla-objectnav
   wandb_name: l1-cnn-cap1m-${SLURM_JOB_ID}
   wandb_tags: replay-capacity,3d-63,l1,cnn,cap-1m,seed-42,sr-ablation
-  video_log_every: 0
-  val_every: 0

--- a/scripts/slurm/configs/l1_cnn_cap500k.yaml
+++ b/scripts/slurm/configs/l1_cnn_cap500k.yaml
@@ -19,5 +19,3 @@ args:
   wandb_project: 3d-vla-objectnav
   wandb_name: l1-cnn-cap500k-${SLURM_JOB_ID}
   wandb_tags: replay-capacity,3d-63,l1,cnn,cap-500k,seed-42,sr-ablation
-  video_log_every: 0
-  val_every: 0

--- a/scripts/slurm/configs/l1_vggt.yaml
+++ b/scripts/slurm/configs/l1_vggt.yaml
@@ -18,12 +18,5 @@ args:
   wandb_name: vggt_jax-${SLURM_JOB_ID}
   wandb_tags: curriculum,level1,1house,chair-only,vggt,vggt_jax,jax,3d-encoder
   render_resolution: 518
-  # Scalars-only during training, shared by the whole VGGT curriculum arm
-  # (l2/l3/l4_vggt inherit via extends). video_log_every=0 disables W&B
-  # episode-video rendering; val_every=0 disables the in-run val loop AND skips
-  # building the eval habitat sim (train.py only spawns val_env when val_every
-  # > 0). Videos + eval metrics are produced later from checkpoints. Keeps the
-  # VGGT arm symmetric with the CNN baseline and drops the two heaviest habitat
-  # GL paths (video re-render + second sim instance).
-  video_log_every: 0
-  val_every: 0
+  # In-run validation and episode-video rendering were removed from training;
+  # generate held-out eval metrics and videos separately from checkpoints.

--- a/scripts/slurm/configs/l1_vggt_wpcp37_cap500k.yaml
+++ b/scripts/slurm/configs/l1_vggt_wpcp37_cap500k.yaml
@@ -12,5 +12,3 @@ args:
   buffer_capacity: 500000
   wandb_name: l1-wpcp37-cap500k-${SLURM_JOB_ID}
   wandb_tags: replay-capacity,3d-63,l1,vggt,wp-cp,wp-37,cap-500k,seed-42,sr-ablation
-  video_log_every: 0
-  val_every: 0

--- a/scripts/slurm/configs/l1_vggt_wpcp64_cap500k.yaml
+++ b/scripts/slurm/configs/l1_vggt_wpcp64_cap500k.yaml
@@ -12,5 +12,3 @@ args:
   buffer_capacity: 500000
   wandb_name: l1-wpcp64-cap500k-${SLURM_JOB_ID}
   wandb_tags: replay-capacity,3d-63,l1,vggt,wp-cp,wp-64,cap-500k,seed-42,sr-ablation
-  video_log_every: 0
-  val_every: 0

--- a/scripts/slurm/configs/l2_vggt.yaml
+++ b/scripts/slurm/configs/l2_vggt.yaml
@@ -13,6 +13,5 @@ args:
   # flatten reference vggt_jax-4216462. The current default is 1 (shallow MLP),
   # so this MUST be set explicitly or the cross-level comparison is confounded.
   mlp_layers: 0
-  # Scalars-only: video_log_every=0 / val_every=0 inherited from l1_vggt.
-  # (Dropped the stale val_data / val_loss_every flags — the parser no longer
-  # accepts them; in-run eval is off and regenerated from checkpoints instead.)
+  # In-run validation/video flags are not exposed by the train parser.
+  # Held-out eval metrics and videos are regenerated from checkpoints.

--- a/scripts/slurm/configs/l3_vggt.yaml
+++ b/scripts/slurm/configs/l3_vggt.yaml
@@ -13,6 +13,5 @@ args:
   # flatten reference vggt_jax-4216462. The current default is 1 (shallow MLP),
   # so this MUST be set explicitly or the cross-level comparison is confounded.
   mlp_layers: 0
-  # Scalars-only: video_log_every=0 / val_every=0 inherited from l1_vggt.
-  # (Dropped the stale val_data / val_loss_every flags — the parser no longer
-  # accepts them; in-run eval is off and regenerated from checkpoints instead.)
+  # In-run validation/video flags are not exposed by the train parser.
+  # Held-out eval metrics and videos are regenerated from checkpoints.

--- a/scripts/slurm/configs/l4_cnn.yaml
+++ b/scripts/slurm/configs/l4_cnn.yaml
@@ -7,10 +7,8 @@ comments:
   - "Level 4 CNN baseline: 10 houses (4 easy, 4 medium, 2 hard) x 6 goal categories"
   - "2D-RGB CNN encoder (64x64) — baseline control for the VGGT 3D-encoder comparison"
   - "2M steps, 24h wall time (matches the VGGT arm's step budget)"
-  - "Scalars-only run: video logging + in-run eval disabled (video_log_every=0,"
-  - "val_every=0). Episode videos and held-out eval metrics are regenerated"
-  - "offline from saved checkpoints, not during training. This also avoids the"
-  - "two heaviest habitat GL paths (video re-render + second val sim instance)."
+  - "In-run validation and episode-video rendering were removed from training."
+  - "Episode videos and held-out eval metrics are regenerated offline from saved checkpoints."
 sbatch:
   time: "24:00:00"
 args:
@@ -22,9 +20,5 @@ args:
   wandb_project: 3d-vla-objectnav
   wandb_name: r2d-L4-cnn-${SLURM_JOB_ID}
   wandb_tags: curriculum,level4,10houses,6goals,cnn,baseline,jax,2d-rgb
-  # Scalars-only during training. video_log_every=0 disables W&B episode-video
-  # rendering; val_every=0 disables the in-run val-episode loop AND skips
-  # building the eval habitat sim (train.py only spawns val_env when val_every
-  # > 0). Videos + eval metrics are produced later from checkpoints.
-  video_log_every: 0
-  val_every: 0
+  # In-run validation and episode-video rendering were removed from training;
+  # generate held-out eval metrics and videos separately from checkpoints.

--- a/scripts/slurm/configs/l4_vggt.yaml
+++ b/scripts/slurm/configs/l4_vggt.yaml
@@ -13,6 +13,5 @@ args:
   # flatten reference vggt_jax-4216462. The current default is 1 (shallow MLP),
   # so this MUST be set explicitly or the cross-level comparison is confounded.
   mlp_layers: 0
-  # Scalars-only: video_log_every=0 / val_every=0 inherited from l1_vggt.
-  # (Dropped the stale val_data / val_loss_every flags — the parser no longer
-  # accepts them; in-run eval is off and regenerated from checkpoints instead.)
+  # In-run validation/video flags are not exposed by the train parser.
+  # Held-out eval metrics and videos are regenerated from checkpoints.

--- a/scripts/verify_3d_35_metrics.sbatch
+++ b/scripts/verify_3d_35_metrics.sbatch
@@ -10,15 +10,9 @@
 #SBATCH --error=output/verify-3d-35/slurm-%j.log
 
 # Verification run for the 3D-35 metrics overhaul. Dev-sized CNN + L1
-# training on dev_gpu_h100 (30-min cap) that fires the new Val-Episode-Loop
-# ~3 times (val_every=5k) so every new metric shows up in W&B during the
-# run, not just at the end:
-#   val/metrics/sr,spl,softspl,dtg,collision_rate,reward
-#   val/goal/{chair,bed,plant,sofa,toilet,tv_monitor}/{sr,spl,reward}
-#   val/episode/{softspl,dtg,collision_rate}
-#   val/episode_video           (deterministic playback)
-# And confirms removal of the old offline val_loss keys (no val/total_loss,
-# no val/loss/*).
+# training on dev_gpu_h100 (30-min cap). In-run validation and episode-video
+# rendering were removed from training; use src.r2dreamer.launch.evaluate on
+# saved checkpoints for held-out eval metrics/videos.
 #
 # Submit from the project root:
 #   sbatch scripts/verify_3d_35_metrics.sbatch
@@ -35,7 +29,7 @@ TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 TAG="verify-3d-35"
 RUN_NAME="${TAG}-cnn-l1-${TIMESTAMP}"
 
-echo "=== 3D-35 metrics-overhaul verification (15k steps, CNN, L1, val every 5k, dev_gpu_h100) ==="
+echo "=== 3D-35 metrics-overhaul verification (15k steps, CNN, L1, no in-run val/video, dev_gpu_h100) ==="
 echo "Node:    $(hostname)"
 echo "GPU:     $(nvidia-smi --query-gpu=name --format=csv,noheader)"
 echo "Date:    $(date)"
@@ -54,10 +48,6 @@ uv run python -m src.main train \
     --seed 0 \
     --log_every 250 \
     --checkpoint_every 5000 \
-    --val_every 5000 \
-    --val_episodes 10 \
-    --val_video_episodes 1 \
-    --val_max_episode_steps 300 \
     --act_entropy 3e-2 \
     --output_dir "output/verify-3d-35/${RUN_NAME}" \
     --wandb_name "${RUN_NAME}" \
@@ -67,8 +57,7 @@ echo ""
 echo "=== Done at $(date) ==="
 echo ""
 echo "Verify in W&B:"
-echo "  - val/metrics/{sr,spl,softspl,dtg,collision_rate,reward} at steps 5k/10k/15k"
-echo "  - val/goal/*/spl and val/goal/*/sr"
-echo "  - val/episode_video (3 deterministic videos, same scene across runs)"
-echo "  - NO val/total_loss, NO val/loss/* keys (3D-37 removed them)"
+echo "  - train/ metrics are logged during training"
+echo "  - NO val/metrics/* and NO episode-video keys are emitted by train"
+echo "  - run offline evaluate from a checkpoint for held-out eval metrics/videos"
 echo "  - NO kl_prior / kl_post duplicates (3D-42 — already absent in current code)"

--- a/src/r2dreamer/launch/parser.py
+++ b/src/r2dreamer/launch/parser.py
@@ -29,27 +29,10 @@ def _add_basic_train_args(p: argparse.ArgumentParser) -> None:
                         "default value (1).")
 
 
-def _add_val_train_args(p: argparse.ArgumentParser) -> None:
-    # Val-Episode-Loop (3D-36). 0 disables. Default 50_000 matches the
-    # checkpoint cadence so val signals land alongside checkpoints.
-    p.add_argument("--val_every", type=int, default=50_000,
-                   help="Run a deterministic val-episode loop every N steps (0 disables)")
-    p.add_argument("--val_episodes", type=int, default=50,
-                   help="Episodes per val-loop trigger")
-    p.add_argument("--val_video_episodes", type=int, default=1,
-                   help="Number of val episodes to record as W&B videos per trigger")
-    p.add_argument("--val_max_episode_steps", type=int, default=500,
-                   help="Per-episode step cap inside the val loop")
-
-
-def _add_resume_video_train_args(p: argparse.ArgumentParser) -> None:
+def _add_resume_train_args(p: argparse.ArgumentParser) -> None:
     p.add_argument("--resume_from", type=str, default=None)
     p.add_argument("--wandb_id", type=str, default=None,
                    help="W&B run-id to reattach to (resume='must')")
-    p.add_argument("--video_log_every", type=int, default=25_000,
-                   help="Log one Habitat episode video every N train steps")
-    p.add_argument("--video_log_episodes", type=int, default=1,
-                   help="Number of Habitat train episodes to record per interval")
     p.add_argument("--act_entropy", type=float, default=3e-2,
                    help="Actor entropy coefficient. 3e-2 is the Habitat 4-action ObjectNav "
                         "baseline; the DreamerV3 paper default 3e-4 (tuned for 17-action Crafter) "
@@ -129,8 +112,7 @@ def _build_parser_train() -> argparse.ArgumentParser:
     """Build CLI parser for train(). Union of flags from all r2dreamer entrypoints."""
     p = argparse.ArgumentParser(add_help=True)
     _add_basic_train_args(p)
-    _add_val_train_args(p)
-    _add_resume_video_train_args(p)
+    _add_resume_train_args(p)
     _add_overfit_train_args(p)
     _add_loss_override_train_args(p)
     _add_latent_decoder_train_args(p)

--- a/src/r2dreamer/launch/train.py
+++ b/src/r2dreamer/launch/train.py
@@ -62,9 +62,8 @@ def _make_env_instances(
     curriculum_path: str | None,
     encoder_spec: Any,
     env_registry: dict[str, Any],
-) -> tuple[Any, Any | None, int]:
+) -> tuple[Any, int]:
     env_fn = env_registry[env]
-    val_env_instance = None
     if env == "habitat":
         env_instance = env_fn(
             curriculum_path=curriculum_path,
@@ -72,18 +71,9 @@ def _make_env_instances(
             seed=args.seed,
             render_resolution=encoder_spec.env_render_resolution,
         )
-        # Val env: same curriculum JSON, eval-key set. Skip when val is off
-        # or the user is in train-of-train mode (curriculum_mode != "train").
-        if args.val_every > 0 and args.curriculum_mode == "train":
-            val_env_instance = env_fn(
-                curriculum_path=curriculum_path,
-                curriculum_mode="eval",
-                seed=args.seed,
-                render_resolution=encoder_spec.env_render_resolution,
-            )
-        return env_instance, val_env_instance, 4
+        return env_instance, 4
 
-    return env_fn(seed=args.seed), None, 17
+    return env_fn(seed=args.seed), 17
 
 
 def _agent_overrides_from_args(args: Any, encoder_spec: Any, latent_presets: dict[str, dict]):
@@ -160,12 +150,6 @@ def _make_trainer_config(
         wandb_name=wandb_name,
         wandb_tags=wandb_tags,
         wandb_id=args.wandb_id,
-        video_log_every=args.video_log_every,
-        video_log_episodes=args.video_log_episodes,
-        val_every=args.val_every,
-        val_episodes=args.val_episodes,
-        val_video_episodes=args.val_video_episodes,
-        val_max_episode_steps=args.val_max_episode_steps,
         resume_from=args.resume_from,
         overfit_one_batch=args.overfit_one_batch,
         overfit_steps=args.overfit_steps,
@@ -181,10 +165,8 @@ def _make_trainer_config(
 def _make_trainer(
     *,
     env: str,
-    enc: Any,
     agent: Any,
     env_instance: Any,
-    val_env_instance: Any | None,
     agent_config: Any,
     trainer_config: Any,
     adapter: Any,
@@ -201,18 +183,6 @@ def _make_trainer(
         )
 
     hab = habitat_defaults_fn(env_instance)
-    val_kwargs: dict[str, object] = {}
-    if val_env_instance is not None:
-        # Val-Episode-Loop (3D-36) wiring: own adapter so the train
-        # VGGT video buffer isn't disturbed; own tracker so val
-        # rolling means stay independent of train rollouts.
-        val_adapter = enc.make_adapter()
-        val_hab = habitat_defaults_fn(val_env_instance, track_collision_rate=True)
-        val_kwargs = {
-            "val_env": val_env_instance,
-            "val_obs_adapter": val_adapter,
-            "val_episode_metrics_fn": val_hab["episode_metrics_fn"],
-        }
     return trainer_cls(
         agent=agent,
         env=env_instance,
@@ -220,7 +190,6 @@ def _make_trainer(
         trainer_config=trainer_config,
         obs_adapter=adapter,
         episode_metrics_fn=hab["episode_metrics_fn"],
-        **val_kwargs,
     )
 
 
@@ -255,11 +224,11 @@ def train(
     curriculum_path = _resolve_curriculum_inputs(
         env=env, args=args, curriculum=curriculum, env_registry=env_registry,
     )
-    enc, adapter, encoder_spec = _make_encoder_bundle(encoder, args, encoder_registry)
+    _enc, adapter, encoder_spec = _make_encoder_bundle(encoder, args, encoder_registry)
     eff_output_dir, eff_wandb_name, eff_wandb_tags = _effective_run_metadata(
         args=args, output_dir=output_dir, wandb_name=wandb_name, wandb_tags=wandb_tags,
     )
-    env_instance, val_env_instance, num_actions = _make_env_instances(
+    env_instance, num_actions = _make_env_instances(
         env=env,
         args=args,
         curriculum_path=curriculum_path,
@@ -289,10 +258,8 @@ def train(
     )
     trainer = _make_trainer(
         env=env,
-        enc=enc,
         agent=agent,
         env_instance=env_instance,
-        val_env_instance=val_env_instance,
         agent_config=agent_config,
         trainer_config=trainer_config,
         adapter=adapter,

--- a/src/r2dreamer/trainer.py
+++ b/src/r2dreamer/trainer.py
@@ -21,7 +21,6 @@ import jax.numpy as jnp
 import numpy as np
 
 from src.buffer.replay_buffer import BufferConfig, ReplayBuffer
-from src.shared.video_utils import compose_frame, log_episode_video, render_topdown_frame
 from src.r2dreamer.adapters import ObsAdapter  # noqa: F401 — re-exported for callers
 from src.r2dreamer.manifest import write_manifest_end, write_manifest_start
 
@@ -118,16 +117,6 @@ class TrainerConfig:
     wandb_tags: list[str] = field(default_factory=lambda: ["r2dreamer"])
     # Resume an existing W&B run (e.g. "87u0l6dy"). Requires the run to exist.
     wandb_id: str | None = None
-    video_log_every: int = 25_000
-    video_log_episodes: int = 1
-
-    # Deterministic Val-Episode-Loop. val_every=0 disables. Requires a
-    # val_env to be passed to Trainer.
-    val_every: int = 50_000
-    val_episodes: int = 50
-    val_video_episodes: int = 1
-    val_max_episode_steps: int = 500
-
     # Resume from checkpoint (.pkl produced by save_checkpoint). When set,
     # restores agent.{params, opt_state, slow_critic_params, ema_state} and
     # offsets the train loop to start at the checkpoint's step.
@@ -157,7 +146,7 @@ def habitat_defaults(env: Any, *, track_collision_rate: bool = False) -> dict[st
 
     Returns dict with keys "obs_adapter" and "episode_metrics_fn".
 
-    Pass track_collision_rate=True for the val-loop tracker; train rollouts
+    Pass track_collision_rate=True for standalone evaluation trackers; train rollouts
     leave it False so the dashboard isn't doubly-noisy.
     """
     from src.shared.wandb_utils import EpisodeTracker
@@ -228,9 +217,6 @@ class Trainer:
         trainer_config: TrainerConfig,
         obs_adapter: ObsAdapter | None = None,
         episode_metrics_fn: EpisodeMetricsFn | None = None,
-        val_env: Env | None = None,
-        val_obs_adapter: ObsAdapter | None = None,
-        val_episode_metrics_fn: EpisodeMetricsFn | None = None,
     ) -> None:
         self.agent = agent
         self.env = env
@@ -238,12 +224,6 @@ class Trainer:
         self.tcfg = trainer_config
         self.obs_adapter = obs_adapter or ObsAdapter()
         self.episode_metrics_fn = episode_metrics_fn
-        # Val-Episode-Loop wiring (3D-36). All three must be non-None for the
-        # loop to run; the launcher constructs them together when val is on.
-        self.val_env = val_env
-        self.val_obs_adapter = val_obs_adapter
-        self.val_episode_metrics_fn = val_episode_metrics_fn
-
         # Build buffer from adapter settings
         self.buffer = ReplayBuffer(BufferConfig(
             capacity=agent_config.buffer_capacity,
@@ -344,8 +324,7 @@ class Trainer:
                 sys.stderr.flush()
                 os._exit(0)
             self.env.close()
-            if self.val_env is not None:
-                self.val_env.close()
+
 
     # ------------------------------------------------------------------
     # Prefill
@@ -392,13 +371,6 @@ class Trainer:
     def _zero_episode_counters(self) -> tuple[float, int, np.ndarray]:
         return 0.0, 0, np.zeros(self.acfg.num_actions, dtype=int)
 
-    def _start_train_video_if_due(
-        self, step: int, next_video_step: int, obs: dict,
-    ) -> dict[str, Any] | None:
-        if self._should_record_video(step, next_video_step):
-            return self._start_video_recording(self.env, obs)
-        return None
-
     def _record_train_transition(
         self,
         *,
@@ -422,8 +394,6 @@ class Trainer:
         step: int,
         writer: Any,
         f: Any,
-        video_recording: dict[str, Any] | None,
-        video_next_step: int,
     ) -> tuple[
         dict,
         np.ndarray | dict[str, np.ndarray],
@@ -431,29 +401,16 @@ class Trainer:
         float,
         int,
         np.ndarray,
-        dict[str, Any] | None,
-        int,
     ]:
         self._on_episode_end(
             last_obs, episode_reward, episode_steps, action_counts, step, writer, f,
         )
-        if video_recording is not None:
-            log_episode_video(
-                self._wandb,
-                "train/episode_video",
-                video_recording["frames"],
-                step,
-            )
-            video_recording = None
-            video_next_step = step + max(1, self.tcfg.video_log_every)
 
         episode_reward, episode_steps, action_counts = self._zero_episode_counters()
         obs, buffer_obs, agent_obs = self._reset_train_episode()
-        if self._should_record_video(step + 1, video_next_step):
-            video_recording = self._start_video_recording(self.env, obs)
         return (
             obs, buffer_obs, agent_obs, episode_reward, episode_steps,
-            action_counts, video_recording, video_next_step,
+            action_counts,
         )
 
     def _train_loop(self, rng_key: jnp.ndarray, writer: Any, f: Any) -> jnp.ndarray:
@@ -461,16 +418,12 @@ class Trainer:
 
         start_step = self._resume_step
         print(f"Training from step {start_step} to {tcfg.total_steps}...")
-        obs, buffer_obs, agent_obs = self._reset_train_episode()
+        _obs, buffer_obs, agent_obs = self._reset_train_episode()
         episode_reward, episode_steps, action_counts = self._zero_episode_counters()
         self._t0 = time.time()
         batch_steps = acfg.batch_size * acfg.seq_len
         train_credit = 0.0
         metrics: dict[str, Any] = {}
-        video_next_step = start_step
-        video_recording = self._start_train_video_if_due(
-            start_step, video_next_step, obs,
-        )
 
         for step in range(start_step, tcfg.total_steps):
             rng_key, act_key = jax.random.split(rng_key)
@@ -484,13 +437,11 @@ class Trainer:
             action_counts[action] += 1
             episode_reward += next_obs["reward"]
             episode_steps += 1
-            if video_recording is not None:
-                self._append_video_frame(self.env, video_recording, next_obs)
 
             if next_obs["done"]:
                 (
-                    obs, buffer_obs, agent_obs, episode_reward, episode_steps,
-                    action_counts, video_recording, video_next_step,
+                    _obs, buffer_obs, agent_obs, episode_reward, episode_steps,
+                    action_counts,
                 ) = self._finish_train_episode(
                     last_obs=next_obs,
                     episode_reward=episode_reward,
@@ -499,11 +450,9 @@ class Trainer:
                     step=step,
                     writer=writer,
                     f=f,
-                    video_recording=video_recording,
-                    video_next_step=video_next_step,
                 )
             else:
-                obs = next_obs
+                _obs = next_obs
                 buffer_obs = next_buffer_obs
                 agent_obs = next_agent_obs
 
@@ -522,59 +471,11 @@ class Trainer:
                     if getattr(acfg, "decoder", False):
                         self._maybe_log_recon(batch, step)
 
-            # --- Val-Episode-Loop (3D-36): deterministic held-out rollouts ---
-            if (self.val_env is not None
-                    and tcfg.val_every > 0
-                    and (step + 1) % tcfg.val_every == 0):
-                rng_key, val_key = jax.random.split(rng_key)
-                self._run_val_loop(val_key, step, writer, f)
-
             # --- Checkpoint ---
             if (step + 1) % tcfg.checkpoint_every == 0:
                 save_checkpoint(self.agent, step + 1, tcfg.output_dir)
 
         return rng_key
-
-    def _should_record_video(self, step: int, next_video_step: int) -> bool:
-        return (
-            self._wandb is not None
-            and self.tcfg.video_log_every > 0
-            and self.tcfg.video_log_episodes > 0
-            and step >= next_video_step
-            and hasattr(self.env, "_env")
-        )
-
-    def _goal_positions(self, env: Env) -> list[list[float]]:
-        positions = []
-        for goal in env._env.current_episode.goals:
-            if goal.view_points:
-                pos = goal.view_points[0].agent_state.position
-            else:
-                pos = goal.position
-            positions.append(pos.tolist() if hasattr(pos, "tolist") else list(pos))
-        return positions
-
-    def _agent_position(self, env: Env) -> list[float]:
-        pos = env._env.sim.get_agent_state().position
-        return pos.tolist() if hasattr(pos, "tolist") else list(pos)
-
-    def _start_video_recording(self, env: Env, obs: dict) -> dict[str, Any]:
-        recording = {
-            "trajectory": [self._agent_position(env)],
-            "goals": self._goal_positions(env),
-            "frames": [],
-        }
-        self._append_video_frame(env, recording, obs)
-        return recording
-
-    def _append_video_frame(self, env: Env, recording: dict[str, Any], obs: dict) -> None:
-        if "image" not in obs:
-            return
-        if recording["frames"]:
-            recording["trajectory"].append(self._agent_position(env))
-        topdown = render_topdown_frame(
-            env, recording["trajectory"], recording["goals"])
-        recording["frames"].append(compose_frame(obs["image"], topdown))
 
     # ------------------------------------------------------------------
     # Overfit-one-batch diagnostic loop (Karpathy step 3)
@@ -719,121 +620,3 @@ class Trainer:
             combo = np.clip(combo * 255.0, 0, 255).astype(np.uint8)
             images.append(self._wandb.Image(combo, caption=f"input | recon ({i})"))
         self._wandb.log({"decoder/reconstructions": images}, step=step)
-
-    def _run_single_val_episode(
-        self,
-        *,
-        rng_key: jnp.ndarray,
-        record_video: bool,
-        step: int,
-    ) -> tuple[dict[str, Any], jnp.ndarray]:
-        val_adapter = self.val_obs_adapter
-        obs = self.val_env.reset()
-        if val_adapter.on_episode_reset:
-            val_adapter.on_episode_reset()
-        _, agent_obs = val_adapter.transform(obs)
-
-        episode_reward = 0.0
-        episode_steps = 0
-        action_counts = np.zeros(self.acfg.num_actions, dtype=int)
-
-        recording = None
-        if record_video:
-            recording = self._start_video_recording(self.val_env, obs)
-
-        for _ in range(self.tcfg.val_max_episode_steps):
-            rng_key, act_key = jax.random.split(rng_key)
-            action = self.agent.act(agent_obs, act_key, training=False)
-            next_obs = self.val_env.step(action)
-            _, next_agent_obs = val_adapter.transform(next_obs)
-
-            action_counts[action] += 1
-            episode_reward += next_obs["reward"]
-            episode_steps += 1
-            if recording is not None:
-                self._append_video_frame(self.val_env, recording, next_obs)
-
-            if next_obs["done"]:
-                obs = next_obs
-                break
-            obs = next_obs
-            agent_obs = next_agent_obs
-
-        val_metrics = self.val_episode_metrics_fn(
-            self.val_env, obs, episode_reward, episode_steps, action_counts,
-        )
-        if recording is not None:
-            log_episode_video(
-                self._wandb, "val/episode_video", recording["frames"], step,
-            )
-        return val_metrics, rng_key
-
-    def _prefix_val_metrics(self, metrics: dict[str, Any]) -> dict[str, Any]:
-        return {
-            f"val/{k}" if not k.startswith("val/") else k: v
-            for k, v in metrics.items()
-        }
-
-    def _log_val_metrics(
-        self, val_logged: dict[str, Any], step: int, writer: Any, f: Any,
-    ) -> None:
-        for k, v in val_logged.items():
-            writer.writerow([step, k, v])
-        f.flush()
-        if self._wandb is not None:
-            self._wandb.log(val_logged, step=step)
-
-    def _print_val_summary(
-        self, val_logged: dict[str, Any], step: int, elapsed: float,
-    ) -> None:
-        sr = val_logged.get("val/metrics/sr", 0.0)
-        spl = val_logged.get("val/metrics/spl", 0.0)
-        softspl = val_logged.get("val/metrics/softspl", 0.0)
-        dtg = val_logged.get("val/metrics/dtg", 0.0)
-        sr_str = f"{sr:.3f}" if isinstance(sr, float) else str(sr)
-        spl_str = f"{spl:.3f}" if isinstance(spl, float) else str(spl)
-        soft_str = f"{softspl:.3f}" if isinstance(softspl, float) else str(softspl)
-        dtg_str = f"{dtg:.3f}" if isinstance(dtg, float) else str(dtg)
-        print(
-            f"[step {step:>8d}] VAL-LOOP "
-            f"sr={sr_str} spl={spl_str} softspl={soft_str} dtg={dtg_str}m "
-            f"({self.tcfg.val_episodes} eps in {elapsed:.1f}s)"
-        )
-
-    def _run_val_loop(
-        self, rng_key: jnp.ndarray, step: int, writer: Any, f: Any,
-    ) -> None:
-        """Deterministic Val-Episode-Loop (3D-36) + video recording (3D-41).
-
-        Runs `val_episodes` greedy rollouts in the pinned eval env and logs
-        rolling val/* metrics. The first val_video_episodes are captured
-        as W&B videos (deterministic playback — same scene across runs
-        because the eval episode order is pinned by the curriculum JSON).
-        """
-        tcfg = self.tcfg
-        if (self.val_env is None or self.val_obs_adapter is None
-                or self.val_episode_metrics_fn is None):
-            return
-
-        last_val_metrics: dict[str, Any] = {}
-        videos_recorded = 0
-        val_t0 = time.time()
-
-        for ep_idx in range(tcfg.val_episodes):
-            record_video = (
-                videos_recorded < tcfg.val_video_episodes
-                and self._wandb is not None
-            )
-            last_val_metrics, rng_key = self._run_single_val_episode(
-                rng_key=rng_key, record_video=record_video, step=step,
-            )
-            if record_video:
-                videos_recorded += 1
-
-        # Prefix the final episode's tracker snapshot with `val/`. The
-        # rolling-mean fields already reflect the whole val loop (since the
-        # tracker is shared across episodes within this run).
-        val_logged = self._prefix_val_metrics(last_val_metrics)
-        self._log_val_metrics(val_logged, step, writer, f)
-        elapsed = time.time() - val_t0
-        self._print_val_summary(val_logged, step, elapsed)

--- a/tests/r2dreamer/launch/test_parser.py
+++ b/tests/r2dreamer/launch/test_parser.py
@@ -2,6 +2,8 @@
 
 from types import SimpleNamespace
 
+import pytest
+
 from src.r2dreamer.launch.parser import _build_parser_train
 from src.r2dreamer.launch.train import _agent_overrides_from_args
 
@@ -39,3 +41,27 @@ def test_buffer_capacity_override_wins_over_encoder_default():
     overrides = _agent_overrides_from_args(args, encoder_spec, latent_presets={})
 
     assert overrides["buffer_capacity"] == 500_000
+
+
+def test_train_parser_does_not_expose_in_run_val_or_video_flags():
+    parser = _build_parser_train()
+    args = _build_parser_train().parse_args([])
+    help_text = parser.format_help()
+
+    assert not hasattr(args, "val_every")
+    assert not hasattr(args, "val_episodes")
+    assert not hasattr(args, "val_video_episodes")
+    assert not hasattr(args, "val_max_episode_steps")
+    assert not hasattr(args, "video_log_every")
+    assert not hasattr(args, "video_log_episodes")
+    assert "--val_every" not in help_text
+    assert "--video_log_every" not in help_text
+
+
+def test_train_parser_rejects_in_run_val_and_video_flags():
+    parser = _build_parser_train()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--val_every", "50000"])
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--video_log_every", "25000"])

--- a/tests/r2dreamer/test_trainer.py
+++ b/tests/r2dreamer/test_trainer.py
@@ -54,6 +54,17 @@ class _MappingObsAdapter(ObsAdapter):
         }, obs_dict
 
 
+def test_trainer_config_has_no_in_run_val_or_video_controls():
+    tcfg = TrainerConfig()
+
+    assert not hasattr(tcfg, "val_every")
+    assert not hasattr(tcfg, "val_episodes")
+    assert not hasattr(tcfg, "val_video_episodes")
+    assert not hasattr(tcfg, "val_max_episode_steps")
+    assert not hasattr(tcfg, "video_log_every")
+    assert not hasattr(tcfg, "video_log_episodes")
+
+
 class TestConvertBatch:
     """convert_batch turns replay buffer output into agent-ready batches."""
 

--- a/tests/slurm/test_launch.py
+++ b/tests/slurm/test_launch.py
@@ -83,12 +83,10 @@ def test_l1_vggt_dry_run_matches_legacy_sbatch() -> None:
 
     assert result.returncode == 0, result.stderr
     expected = (ROOT / LEGACY_SBATCH / "train_curriculum_l1_vggt.sbatch").read_text()
-    # _base / l1_vggt have since gained three intentional changes the frozen
+    # _base / l1_vggt have since gained two intentional changes the frozen
     # legacy script predates: (1) the GL-teardown hard-exit env var (so every
     # habitat variant exits 0 on completion), (2) multi-partition auto-select
-    # (gpu_h100_il,gpu_h100), and (3) the scalars-only flags video_log_every=0 /
-    # val_every=0 (videos + eval regenerated from checkpoints, not during
-    # training). Normalise all three back out before the byte-equality check so
+    # (gpu_h100_il,gpu_h100). Normalise both back out before the byte-equality check so
     # the rest of the contract still holds.
     rendered = result.stdout.replace('export R2DREAMER_HARD_EXIT_ON_FINISH="1"\n\n', "", 1)
     # The entrypoint migrated to the single run.py dispatcher (run id positional);
@@ -100,13 +98,6 @@ def test_l1_vggt_dry_run_matches_legacy_sbatch() -> None:
     )
     rendered = rendered.replace(
         "#SBATCH --partition=gpu_h100_il,gpu_h100", "#SBATCH --partition=gpu_h100", 1
-    )
-    rendered = rendered.replace(
-        "    --render_resolution 518 \\\n"
-        "    --video_log_every 0 \\\n"
-        "    --val_every 0",
-        "    --render_resolution 518",
-        1,
     )
     assert rendered == expected
 
@@ -195,12 +186,10 @@ def test_curriculum_variants_match_legacy_args(variant: str, run_id: str, legacy
     assert r_run_id == run_id
 
     # Intentional divergence from the frozen legacy sbatch: the VGGT arm is now
-    # the flatten/WP-CP readout (`mlp_layers=0`) and scalars-only — video +
-    # in-run eval disabled (video_log_every=0 / val_every=0, inherited from
-    # l1_vggt), and the stale replay-buffer val flags (val_data /
-    # val_loss_every) dropped since the parser rejects them. Videos + eval
-    # metrics are regenerated from checkpoints. Normalise those out, then assert
-    # the rest of the training command still matches.
+    # the flatten/WP-CP readout (`mlp_layers=0`). The stale replay-buffer val
+    # flags (val_data / val_loss_every) are also absent because the parser
+    # rejects in-run validation flags. Normalise those out, then assert the rest
+    # of the training command still matches.
     assert r_flags["--mlp_layers"] == "0"
     assert "--mlp_layers" not in l_flags
     assert r_flags["--wandb_name"] == l_flags["--wandb_name"].replace(
@@ -208,8 +197,8 @@ def test_curriculum_variants_match_legacy_args(variant: str, run_id: str, legacy
         "-flatten-${SLURM_JOB_ID}",
     )
     assert r_flags["--wandb_tags"] == f"{l_flags['--wandb_tags']},flatten,wp-cp"
-    assert r_flags["--video_log_every"] == "0"
-    assert r_flags["--val_every"] == "0"
+    assert "--video_log_every" not in r_flags
+    assert "--val_every" not in r_flags
     assert "--val_data" not in r_flags
     assert "--val_loss_every" not in r_flags
 
@@ -217,8 +206,6 @@ def test_curriculum_variants_match_legacy_args(variant: str, run_id: str, legacy
         "--mlp_layers",
         "--wandb_name",
         "--wandb_tags",
-        "--video_log_every",
-        "--val_every",
         "--val_data",
         "--val_loss_every",
     }
@@ -234,9 +221,9 @@ def test_extends_chain_is_recursive() -> None:
     # Inherited from _base via l1_vggt:
     assert config.sbatch.gres == "gpu:1"
     assert config.args["render_resolution"] == 518
-    # Scalars-only flags inherited from l1_vggt (videos/eval regenerated offline):
-    assert config.args["video_log_every"] == 0
-    assert config.args["val_every"] == 0
+    # In-run val/video train flags are not part of the launch config anymore:
+    assert "video_log_every" not in config.args
+    assert "val_every" not in config.args
     # script is inherited from _base (the shared run.py dispatcher); the run is
     # selected by run_id, which l2_vggt sets as its own override:
     assert config.script.endswith("run.py")
@@ -339,8 +326,8 @@ def test_l1_replay_capacity_ablation_configs(
     assert flags["--buffer_capacity"] == capacity
     assert tag in flags["--wandb_tags"]
     assert "3d-63" in flags["--wandb_tags"]
-    assert flags["--video_log_every"] == "0"
-    assert flags["--val_every"] == "0"
+    assert "--video_log_every" not in flags
+    assert "--val_every" not in flags
 
 
 def test_l1_aggregator_capacity_ablation_keeps_encoder_batch_defaults() -> None:


### PR DESCRIPTION
## Summary
- Remove the in-run validation loop and train-time episode-video recording from `Trainer`.
- Remove train CLI/config knobs that could re-enable them (`--val_*`, `--video_log_*`) and clean SLURM configs/scripts accordingly.
- Keep offline evaluation/video generation intact via `src.r2dreamer.launch.evaluate`.

## Test Plan
- `uv run ruff check src/r2dreamer/launch/parser.py src/r2dreamer/launch/train.py src/r2dreamer/trainer.py tests/r2dreamer/launch/test_parser.py tests/r2dreamer/test_trainer.py tests/slurm/test_launch.py`
- `bash -n scripts/verify_3d_35_metrics.sbatch`
- `uv run pytest tests/r2dreamer/launch/test_parser.py tests/r2dreamer/test_trainer.py tests/slurm/test_launch.py -q` — 42 passed

## Review
- Independent reviewer passed after re-review; no security concerns or logic errors found.
