### PR TITLE
3D-85: Make observation preparation the public launcher language

### DIFF
--- a/scripts/debug_viz/evaluate_debug.py
+++ b/scripts/debug_viz/evaluate_debug.py
@@ -36,7 +36,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from src.r2dreamer.launch.registries import encoder_registry
+from src.r2dreamer.launch.registries import observation_preparation_registry
 from src.r2dreamer.adapters import VGGT_FEATURE_DIM
 from src.r2dreamer.adapters.vggt_adapter import flatten_world_points_camera_pose
 from src.r2dreamer.agent import R2DreamerAgent
@@ -116,7 +116,7 @@ def main(argv: list[str] | None = None) -> dict:
     )
 
     # --- encoder + adapter (VGGT) ---
-    encoder_cls = encoder_registry["vggt"]
+    encoder_cls = observation_preparation_registry["vggt"]
     enc = encoder_cls(resolution=render_resolution)
     adapter = enc.make_adapter()
     extractor = adapter._extractor  # un-flattened access

--- a/scripts/r2dreamer/AGENTS.md
+++ b/scripts/r2dreamer/AGENTS.md
@@ -16,9 +16,10 @@ heavy logic lives in `src/r2dreamer/`.
 ### Live training launcher (single dispatcher → `src.r2dreamer.launch.train`)
 `run.py <run-id> [train flags...]` is the one entrypoint for every live training
 run (the per-run `run_jax_*.py` shims were folded into it). The per-run `(env,
-encoder, curriculum, output_dir, wandb_name, wandb_tags)` lives in the
+Observation Preparation, curriculum, output_dir, wandb_name, wandb_tags)` lives in the
 `RUN_CONFIGS` table in [`_run_configs.py`](_run_configs.py) (single source of
-truth; `launch_run` validates the encoder against `encoder_registry` at launch).
+truth; `launch_run` validates Observation Preparation against
+`observation_preparation_registry` at launch).
 Run ids: `habitat-l{1,2,3,4}-cnn`, `habitat-l{1,2,3,4}-vggt`,
 `habitat-l1-{hybrid,vggt-aggregator-mlp,vggt-wp-cp-64,vggt-wp-dense}`,
 `crafter-cnn`. **To add a run:** add one `RUN_CONFIGS` entry + a

--- a/scripts/r2dreamer/_run_configs.py
+++ b/scripts/r2dreamer/_run_configs.py
@@ -2,16 +2,16 @@
 
 DRY: the per-run ``run_jax_*.py`` shims used to each repeat the same ~5-line
 ``sys.path`` bootstrap plus a hardcoded ``train(...)`` call differing only in
-env/encoder/curriculum/output_dir/wandb_name/wandb_tags. That metadata now lives
+env/Observation Preparation/curriculum/output_dir/wandb_name/wandb_tags. That metadata now lives
 here as one ``RUN_CONFIGS`` table, launched by the single ``run.py`` dispatcher::
 
     uv run python scripts/r2dreamer/run.py <run-id> [train flags...]
 
 Slurm configs select a run via the ``run_id:`` field (rendered as that leading
 positional by ``scripts/slurm/launch.py``); ad-hoc / legacy ``*.sbatch`` files
-call ``run.py <run-id>`` directly. ``launch_run`` validates the encoder against
-the canonical ``encoder_registry`` at launch, so a typo fails fast instead of at
-train-time.
+call ``run.py <run-id>`` directly. ``launch_run`` validates the Observation
+Preparation mode against the canonical registry at launch, so a typo fails fast
+instead of at train-time.
 """
 
 from __future__ import annotations
@@ -31,7 +31,7 @@ RUN_CONFIGS: dict[str, dict[str, Any]] = {
     # ── CNN curriculum baselines (L1–L4) ────────────────────────────────────
     "habitat-l1-cnn": dict(
         env="habitat",
-        encoder="cnn",
+        observation_preparation="cnn",
         curriculum="L1",
         output_dir="output/runs/r2dreamer-curriculum-l1",
         wandb_name="r2d-L1-1house-chair",
@@ -39,7 +39,7 @@ RUN_CONFIGS: dict[str, dict[str, Any]] = {
     ),
     "habitat-l2-cnn": dict(
         env="habitat",
-        encoder="cnn",
+        observation_preparation="cnn",
         curriculum="L2",
         output_dir="output/runs/r2dreamer-curriculum-l2",
         wandb_name="r2d-L2-buffix",
@@ -47,7 +47,7 @@ RUN_CONFIGS: dict[str, dict[str, Any]] = {
     ),
     "habitat-l3-cnn": dict(
         env="habitat",
-        encoder="cnn",
+        observation_preparation="cnn",
         curriculum="L3",
         output_dir="output/runs/r2dreamer-curriculum-l3",
         wandb_name="r2d-L3-buffix",
@@ -55,16 +55,16 @@ RUN_CONFIGS: dict[str, dict[str, Any]] = {
     ),
     "habitat-l4-cnn": dict(
         env="habitat",
-        encoder="cnn",
+        observation_preparation="cnn",
         curriculum="L4",
         output_dir="output/runs/r2dreamer-curriculum-l4",
         wandb_name="r2d-L4-buffix",
         wandb_tags=["curriculum", "level4", "10houses", "6goals", "buffer-fix", "rerun"],
     ),
-    # ── VGGT 3D-encoder curriculum (L1–L4) ──────────────────────────────────
+    # ── VGGT Observation Preparation curriculum (L1–L4) ─────────────────────
     "habitat-l1-vggt": dict(
         env="habitat",
-        encoder="vggt",
+        observation_preparation="vggt",
         curriculum="L1",
         output_dir="output/runs/r2dreamer-curriculum-l1-vggt",
         wandb_name="vggt_jax",
@@ -75,7 +75,7 @@ RUN_CONFIGS: dict[str, dict[str, Any]] = {
     ),
     "habitat-l2-vggt": dict(
         env="habitat",
-        encoder="vggt",
+        observation_preparation="vggt",
         curriculum="L2",
         output_dir="output/runs/r2dreamer-curriculum-l2-vggt",
         wandb_name="r2d-L2-vggt",
@@ -83,7 +83,7 @@ RUN_CONFIGS: dict[str, dict[str, Any]] = {
     ),
     "habitat-l3-vggt": dict(
         env="habitat",
-        encoder="vggt",
+        observation_preparation="vggt",
         curriculum="L3",
         output_dir="output/runs/r2dreamer-curriculum-l3-vggt",
         wandb_name="r2d-L3-vggt",
@@ -91,17 +91,17 @@ RUN_CONFIGS: dict[str, dict[str, Any]] = {
     ),
     "habitat-l4-vggt": dict(
         env="habitat",
-        encoder="vggt",
+        observation_preparation="vggt",
         curriculum="L4",
         output_dir="output/runs/r2dreamer-curriculum-l4-vggt",
         wandb_name="r2d-L4-vggt",
         wandb_tags=["curriculum", "level4", "10houses", "6goals", "vggt", "jax", "3d-encoder"],
     ),
-    # ── VGGT encoder variants / ablations ───────────────────────────────────
-    # L1 Hybrid — CNN(RGB) + gated MLP(WP/CP) hybrid encoder (3D-50/51/52).
+    # ── VGGT Observation Preparation variants / ablations ───────────────────
+    # L1 Hybrid — CNN(RGB) + gated MLP(WP/CP) hybrid Encoder Module (3D-50/51/52).
     "habitat-l1-hybrid": dict(
         env="habitat",
-        encoder="hybrid",
+        observation_preparation="hybrid",
         curriculum="L1",
         output_dir="output/runs/r2dreamer-curriculum-l1-hybrid",
         wandb_name="hybrid-cnn-vggt",
@@ -113,7 +113,7 @@ RUN_CONFIGS: dict[str, dict[str, Any]] = {
     # L1 VGGT — WP+CP MLP at a 64x64 world-point grid (3D-52/3D-53).
     "habitat-l1-vggt-wp-cp-64": dict(
         env="habitat",
-        encoder="vggt_wp_cp_64",
+        observation_preparation="vggt_wp_cp_64",
         curriculum="L1",
         output_dir="output/runs/r2dreamer-curriculum-l1-vggt-wp-cp-64",
         wandb_name="wp-cp-mlp-64",
@@ -125,7 +125,7 @@ RUN_CONFIGS: dict[str, dict[str, Any]] = {
     # L1 VGGT — full-resolution 518x518x3 world-point CNN encoder (3D-53).
     "habitat-l1-vggt-wp-dense": dict(
         env="habitat",
-        encoder="vggt_wp_dense_cnn",
+        observation_preparation="vggt_wp_dense_cnn",
         curriculum="L1",
         output_dir="output/runs/r2dreamer-curriculum-l1-vggt-wp-dense",
         wandb_name="vggt_wp_dense_cnn",
@@ -137,7 +137,7 @@ RUN_CONFIGS: dict[str, dict[str, Any]] = {
     # L1 VGGT aggregator-MLP encoder (variant-1).
     "habitat-l1-vggt-aggregator-mlp": dict(
         env="habitat",
-        encoder="vggt_aggregator_mlp",
+        observation_preparation="vggt_aggregator_mlp",
         curriculum="L1",
         output_dir="output/runs/r2dreamer-curriculum-l1-vggt-aggregator-mlp",
         wandb_name="variant-1-aggregator-mlp",
@@ -149,7 +149,7 @@ RUN_CONFIGS: dict[str, dict[str, Any]] = {
     # ── Crafter (non-curriculum sanity env) ─────────────────────────────────
     "crafter-cnn": dict(
         env="crafter",
-        encoder="cnn",
+        observation_preparation="cnn",
         curriculum=None,
         output_dir="output/runs/r2dreamer-crafter",
         wandb_name="r2d-crafter",
@@ -170,13 +170,14 @@ def launch_run(name: str, *, argv: list[str] | None = None):
         raise KeyError(f"Unknown run {name!r}. Available: {sorted(RUN_CONFIGS)}")
     cfg = RUN_CONFIGS[name]
 
-    # Fail fast on an encoder typo, against the canonical registry.
-    from src.r2dreamer.launch.registries import encoder_registry
+    # Fail fast on an Observation Preparation typo, against the canonical registry.
+    from src.r2dreamer.launch.registries import observation_preparation_registry
 
-    if cfg["encoder"] not in encoder_registry:
+    if cfg["observation_preparation"] not in observation_preparation_registry:
         raise KeyError(
-            f"Run {name!r} uses unknown encoder {cfg['encoder']!r}. "
-            f"Available: {sorted(encoder_registry)}"
+            f"Run {name!r} uses unknown observation_preparation "
+            f"{cfg['observation_preparation']!r}. "
+            f"Available: {sorted(observation_preparation_registry)}"
         )
 
     from src.main import train

--- a/scripts/r2dreamer/eval_habitat.py
+++ b/scripts/r2dreamer/eval_habitat.py
@@ -7,6 +7,6 @@ from src.main import evaluate
 
 if __name__ == "__main__":
     evaluate(
-        env="habitat", encoder="cnn", curriculum=None,
+        env="habitat", observation_preparation="cnn", curriculum=None,
         output_dir="output/runs/r2dreamer-eval",
     )

--- a/scripts/r2dreamer/eval_habitat_vggt.py
+++ b/scripts/r2dreamer/eval_habitat_vggt.py
@@ -7,6 +7,6 @@ from src.main import evaluate
 
 if __name__ == "__main__":
     evaluate(
-        env="habitat", encoder="vggt", curriculum=None,
+        env="habitat", observation_preparation="vggt", curriculum=None,
         output_dir="output/runs/r2dreamer-eval-vggt",
     )

--- a/scripts/r2dreamer/profile_training.py
+++ b/scripts/r2dreamer/profile_training.py
@@ -170,7 +170,7 @@ def run_loop(
             compile_mode=compile_mode,
         )
     else:
-        raise ValueError(f"Unknown encoder: {encoder!r}")
+        raise ValueError(f"Unknown Observation Preparation mode: {encoder!r}")
 
     phase_times = init_phase_times()
     reset_count = 0
@@ -398,7 +398,13 @@ def save_json(results_by_encoder: dict[str, RunResult], output_dir: Path) -> Pat
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="R2-Dreamer training-loop profiler")
-    parser.add_argument("--encoder", choices=("cnn", "vggt"), required=True)
+    parser.add_argument(
+        "--observation-preparation",
+        choices=("cnn", "vggt"),
+        required=True,
+        dest="observation_preparation",
+        help="Observation Preparation input mode to profile.",
+    )
     parser.add_argument("--prefill_steps", type=int, default=2000)
     parser.add_argument("--acting_steps", type=int, default=2000)
     parser.add_argument("--output_dir", type=str, default="output/methods/profiling")
@@ -425,7 +431,7 @@ def main() -> None:
     args = parser.parse_args()
 
     result = run_loop(
-        encoder=args.encoder,
+        encoder=args.observation_preparation,
         prefill_steps=args.prefill_steps,
         acting_steps=args.acting_steps,
         seed=args.seed,
@@ -435,9 +441,9 @@ def main() -> None:
         compile_mode=args.compile_mode,
     )
 
-    json_path = save_json({args.encoder: result}, Path(args.output_dir))
+    json_path = save_json({args.observation_preparation: result}, Path(args.output_dir))
     print()
-    print(format_report({args.encoder: result}))
+    print(format_report({args.observation_preparation: result}))
     print()
     print(f"JSON saved to: {json_path}")
 

--- a/scripts/r2dreamer/run.py
+++ b/scripts/r2dreamer/run.py
@@ -6,10 +6,11 @@ Usage::
     uv run python scripts/r2dreamer/run.py <run-id> [train flags...]
 
 The leading positional selects an entry from ``_run_configs.RUN_CONFIGS`` (the
-single source of truth for env/encoder/curriculum/output_dir/wandb_*). Every
-flag after it is forwarded verbatim to ``src.main.train`` and overrides the
-config's defaults, exactly as the old shims did. Slurm configs render this
-positional from their ``run_id:`` field (see ``scripts/slurm/launch.py``).
+single source of truth for env/Observation Preparation/curriculum/output_dir/
+wandb_*). Every flag after it is forwarded verbatim to ``src.main.train`` and
+overrides the config's defaults, exactly as the old shims did. Slurm configs
+render this positional from their ``run_id:`` field (see
+``scripts/slurm/launch.py``).
 """
 import sys
 

--- a/scripts/verify_3d_35_metrics.sbatch
+++ b/scripts/verify_3d_35_metrics.sbatch
@@ -47,7 +47,7 @@ echo ""
 
 uv run python -m src.main train \
     --env habitat \
-    --encoder cnn \
+    --observation-preparation cnn \
     --curriculum L1 \
     --steps 15000 \
     --prefill 2000 \

--- a/src/main.py
+++ b/src/main.py
@@ -7,6 +7,7 @@ import sys
 from typing import Sequence
 
 from src.r2dreamer.launch.evaluate import evaluate
+from src.r2dreamer.launch.parser import OBSERVATION_PREPARATION_CHOICES
 from src.r2dreamer.launch.train import train
 
 
@@ -33,18 +34,22 @@ def _build_parser() -> argparse.ArgumentParser:
     train_parser = subparsers.add_parser("train", help="Train R2Dreamer end to end.")
     train_parser.add_argument("--env", default="habitat", choices=["habitat", "crafter"])
     train_parser.add_argument(
-        "--encoder",
+        "--observation-preparation",
+        dest="observation_preparation",
         default="cnn",
-        choices=["cnn", "vggt", "vggt_aggregator_mlp", "vggt_wp_dense_cnn", "vggt_wp_cp_64", "hybrid"],
+        choices=OBSERVATION_PREPARATION_CHOICES,
+        help="Observation Preparation input mode",
     )
     train_parser.add_argument("--curriculum", default=None)
 
     eval_parser = subparsers.add_parser("evaluate", help="Evaluate a trained agent.")
     eval_parser.add_argument("--env", default="habitat", choices=["habitat"])
     eval_parser.add_argument(
-        "--encoder",
+        "--observation-preparation",
+        dest="observation_preparation",
         default="cnn",
-        choices=["cnn", "vggt", "vggt_aggregator_mlp", "vggt_wp_dense_cnn", "vggt_wp_cp_64", "hybrid"],
+        choices=OBSERVATION_PREPARATION_CHOICES,
+        help="Observation Preparation input mode",
     )
     eval_parser.add_argument("--curriculum", default=None)
     eval_parser.add_argument("--checkpoint", default=None)
@@ -63,14 +68,14 @@ def main(argv: Sequence[str] | None = None) -> object:
     if args.command == "train":
         return train(
             env=args.env,
-            encoder=args.encoder,
+            observation_preparation=args.observation_preparation,
             curriculum=args.curriculum,
             argv=rest,
         )
     if args.command == "evaluate":
         return evaluate(
             env=args.env,
-            encoder=args.encoder,
+            observation_preparation=args.observation_preparation,
             curriculum=args.curriculum,
             checkpoint=args.checkpoint,
             output_dir=args.output_dir,

--- a/src/r2dreamer/AGENTS.md
+++ b/src/r2dreamer/AGENTS.md
@@ -53,11 +53,13 @@ src/r2dreamer/
 ├── encoders/__init__.py launcher-side Encoder/EncoderSpec specs (CNN, VGGT*, Hybrid)
 │
 └── launch/             entrypoints + wiring
-    ├── train.py ........ train() — resolves env/encoder/curriculum, builds Trainer, runs
+    ├── train.py ........ train() — resolves env/Observation Preparation/curriculum,
+    │                     builds Trainer, runs
     ├── evaluate.py ..... evaluate() — load checkpoint, run episodes, log to W&B
     ├── parser.py ....... shared argparse for the launcher shims
-    ├── registries.py ... encoder_registry {cnn, vggt, vggt_aggregator_mlp,
-    │                     vggt_wp_dense_cnn, vggt_wp_cp_64, hybrid}, env_registry {habitat, crafter}
+    ├── registries.py ... observation_preparation_registry {cnn, vggt,
+    │                     vggt_aggregator_mlp, vggt_wp_dense_cnn, vggt_wp_cp_64,
+    │                     hybrid}, env_registry {habitat, crafter}
     ├── curricula.py .... CURRICULA {L1..L4} → data/curriculum/*.json
     ├── habitat_setup.py  make_habitat_env() (HabitatObjectNavEnv factory)
     └── parity/ ......... train_parity.py, batch_utils.py, benchmark.py — JAX↔PyTorch parity
@@ -68,11 +70,11 @@ src/r2dreamer/
 ```python
 # Train (driven by the scripts/r2dreamer/run.py dispatcher via _run_configs.launch_run)
 from src.r2dreamer.launch.train import train
-train(env="habitat", encoder="cnn", curriculum="L1", output_dir=..., wandb_name=...)
+train(env="habitat", observation_preparation="cnn", curriculum="L1", output_dir=..., wandb_name=...)
 
 # Evaluate a checkpoint
 from src.r2dreamer.launch.evaluate import evaluate
-evaluate(checkpoint_path=".../step_xxxxxx.pkl", env="habitat", encoder="cnn")
+evaluate(checkpoint_path=".../step_xxxxxx.pkl", env="habitat", observation_preparation="cnn")
 
 # Direct agent use
 from src.r2dreamer.agent import R2DreamerAgent
@@ -82,9 +84,9 @@ metrics = agent.train_step(batch, rng_key)   # JIT'd
 action  = agent.act(obs_dict, rng_key)
 ```
 
-`encoder` and `env` strings resolve through `launch/registries.py`; `curriculum`
-through `launch/curricula.py`. To add an encoder: implement an `Encoder`/`EncoderSpec`
-in `encoders/__init__.py`, register it in `registries.py`, then add a `RUN_CONFIGS`
+Observation Preparation and `env` strings resolve through `launch/registries.py`;
+`curriculum` through `launch/curricula.py`. To add an Observation Preparation mode:
+implement an `Encoder`/`EncoderSpec` in `encoders/__init__.py`, register it in `registries.py`, then add a `RUN_CONFIGS`
 entry in `scripts/r2dreamer/_run_configs.py` (launched via `run.py <run-id>`) and a
 `test_presets.py` entry.
 

--- a/src/r2dreamer/config.py
+++ b/src/r2dreamer/config.py
@@ -29,7 +29,7 @@ class R2DreamerConfig:
     img_layers: int = 2
 
     # --- Encoder ---
-    encoder_type: str = "cnn"  # canonical set: encoder_registry in src.r2dreamer.launch.registries
+    encoder_type: str = "cnn"  # internal Encoder Module identity; launched via Observation Preparation registry
     encoder_module_cls: Any = None  # Flax nn.Module class; sourced from EncoderSpec.module_cls
     encoder_depth: int = 16
     encoder_kernel: int = 5

--- a/src/r2dreamer/launch/evaluate.py
+++ b/src/r2dreamer/launch/evaluate.py
@@ -68,9 +68,19 @@ def _find_manifest_for_checkpoint(checkpoint: str | Path) -> Path | None:
     return None
 
 
-def _resolve_eval_settings(args, *, encoder: str, checkpoint: str | None, output_dir: str | None):
-    # CLI --encoder overrides shim kwarg if user passed it explicitly.
-    eff_encoder = args.encoder if args.encoder is not None else encoder
+def _resolve_eval_settings(
+    args,
+    *,
+    observation_preparation: str,
+    checkpoint: str | None,
+    output_dir: str | None,
+):
+    # CLI value overrides shim kwarg if user passed it explicitly.
+    eff_observation_preparation = (
+        args.observation_preparation
+        if args.observation_preparation is not None
+        else observation_preparation
+    )
 
     eff_checkpoint = args.checkpoint if args.checkpoint is not None else checkpoint
     if not args.random and eff_checkpoint is None:
@@ -81,7 +91,7 @@ def _resolve_eval_settings(args, *, encoder: str, checkpoint: str | None, output
     eff_output_dir = args.output_dir if args.output_dir is not None else output_dir
     if eff_output_dir is None:
         raise ValueError("output_dir must be set via evaluate(..., output_dir=...) or --output_dir")
-    return eff_encoder, eff_checkpoint, eff_output_dir
+    return eff_observation_preparation, eff_checkpoint, eff_output_dir
 
 
 def _init_eval_wandb(args):
@@ -92,14 +102,17 @@ def _init_eval_wandb(args):
     return wandb
 
 
-def _make_eval_env(*, args, curriculum_path: str | None, eff_encoder: str):
+def _make_eval_env(*, args, curriculum_path: str | None, eff_observation_preparation: str):
     from src.shared.configs import DreamerConfig
     from src.environments.habitat import HabitatObjectNavEnv
 
-    # All VGGT readouts (wp_cp, aggregator, dense-WP CNN) AND the hybrid encoder
-    # need 518x518 frames; the plain CNN baseline uses 64. Everything else is
-    # driven off the EncoderSpec below.
-    needs_hires = eff_encoder.startswith("vggt") or eff_encoder == "hybrid"
+    # All VGGT readouts (wp_cp, aggregator, dense-WP CNN) AND the hybrid
+    # Observation Preparation mode need 518x518 frames; the plain CNN baseline
+    # uses 64. Everything else is driven off the EncoderSpec below.
+    needs_hires = (
+        eff_observation_preparation.startswith("vggt")
+        or eff_observation_preparation == "hybrid"
+    )
     default_resolution = 518 if needs_hires else 64
     render_resolution = (
         args.render_resolution if args.render_resolution is not None else default_resolution
@@ -119,8 +132,13 @@ def _make_eval_env(*, args, curriculum_path: str | None, eff_encoder: str):
     return env_instance, needs_hires, render_resolution
 
 
-def _make_eval_encoder(eff_encoder: str, encoder_registry: dict, needs_hires: bool, render_resolution: int):
-    encoder_cls = encoder_registry[eff_encoder]
+def _make_eval_encoder(
+    eff_observation_preparation: str,
+    observation_preparation_registry: dict,
+    needs_hires: bool,
+    render_resolution: int,
+):
+    encoder_cls = observation_preparation_registry[eff_observation_preparation]
     enc = encoder_cls(resolution=render_resolution) if needs_hires else encoder_cls()
     return enc, enc.make_adapter(), enc.spec()
 
@@ -345,28 +363,34 @@ def _print_eval_summary(results: list[dict], episodes: int) -> None:
 def evaluate(
     *,
     env: str,
-    encoder: str,
+    observation_preparation: str,
     curriculum: str | None = None,
     checkpoint: str | None = None,
     output_dir: str | None = None,
     argv: list[str] | None = None,
 ) -> dict:
-    """Resolve (env, encoder, curriculum) via registries; parse CLI; run eval loop.
+    """Resolve env, Observation Preparation, curriculum; parse CLI; run eval loop.
 
     Kwargs (checkpoint, output_dir) are shim-supplied defaults — CLI flags override.
 
     Returns metrics dict with 'results' and 'meta' keys.
     """
-    from src.r2dreamer.launch.registries import encoder_registry
+    from src.r2dreamer.launch.registries import observation_preparation_registry
 
     parser = _build_parser_eval()
     args = parser.parse_args(argv if argv is not None else sys.argv[1:])
 
-    eff_encoder, eff_checkpoint, eff_output_dir = _resolve_eval_settings(
-        args, encoder=encoder, checkpoint=checkpoint, output_dir=output_dir,
+    eff_observation_preparation, eff_checkpoint, eff_output_dir = _resolve_eval_settings(
+        args,
+        observation_preparation=observation_preparation,
+        checkpoint=checkpoint,
+        output_dir=output_dir,
     )
-    if eff_encoder not in encoder_registry:
-        raise KeyError(f"Unknown encoder {eff_encoder!r}. Available: {list(encoder_registry)}")
+    if eff_observation_preparation not in observation_preparation_registry:
+        raise KeyError(
+            f"Unknown observation_preparation {eff_observation_preparation!r}. "
+            f"Available: {list(observation_preparation_registry)}"
+        )
 
     # --- Resolve curriculum path (shared with train via launch._helpers) ---
     curriculum_path = resolve_curriculum_path(args.curriculum_path, curriculum)
@@ -379,12 +403,17 @@ def evaluate(
     if env not in env_registry:
         raise KeyError(f"Unknown env {env!r}. Available: {list(env_registry)}")
     env_instance, needs_hires, render_resolution = _make_eval_env(
-        args=args, curriculum_path=curriculum_path, eff_encoder=eff_encoder,
+        args=args,
+        curriculum_path=curriculum_path,
+        eff_observation_preparation=eff_observation_preparation,
     )
 
     # --- Build encoder + adapter ---
     enc, adapter, encoder_spec = _make_eval_encoder(
-        eff_encoder, encoder_registry, needs_hires, render_resolution,
+        eff_observation_preparation,
+        observation_preparation_registry,
+        needs_hires,
+        render_resolution,
     )
 
     # --- Build agent ---

--- a/src/r2dreamer/launch/parser.py
+++ b/src/r2dreamer/launch/parser.py
@@ -3,6 +3,16 @@
 import argparse
 
 
+OBSERVATION_PREPARATION_CHOICES = (
+    "cnn",
+    "vggt",
+    "vggt_aggregator_mlp",
+    "vggt_wp_dense_cnn",
+    "vggt_wp_cp_64",
+    "hybrid",
+)
+
+
 def _add_basic_train_args(p: argparse.ArgumentParser) -> None:
     p.add_argument("--steps", type=int, default=2_400_000)
     p.add_argument("--prefill", type=int, default=5000)
@@ -19,13 +29,14 @@ def _add_basic_train_args(p: argparse.ArgumentParser) -> None:
                    help="Override shim curriculum path (escape hatch)")
     p.add_argument("--curriculum_mode", type=str, default="train")
     p.add_argument("--render_resolution", type=int, default=518,
-                   help="Render resolution for VGGT encoder")
+                   help="Render resolution for VGGT Feature Extractor based "
+                        "Observation Preparation modes")
     p.add_argument("--mlp_layers", type=int, default=None,
-                   help="Depth of the VGGT MLP encoders (wp_cp + aggregator): number "
+                   help="Depth of the VGGT MLP Encoder Modules (wp_cp + aggregator): number "
                         "of hidden Dense->RMSNorm->SiLU blocks before the linear readout. "
                         "None keeps the config default (1). The experiment runs pass 3 to "
                         "match R2Dreamer's native encoder.mlp.layers (3D-52). Only valid "
-                        "for VGGT MLP encoders; CNN/dense-WP conv encoders require the "
+                        "for VGGT MLP Encoder Modules; CNN/dense-WP conv Encoder Modules require the "
                         "default value (1).")
 
 
@@ -84,7 +95,7 @@ def _add_loss_override_train_args(p: argparse.ArgumentParser) -> None:
                    help="Override cfg.scale_repval. Set 0 to disable replay value loss.")
     # Protocol D toggle
     p.add_argument("--barlow_grad_to_encoder", action="store_true",
-                   help="Let Barlow Twins gradient reach the encoder (removes the "
+                   help="Let Barlow Twins gradient reach the Encoder Module (removes the "
                         "stop_gradient at agent._loss_fn). Default off matches "
                         "PyTorch reference.")
     # Small-batch knobs for the overfit run
@@ -141,8 +152,10 @@ def _build_parser_eval() -> argparse.ArgumentParser:
     """Build CLI parser for evaluate()."""
     p = argparse.ArgumentParser(add_help=True)
     p.add_argument("--checkpoint", type=str, default=None)
-    p.add_argument("--encoder", type=str, default=None,
-                   choices=["cnn", "vggt", "vggt_aggregator_mlp", "vggt_wp_dense_cnn", "vggt_wp_cp_64", "hybrid"])
+    p.add_argument("--observation-preparation", type=str, default=None,
+                   choices=OBSERVATION_PREPARATION_CHOICES,
+                   dest="observation_preparation",
+                   help="Observation Preparation input mode")
     p.add_argument("--random", action="store_true",
                    help="Use random agent instead of a checkpoint")
     p.add_argument("--episodes", type=int, default=10)
@@ -153,7 +166,8 @@ def _build_parser_eval() -> argparse.ArgumentParser:
     p.add_argument("--curriculum_path", type=str, default=None,
                    help="Override shim curriculum path (escape hatch)")
     p.add_argument("--render_resolution", type=int, default=None,
-                   help="Render resolution (default: 518 for vggt, 64 for cnn)")
+                   help="Render resolution (default: 518 for VGGT Feature Extractor "
+                        "based Observation Preparation modes, 64 for cnn)")
     p.add_argument("--split", type=str, default="val")
     p.add_argument("--save_frames", action="store_true")
     p.add_argument("--semantic", action="store_true")

--- a/src/r2dreamer/launch/registries.py
+++ b/src/r2dreamer/launch/registries.py
@@ -20,7 +20,7 @@ def make_crafter_env(*, seed: int = 0, **kwargs):
     return CrafterEnv(size=(64, 64), seed=seed)
 
 
-encoder_registry: dict[str, type[Encoder]] = {
+observation_preparation_registry: dict[str, type[Encoder]] = {
     "cnn": CNNEncoder,
     "vggt": VGGTEncoder,
     "vggt_aggregator_mlp": VGGTAggregatorMLPEncoder,
@@ -28,6 +28,10 @@ encoder_registry: dict[str, type[Encoder]] = {
     "vggt_wp_cp_64": VGGTWPCP64Encoder,
     "hybrid": HybridEncoder,
 }
+
+# Compatibility for internal callers that still talk to the Dreamer-side encoder
+# module contract. Public launchers should use observation_preparation_registry.
+encoder_registry = observation_preparation_registry
 
 env_registry: dict[str, Callable] = {
     "habitat": make_habitat_env,

--- a/src/r2dreamer/launch/train.py
+++ b/src/r2dreamer/launch/train.py
@@ -29,10 +29,17 @@ def _resolve_curriculum_inputs(
     return curriculum_path
 
 
-def _make_encoder_bundle(encoder: str, args: Any, encoder_registry: dict[str, Any]):
-    if encoder not in encoder_registry:
-        raise KeyError(f"Unknown encoder {encoder!r}. Available: {list(encoder_registry)}")
-    enc = encoder_registry[encoder].from_train_args(args)
+def _make_observation_preparation_bundle(
+    observation_preparation: str,
+    args: Any,
+    observation_preparation_registry: dict[str, Any],
+):
+    if observation_preparation not in observation_preparation_registry:
+        raise KeyError(
+            f"Unknown observation_preparation {observation_preparation!r}. "
+            f"Available: {list(observation_preparation_registry)}"
+        )
+    enc = observation_preparation_registry[observation_preparation].from_train_args(args)
     return enc, enc.make_adapter(), enc.spec()
 
 
@@ -227,14 +234,14 @@ def _make_trainer(
 def train(
     *,
     env: str,
-    encoder: str,
+    observation_preparation: str,
     curriculum: str | None = None,
     output_dir: str | None = None,
     wandb_name: str | None = None,
     wandb_tags: list[str] | None = None,
     argv: list[str] | None = None,
 ) -> "Trainer":
-    """Resolve (env, encoder, curriculum) via registries; parse CLI; run Trainer.run().
+    """Resolve env, Observation Preparation, curriculum; parse CLI; run Trainer.run().
 
     Kwargs (output_dir, wandb_name, wandb_tags) are shim-supplied defaults — CLI
     flags from argparse override if provided.
@@ -246,7 +253,10 @@ def train(
     from src.r2dreamer.agent import R2DreamerAgent
     from src.r2dreamer.config import R2DreamerConfig, LATENT_PRESETS
     from src.r2dreamer.launch.parser import _build_parser_train
-    from src.r2dreamer.launch.registries import env_registry, encoder_registry
+    from src.r2dreamer.launch.registries import (
+        env_registry,
+        observation_preparation_registry,
+    )
     from src.r2dreamer.trainer import Trainer, TrainerConfig, habitat_defaults
 
     parser = _build_parser_train()
@@ -255,7 +265,11 @@ def train(
     curriculum_path = _resolve_curriculum_inputs(
         env=env, args=args, curriculum=curriculum, env_registry=env_registry,
     )
-    enc, adapter, encoder_spec = _make_encoder_bundle(encoder, args, encoder_registry)
+    enc, adapter, encoder_spec = _make_observation_preparation_bundle(
+        observation_preparation,
+        args,
+        observation_preparation_registry,
+    )
     eff_output_dir, eff_wandb_name, eff_wandb_tags = _effective_run_metadata(
         args=args, output_dir=output_dir, wandb_name=wandb_name, wandb_tags=wandb_tags,
     )

--- a/src/r2dreamer/manifest.py
+++ b/src/r2dreamer/manifest.py
@@ -21,6 +21,14 @@ from typing import Any
 MANIFEST_NAME = "MANIFEST.json"
 
 
+def public_config_snapshot(config: dict) -> dict:
+    """Return the public config snapshot written to new run manifests."""
+    snapshot = dict(config)
+    if "encoder_type" in snapshot:
+        snapshot["observation_preparation_type"] = snapshot.pop("encoder_type")
+    return snapshot
+
+
 def _git(*args: str) -> str:
     """Run a git command and return stdout stripped. Lets git failures propagate."""
     return subprocess.run(
@@ -49,7 +57,7 @@ def write_manifest_start(run_dir: Path, config: dict) -> Path:
         "git_sha": _git("rev-parse", "HEAD"),
         "git_branch": _git("rev-parse", "--abbrev-ref", "HEAD"),
         "git_dirty": bool(_git("status", "--porcelain")),
-        "config": config,
+        "config": public_config_snapshot(config),
         "wandb_id": _wandb_id(),
         "slurm_id": os.environ.get("SLURM_JOB_ID"),
         "started_at": datetime.now(timezone.utc).isoformat(),

--- a/src/r2dreamer/trainer.py
+++ b/src/r2dreamer/trainer.py
@@ -23,7 +23,11 @@ import numpy as np
 from src.buffer.replay_buffer import BufferConfig, ReplayBuffer
 from src.shared.video_utils import compose_frame, log_episode_video, render_topdown_frame
 from src.r2dreamer.adapters import ObsAdapter  # noqa: F401 — re-exported for callers
-from src.r2dreamer.manifest import write_manifest_end, write_manifest_start
+from src.r2dreamer.manifest import (
+    public_config_snapshot,
+    write_manifest_end,
+    write_manifest_start,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -280,7 +284,9 @@ class Trainer:
             init_kwargs: dict[str, Any] = dict(
                 project=trainer_config.wandb_project,
                 name=trainer_config.wandb_name,
-                config=vars(agent_config) if hasattr(agent_config, "__dict__") else {},
+                config=public_config_snapshot(
+                    vars(agent_config) if hasattr(agent_config, "__dict__") else {}
+                ),
                 tags=trainer_config.wandb_tags,
             )
             if trainer_config.wandb_id is not None:

--- a/tests/r2dreamer/AGENTS.md
+++ b/tests/r2dreamer/AGENTS.md
@@ -34,7 +34,7 @@ real VGGT extractor.
 | File | Covers | GPU |
 |------|--------|-----|
 | `test_encoders.py` | encoder construction/specs/adapters; `TestVGGTEncoder` loads the real model | **GPU (that class)** |
-| `test_registries.py` | `encoder_registry`, `env_registry`, `CURRICULA` entries | CPU |
+| `test_registries.py` | `observation_preparation_registry`, `env_registry`, `CURRICULA` entries | CPU |
 | `test_presets.py` | `(env, encoder, curriculum)` preset matrix resolves (parametrized) | CPU |
 | `test_parser.py` | train parser does not expose `wandb_notes_file` | CPU |
 | `test_shim_invocation.py` | every `run.py <run-id>` (parametrized over `RUN_CONFIGS`) + each standalone `eval_*`/validation shim `--help` exits 0 (subprocess) | CPU |

--- a/tests/r2dreamer/launch/test_observation_preparation_public_language.py
+++ b/tests/r2dreamer/launch/test_observation_preparation_public_language.py
@@ -1,0 +1,34 @@
+"""Public observation-preparation launcher language tests."""
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "r2dreamer"))
+import _run_configs  # noqa: E402
+
+from src.r2dreamer.manifest import write_manifest_start  # noqa: E402
+
+
+def test_run_configs_use_observation_preparation_key():
+    for run_id, cfg in _run_configs.RUN_CONFIGS.items():
+        assert "observation_preparation" in cfg, run_id
+        assert "encoder" not in cfg, run_id
+
+
+def test_manifest_config_snapshot_uses_observation_preparation_identity(tmp_path, monkeypatch):
+    monkeypatch.setattr("src.r2dreamer.manifest._git", lambda *args: "test")
+
+    path = write_manifest_start(
+        tmp_path,
+        {
+            "encoder_type": "vggt",
+            "obs_shape": (4116,),
+            "total_steps": 1,
+        },
+    )
+
+    manifest = json.loads(path.read_text())
+    assert manifest["config"]["observation_preparation_type"] == "vggt"
+    assert "encoder_type" not in manifest["config"]

--- a/tests/r2dreamer/launch/test_parser.py
+++ b/tests/r2dreamer/launch/test_parser.py
@@ -2,7 +2,10 @@
 
 from types import SimpleNamespace
 
-from src.r2dreamer.launch.parser import _build_parser_train
+import pytest
+
+from src.main import _build_parser as _build_main_parser
+from src.r2dreamer.launch.parser import _build_parser_eval, _build_parser_train
 from src.r2dreamer.launch.train import _agent_overrides_from_args
 
 
@@ -17,8 +20,8 @@ def test_train_parser_does_not_expose_wandb_notes_file():
 def test_mlp_layers_help_matches_conv_encoder_guard():
     help_text = " ".join(_build_parser_train().format_help().split())
 
-    assert "Only valid for VGGT MLP encoders" in help_text
-    assert "CNN/dense-WP conv encoders require the default value (1)" in help_text
+    assert "Only valid for VGGT MLP Encoder Modules" in help_text
+    assert "CNN/dense-WP conv Encoder Modules require the default value (1)" in help_text
     assert "Ignored by the CNN/dense-WP conv encoders" not in help_text
 
 
@@ -39,3 +42,39 @@ def test_buffer_capacity_override_wins_over_encoder_default():
     overrides = _agent_overrides_from_args(args, encoder_spec, latent_presets={})
 
     assert overrides["buffer_capacity"] == 500_000
+
+
+def test_eval_parser_uses_observation_preparation_flag():
+    parser = _build_parser_eval()
+
+    args = parser.parse_args(["--observation-preparation", "vggt"])
+
+    assert args.observation_preparation == "vggt"
+    assert not hasattr(args, "encoder")
+    assert "--observation-preparation" in parser.format_help()
+    assert "--encoder" not in parser.format_help()
+
+
+def test_eval_parser_rejects_old_encoder_flag():
+    parser = _build_parser_eval()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--encoder", "vggt"])
+
+
+@pytest.mark.parametrize("command", ["train", "evaluate"])
+def test_main_parser_uses_observation_preparation_flag(command):
+    parser = _build_main_parser()
+
+    args = parser.parse_args([command, "--observation-preparation", "hybrid"])
+
+    assert args.observation_preparation == "hybrid"
+    assert not hasattr(args, "encoder")
+
+
+@pytest.mark.parametrize("command", ["train", "evaluate"])
+def test_main_parser_rejects_old_encoder_flag(command):
+    parser = _build_main_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args([command, "--encoder", "hybrid"])

--- a/tests/r2dreamer/launch/test_presets.py
+++ b/tests/r2dreamer/launch/test_presets.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-# Every (env, encoder, curriculum) combination in active sbatch files.
+# Every (env, Observation Preparation, curriculum) combination in active sbatch files.
 PRESETS = [
     ("habitat", "cnn",  "L1"),
     ("habitat", "cnn",  "L2"),
@@ -14,15 +14,19 @@ PRESETS = [
 ]
 
 
-@pytest.mark.parametrize("env_name, encoder_name, curriculum_name", PRESETS)
-def test_preset_resolves(env_name, encoder_name, curriculum_name):
-    """Every (env, encoder, curriculum) combo from active sbatch files must
-    resolve through registries + curricula without raising."""
-    from src.r2dreamer.launch.registries import env_registry, encoder_registry
+@pytest.mark.parametrize("env_name, observation_preparation_name, curriculum_name", PRESETS)
+def test_preset_resolves(env_name, observation_preparation_name, curriculum_name):
+    """Every active preset resolves through registries + curricula."""
+    from src.r2dreamer.launch.registries import (
+        env_registry,
+        observation_preparation_registry,
+    )
     from src.r2dreamer.launch.curricula import CURRICULA
 
     assert env_name in env_registry, f"{env_name!r} not in env_registry"
-    assert encoder_name in encoder_registry, f"{encoder_name!r} not in encoder_registry"
+    assert observation_preparation_name in observation_preparation_registry, (
+        f"{observation_preparation_name!r} not in observation_preparation_registry"
+    )
     if curriculum_name is not None:
         assert curriculum_name in CURRICULA, f"{curriculum_name!r} not in CURRICULA"
         assert CURRICULA[curriculum_name].exists(), (

--- a/tests/r2dreamer/launch/test_registries.py
+++ b/tests/r2dreamer/launch/test_registries.py
@@ -1,37 +1,40 @@
-"""L1 structural tests — registry contents and curriculum paths."""
+"""L1 structural tests: Observation Preparation registry and curriculum paths."""
 
 import inspect
 import pytest
 
 from src.r2dreamer.encoders import Encoder, HybridEncoder
-from src.r2dreamer.launch.registries import encoder_registry, env_registry
+from src.r2dreamer.launch.registries import (
+    env_registry,
+    observation_preparation_registry,
+)
 from src.r2dreamer.launch.curricula import CURRICULA
 
 
-class TestEncoderRegistry:
+class TestObservationPreparationRegistry:
     def test_all_values_are_encoder_subclasses(self):
-        for name, cls in encoder_registry.items():
+        for name, cls in observation_preparation_registry.items():
             assert inspect.isclass(cls), f"{name!r} is not a class"
             assert issubclass(cls, Encoder), f"{name!r} is not a subclass of Encoder"
 
     def test_all_encoder_subclasses_implement_make_adapter(self):
-        for name, cls in encoder_registry.items():
+        for name, cls in observation_preparation_registry.items():
             assert hasattr(cls, "make_adapter"), f"{name!r} missing make_adapter"
             assert callable(cls.make_adapter), f"{name!r}.make_adapter not callable"
 
     def test_missing_key_raises_key_error(self):
         with pytest.raises(KeyError):
-            _ = encoder_registry["nonexistent"]
+            _ = observation_preparation_registry["nonexistent"]
 
     def test_known_keys_present(self):
-        assert "cnn" in encoder_registry
-        assert "vggt" in encoder_registry
-        assert "vggt_aggregator_mlp" in encoder_registry
-        assert "vggt_wp_dense_cnn" in encoder_registry
-        assert "hybrid" in encoder_registry
+        assert "cnn" in observation_preparation_registry
+        assert "vggt" in observation_preparation_registry
+        assert "vggt_aggregator_mlp" in observation_preparation_registry
+        assert "vggt_wp_dense_cnn" in observation_preparation_registry
+        assert "hybrid" in observation_preparation_registry
 
     def test_hybrid_key_resolves_to_hybrid_spec_class(self):
-        assert encoder_registry["hybrid"] is HybridEncoder
+        assert observation_preparation_registry["hybrid"] is HybridEncoder
 
 
 class TestEnvRegistry:


### PR DESCRIPTION
## What changed

- Renamed public launcher input-mode selection from `encoder` to `observation_preparation` / `--observation-preparation` across `src.main`, eval parsing, run configs, and launcher validation.
- Added `observation_preparation_registry` as the public registry name, with a narrow internal compatibility alias for existing Encoder Module callers.
- Normalized new manifest and W&B config snapshots from `encoder_type` to `observation_preparation_type` while preserving the internal agent `encoder_type` contract.
- Updated launcher help text, run docs, AGENTS references, eval shims, and the 3D-35 verification sbatch to use Observation Preparation language.
- Preserved existing output paths, W&B names/tags, SLURM run IDs, and experiment run IDs.

## Why

Linear 3D-85 makes Observation Preparation the public launcher language so the input-mode boundary is distinct from the Dreamer-side Encoder Module and any external Feature Extractor.

## Linear issue

https://linear.app/3d-wm-objectnav/issue/3D-85/3d-make-observation-preparation-the-public-launcher-language

## Acceptance criteria checked

- Public launcher arguments use `--observation-preparation` as the canonical input-mode flag.
- Public `--encoder` usage is rejected in parser coverage.
- Run config and registry language use Observation Preparation terminology.
- New manifest/config snapshots use `observation_preparation_type`.
- Help text uses Observation Preparation, Encoder Module, and Feature Extractor terms.
- Existing output paths, W&B names/tags, SLURM behavior, defaults, and run IDs were not migrated.

## How to test

- `uv run pytest tests/r2dreamer/launch tests/test_manifest.py -q` -> 69 passed, 2 skipped.
- `git diff --check` -> clean.

## Risk

Medium: this intentionally breaks new public `--encoder` CLI usage, while preserving internal agent behavior and existing experiment identity strings.

## Intentionally not done

- Did not rename internal `R2DreamerConfig.encoder_type`, parameter tree keys, or Encoder Module implementation names.
- Did not migrate historical W&B tags, run names, output directories, or run IDs.

## Agent involvement

Implemented through the requested automated coding workflow.