### PR TITLE
3D-81: Route CNN through Observation Preparation contract

### DIFF
--- a/src/r2dreamer/encoders/specs.py
+++ b/src/r2dreamer/encoders/specs.py
@@ -18,6 +18,7 @@ import flax.linen as nn
 
 from src.r2dreamer.adapters.obs_adapter import ObsAdapter
 from src.r2dreamer.adapters.vggt_adapter import VGGTFeatureKind, VGGTObsAdapter
+from src.r2dreamer.observation_preparation import CNNObservationPreparation
 from src.r2dreamer.world_model import encoders as wm_encoders
 from src.vggt.jax.feature_extractor import JAXVGGTFeatureExtractor as VGGTFeatureExtractor
 
@@ -199,6 +200,16 @@ class Encoder(ABC):
                 f"{type(self).__name__} must set module_cls (a Flax nn.Module class)"
             )
         adapter = self.make_adapter()
+        contract = getattr(adapter, "contract", None)
+        if contract is not None:
+            return EncoderSpec(
+                obs_shape=contract.encoder_input.shape,
+                env_render_resolution=contract.env_render_resolution,
+                encoder_type=contract.encoder_type,
+                module_cls=contract.encoder_module_cls,
+                agent_overrides=dict(contract.agent_overrides),
+                design_notes=contract.design_notes,
+            )
         return EncoderSpec(
             obs_shape=adapter.encoder_obs_shape,
             env_render_resolution=self.env_render_resolution,
@@ -210,13 +221,13 @@ class Encoder(ABC):
 
 
 class CNNEncoder(Encoder):
-    """Identity encoder - agent's internal CNN handles RGB -> embedding -> RSSM."""
+    """CNN Observation Preparation feeding the internal ConvEncoder."""
 
     encoder_type = "cnn"
     module_cls = wm_encoders.ConvEncoder
 
     def _build_adapter(self) -> ObsAdapter:
-        return ObsAdapter()  # passthrough, default behavior
+        return CNNObservationPreparation()
 
 
 class VGGTEncoder(Encoder):

--- a/src/r2dreamer/observation_preparation/__init__.py
+++ b/src/r2dreamer/observation_preparation/__init__.py
@@ -1,0 +1,21 @@
+"""Observation Preparation public API."""
+
+from src.r2dreamer.observation_preparation.contracts import (
+    EncoderInputContract,
+    ObservationField,
+    ObservationFormContract,
+    PreparedObservation,
+)
+from src.r2dreamer.observation_preparation.cnn import (
+    CNN_IMAGE_SHAPE,
+    CNNObservationPreparation,
+)
+
+__all__ = [
+    "CNN_IMAGE_SHAPE",
+    "CNNObservationPreparation",
+    "EncoderInputContract",
+    "ObservationField",
+    "ObservationFormContract",
+    "PreparedObservation",
+]

--- a/src/r2dreamer/observation_preparation/cnn.py
+++ b/src/r2dreamer/observation_preparation/cnn.py
@@ -1,0 +1,78 @@
+"""CNN Observation Preparation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from src.r2dreamer.adapters.obs_adapter import ObsAdapter
+from src.r2dreamer.observation_preparation.contracts import (
+    EncoderInputContract,
+    ObservationField,
+    ObservationFormContract,
+    PreparedObservation,
+)
+from src.r2dreamer.world_model import encoders as wm_encoders
+
+
+CNN_IMAGE_SHAPE = (3, 64, 64)
+
+
+def _cnn_contract() -> EncoderInputContract:
+    image_uint8 = ObservationField(CNN_IMAGE_SHAPE, "uint8")
+    return EncoderInputContract(
+        observation_preparation_type="cnn",
+        encoder_type="cnn",
+        env_render_resolution=64,
+        encoder_module_cls=wm_encoders.ConvEncoder,
+        env_observation=ObservationFormContract(
+            {
+                "image": image_uint8,
+                "is_first": ObservationField((), "bool"),
+            }
+        ),
+        replay_observation=ObservationFormContract(
+            ObservationField(CNN_IMAGE_SHAPE, "uint8", normalize_on_sample=True)
+        ),
+        agent_observation=ObservationFormContract(
+            {
+                "image": image_uint8,
+                "is_first": ObservationField((), "bool"),
+            }
+        ),
+        encoder_input=ObservationFormContract(
+            ObservationField(CNN_IMAGE_SHAPE, "float32")
+        ),
+        decoder_target=ObservationFormContract(
+            ObservationField(CNN_IMAGE_SHAPE, "float32")
+        ),
+    )
+
+
+class CNNObservationPreparation(ObsAdapter):
+    """Prepare 64x64 CHW RGB observations for the CNN Encoder Module."""
+
+    def __init__(self, contract: EncoderInputContract | None = None):
+        self.contract = contract or _cnn_contract()
+        super().__init__(
+            buffer_dtype=self.contract.replay_observation.buffer_dtype(),
+            buffer_shape=self.contract.replay_observation.buffer_shape(),
+            normalize_on_sample=self.contract.replay_observation.buffer_normalize(),
+            agent_obs_shape=self.contract.encoder_input.shape,
+        )
+
+    def prepare_env_step(self, obs_dict: dict[str, Any]) -> PreparedObservation:
+        image = np.asarray(obs_dict["image"])
+        return PreparedObservation(
+            replay_obs=image,
+            agent_obs={
+                "image": image,
+                "is_first": obs_dict.get("is_first", False),
+            },
+        )
+
+    def transform(self, obs_dict: dict[str, Any]):
+        """Compatibility wrapper for legacy ObsAdapter call sites."""
+        prepared = self.prepare_env_step(obs_dict)
+        return prepared.replay_obs, prepared.agent_obs

--- a/src/r2dreamer/observation_preparation/contracts.py
+++ b/src/r2dreamer/observation_preparation/contracts.py
@@ -1,0 +1,97 @@
+"""Observation Preparation contracts.
+
+Observation Preparation turns raw environment observations into the replay-buffer
+observation and the one-step agent observation for a chosen input mode. The
+contract records the observation forms that keep replay storage, agent acting,
+and the Encoder Module input aligned.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+import flax.linen as nn
+import numpy as np
+
+
+ObservationValue = np.ndarray | dict[str, np.ndarray]
+
+
+@dataclass(frozen=True)
+class ObservationField:
+    """Metadata for one observation field."""
+
+    shape: tuple[int, ...]
+    dtype: str
+    normalize_on_sample: bool = False
+
+
+@dataclass(frozen=True)
+class ObservationFormContract:
+    """Shape/dtype contract for a single or structured observation form."""
+
+    fields: ObservationField | Mapping[str, ObservationField]
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        if isinstance(self.fields, Mapping):
+            raise ValueError("structured observation forms do not have one shape")
+        return self.fields.shape
+
+    @property
+    def dtype(self) -> str:
+        if isinstance(self.fields, Mapping):
+            raise ValueError("structured observation forms do not have one dtype")
+        return self.fields.dtype
+
+    @property
+    def normalize_on_sample(self) -> bool:
+        if isinstance(self.fields, Mapping):
+            raise ValueError(
+                "structured observation forms do not have one normalize flag"
+            )
+        return self.fields.normalize_on_sample
+
+    def buffer_shape(self) -> tuple[int, ...] | dict[str, tuple[int, ...]]:
+        if isinstance(self.fields, Mapping):
+            return {key: field.shape for key, field in self.fields.items()}
+        return self.fields.shape
+
+    def buffer_dtype(self) -> str | dict[str, str]:
+        if isinstance(self.fields, Mapping):
+            return {key: field.dtype for key, field in self.fields.items()}
+        return self.fields.dtype
+
+    def buffer_normalize(self) -> bool | dict[str, bool]:
+        if isinstance(self.fields, Mapping):
+            return {
+                key: field.normalize_on_sample for key, field in self.fields.items()
+            }
+        return self.fields.normalize_on_sample
+
+
+@dataclass(frozen=True)
+class EncoderInputContract:
+    """Resolved contract connecting preparation to an Encoder Module."""
+
+    observation_preparation_type: str
+    encoder_type: str
+    env_render_resolution: int
+    encoder_module_cls: type[nn.Module]
+    env_observation: ObservationFormContract
+    replay_observation: ObservationFormContract
+    agent_observation: ObservationFormContract
+    encoder_input: ObservationFormContract
+    decoder_target: ObservationFormContract | None
+    agent_overrides: Mapping[str, Any] = field(default_factory=dict)
+    design_notes: str = ""
+
+
+@dataclass(frozen=True)
+class PreparedObservation:
+    """Per-step prepared observation for replay storage and immediate acting."""
+
+    replay_obs: ObservationValue
+    agent_obs: dict[str, Any]

--- a/src/r2dreamer/trainer.py
+++ b/src/r2dreamer/trainer.py
@@ -244,12 +244,24 @@ class Trainer:
         self.val_obs_adapter = val_obs_adapter
         self.val_episode_metrics_fn = val_episode_metrics_fn
 
-        # Build buffer from adapter settings
+        # Build buffer from the Observation Preparation contract when present;
+        # legacy adapters keep using their adapter attributes during migration.
+        replay_contract = getattr(
+            getattr(self.obs_adapter, "contract", None), "replay_observation", None,
+        )
+        if replay_contract is not None:
+            obs_shape = replay_contract.buffer_shape()
+            obs_dtype = replay_contract.buffer_dtype()
+            normalize_obs = replay_contract.buffer_normalize()
+        else:
+            obs_shape = self.obs_adapter.buffer_shape
+            obs_dtype = self.obs_adapter.buffer_dtype
+            normalize_obs = self.obs_adapter.normalize_on_sample
         self.buffer = ReplayBuffer(BufferConfig(
             capacity=agent_config.buffer_capacity,
-            obs_shape=self.obs_adapter.buffer_shape,
-            obs_dtype=self.obs_adapter.buffer_dtype,
-            normalize_obs=self.obs_adapter.normalize_on_sample,
+            obs_shape=obs_shape,
+            obs_dtype=obs_dtype,
+            normalize_obs=normalize_obs,
         ))
 
         # Resume from checkpoint (overwrite freshly-initialised agent state).
@@ -351,6 +363,12 @@ class Trainer:
     # Prefill
     # ------------------------------------------------------------------
 
+    def _prepare_observation(self, adapter: ObsAdapter, obs: dict) -> tuple[Any, dict]:
+        if hasattr(adapter, "prepare_env_step"):
+            prepared = adapter.prepare_env_step(obs)
+            return prepared.replay_obs, prepared.agent_obs
+        return adapter.transform(obs)
+
     def _prefill(self, rng_key: jnp.ndarray, writer: Any, f: Any) -> None:
         acfg, tcfg = self.acfg, self.tcfg
         print(f"Prefilling {tcfg.prefill_steps} steps...")
@@ -358,12 +376,12 @@ class Trainer:
         obs = self.env.reset()
         if self.obs_adapter.on_episode_reset:
             self.obs_adapter.on_episode_reset()
-        buffer_obs, _ = self.obs_adapter.transform(obs)
+        buffer_obs, _ = self._prepare_observation(self.obs_adapter, obs)
 
         for _ in range(tcfg.prefill_steps):
             action = np.random.randint(0, acfg.num_actions)
             next_obs = self.env.step(action)
-            next_buffer_obs, _ = self.obs_adapter.transform(next_obs)
+            next_buffer_obs, _ = self._prepare_observation(self.obs_adapter, next_obs)
 
             success = next_obs.get("success", 0.0) > 0
             self.buffer.add(buffer_obs, action, next_obs["reward"],
@@ -373,7 +391,7 @@ class Trainer:
                 obs = self.env.reset()
                 if self.obs_adapter.on_episode_reset:
                     self.obs_adapter.on_episode_reset()
-                buffer_obs, _ = self.obs_adapter.transform(obs)
+                buffer_obs, _ = self._prepare_observation(self.obs_adapter, obs)
             else:
                 obs = next_obs
                 buffer_obs = next_buffer_obs
@@ -386,7 +404,7 @@ class Trainer:
         obs = self.env.reset()
         if self.obs_adapter.on_episode_reset:
             self.obs_adapter.on_episode_reset()
-        buffer_obs, agent_obs = self.obs_adapter.transform(obs)
+        buffer_obs, agent_obs = self._prepare_observation(self.obs_adapter, obs)
         return obs, buffer_obs, agent_obs
 
     def _zero_episode_counters(self) -> tuple[float, int, np.ndarray]:
@@ -476,7 +494,9 @@ class Trainer:
             rng_key, act_key = jax.random.split(rng_key)
             action = self.agent.act(agent_obs, act_key)
             next_obs = self.env.step(action)
-            next_buffer_obs, next_agent_obs = self.obs_adapter.transform(next_obs)
+            next_buffer_obs, next_agent_obs = self._prepare_observation(
+                self.obs_adapter, next_obs,
+            )
 
             self._record_train_transition(
                 buffer_obs=buffer_obs, action=action, next_obs=next_obs,
@@ -731,7 +751,7 @@ class Trainer:
         obs = self.val_env.reset()
         if val_adapter.on_episode_reset:
             val_adapter.on_episode_reset()
-        _, agent_obs = val_adapter.transform(obs)
+        _, agent_obs = self._prepare_observation(val_adapter, obs)
 
         episode_reward = 0.0
         episode_steps = 0
@@ -745,7 +765,7 @@ class Trainer:
             rng_key, act_key = jax.random.split(rng_key)
             action = self.agent.act(agent_obs, act_key, training=False)
             next_obs = self.val_env.step(action)
-            _, next_agent_obs = val_adapter.transform(next_obs)
+            _, next_agent_obs = self._prepare_observation(val_adapter, next_obs)
 
             action_counts[action] += 1
             episode_reward += next_obs["reward"]

--- a/tests/r2dreamer/launch/test_encoders.py
+++ b/tests/r2dreamer/launch/test_encoders.py
@@ -9,6 +9,7 @@ import pytest
 from src.r2dreamer.adapters import ObsAdapter, VGGTObsAdapter
 from src.r2dreamer.adapters.hybrid_adapter import HybridObsAdapter
 from src.r2dreamer.obs_batch import HYBRID_IMAGE_KEY, HYBRID_WP_CP_KEY
+from src.r2dreamer.observation_preparation import CNNObservationPreparation
 from src.r2dreamer.encoders import (
     CNNEncoder,
     EncoderSpec,
@@ -52,6 +53,7 @@ class TestCNNEncoder:
         enc = CNNEncoder()
         adapter = enc.make_adapter()
         assert isinstance(adapter, ObsAdapter)
+        assert isinstance(adapter, CNNObservationPreparation)
 
     def test_cnn_encoder_exposes_spec(self):
         spec = CNNEncoder().spec()
@@ -59,6 +61,7 @@ class TestCNNEncoder:
         assert spec.encoder_type == "cnn"
         assert spec.obs_shape == (3, 64, 64)
         assert spec.env_render_resolution == 64
+        assert spec.module_cls is wm_encoders.ConvEncoder
         assert spec.agent_overrides == {}
 
     def test_cnn_adapter_passthrough(self):
@@ -66,9 +69,10 @@ class TestCNNEncoder:
         dummy_img = np.zeros((3, 64, 64), dtype=np.uint8)
         obs = {"image": dummy_img, "is_first": True}
         buf_obs, agent_obs = adapter.transform(obs)
-        # Default ObsAdapter returns the image unchanged and the full obs dict
+        # CNN Observation Preparation returns explicit replay and agent observations.
         np.testing.assert_array_equal(buf_obs, dummy_img)
-        assert agent_obs is obs
+        assert agent_obs["image"] is dummy_img
+        assert agent_obs["is_first"] is True
 
 
 class TestVGGTEncoderConfiguration:

--- a/tests/r2dreamer/test_observation_preparation.py
+++ b/tests/r2dreamer/test_observation_preparation.py
@@ -1,0 +1,55 @@
+"""Observation Preparation contract tests."""
+
+import numpy as np
+
+from src.r2dreamer.observation_preparation import (
+    CNNObservationPreparation,
+    PreparedObservation,
+)
+from src.r2dreamer.world_model import encoders as wm_encoders
+
+
+class TestCNNObservationPreparation:
+    def test_contract_declares_cnn_replay_and_encoder_input_forms(self):
+        prep = CNNObservationPreparation()
+        contract = prep.contract
+
+        assert contract.observation_preparation_type == "cnn"
+        assert contract.encoder_type == "cnn"
+        assert contract.env_render_resolution == 64
+        assert contract.encoder_module_cls is wm_encoders.ConvEncoder
+        assert contract.encoder_input.shape == (3, 64, 64)
+        assert contract.env_observation.fields["image"].shape == (3, 64, 64)
+        assert contract.env_observation.fields["image"].dtype == "uint8"
+        assert contract.env_observation.fields["is_first"].dtype == "bool"
+
+        replay = contract.replay_observation
+        assert replay.shape == (3, 64, 64)
+        assert replay.dtype == "uint8"
+        assert replay.normalize_on_sample is True
+
+        decoder = contract.decoder_target
+        assert decoder is not None
+        assert decoder.shape == (3, 64, 64)
+        assert decoder.dtype == "float32"
+
+    def test_prepare_env_step_returns_replay_and_agent_observations(self):
+        prep = CNNObservationPreparation()
+        image = np.arange(3 * 64 * 64, dtype=np.uint8).reshape(3, 64, 64)
+
+        prepared = prep.prepare_env_step({"image": image, "is_first": True})
+
+        assert isinstance(prepared, PreparedObservation)
+        np.testing.assert_array_equal(prepared.replay_obs, image)
+        assert prepared.agent_obs["image"] is image
+        assert prepared.agent_obs["is_first"] is True
+
+    def test_legacy_transform_routes_through_prepared_observation(self):
+        prep = CNNObservationPreparation()
+        image = np.zeros((3, 64, 64), dtype=np.uint8)
+
+        replay_obs, agent_obs = prep.transform({"image": image})
+
+        np.testing.assert_array_equal(replay_obs, image)
+        assert agent_obs["image"] is image
+        assert agent_obs["is_first"] is False

--- a/tests/r2dreamer/test_trainer.py
+++ b/tests/r2dreamer/test_trainer.py
@@ -11,6 +11,10 @@ import pytest
 from src.r2dreamer.config import R2DreamerConfig
 from src.r2dreamer.agent import R2DreamerAgent
 from src.r2dreamer.adapters import ObsAdapter
+from src.r2dreamer.observation_preparation import (
+    CNNObservationPreparation,
+    PreparedObservation,
+)
 from src.r2dreamer.trainer import (
     Trainer,
     TrainerConfig,
@@ -38,6 +42,35 @@ class _DummyEnv:
         pass
 
 
+class _TinyCNNEnv:
+    """Small deterministic env for a full CNN Trainer pipeline smoke test."""
+
+    def __init__(self):
+        self.t = 0
+        self.closed = False
+
+    def reset(self) -> dict:
+        self.t = 0
+        return {
+            "image": np.zeros((3, 64, 64), dtype=np.uint8),
+            "is_first": True,
+        }
+
+    def step(self, action: int) -> dict:
+        self.t += 1
+        done = self.t >= 4
+        return {
+            "image": np.full((3, 64, 64), self.t, dtype=np.uint8),
+            "reward": 1.0,
+            "done": done,
+            "success": 0.0,
+            "is_first": False,
+        }
+
+    def close(self) -> None:
+        self.closed = True
+
+
 class _MappingObsAdapter(ObsAdapter):
     def __init__(self):
         super().__init__(
@@ -52,6 +85,60 @@ class _MappingObsAdapter(ObsAdapter):
             "image": obs_dict["image"],
             "wp_cp": np.ones((4116,), dtype=np.float32),
         }, obs_dict
+
+
+class _PrepareOnlyAdapter(ObsAdapter):
+    def __init__(self):
+        super().__init__()
+        self.calls = 0
+
+    def prepare_env_step(self, obs_dict: dict) -> PreparedObservation:
+        self.calls += 1
+        return PreparedObservation(
+            replay_obs=obs_dict["image"],
+            agent_obs={"image": obs_dict["image"], "is_first": True},
+        )
+
+    def transform(self, obs_dict: dict):
+        raise AssertionError("trainer should route through prepare_env_step")
+
+
+def _tiny_cnn_cfg(tmp_path):
+    return R2DreamerConfig(
+        encoder_type="cnn",
+        obs_shape=(3, 64, 64),
+        num_actions=4,
+        buffer_capacity=64,
+        batch_size=1,
+        seq_len=2,
+        train_ratio=2,
+        deter_size=32,
+        hidden_size=16,
+        stoch_classes=4,
+        stoch_discrete=4,
+        blocks=4,
+        encoder_depth=4,
+        encoder_kernel=3,
+        encoder_mults=(1, 1),
+        mlp_units=16,
+        mlp_layers_reward=1,
+        mlp_layers_cont=1,
+        mlp_layers_actor=1,
+        mlp_layers_critic=1,
+        twohot_bins=21,
+        imagination_horizon=2,
+        horizon=20,
+        lr=1e-3,
+        warmup_steps=0,
+        logdir=str(tmp_path),
+    )
+
+
+def _tree_any_changed(before, after, *, atol=1e-7):
+    return any(
+        not np.allclose(np.asarray(a), np.asarray(b), atol=atol)
+        for a, b in zip(before, jax.tree.leaves(after))
+    )
 
 
 class TestConvertBatch:
@@ -215,6 +302,59 @@ class TestResume:
             Trainer(
                 agent=agent, env=_DummyEnv(), agent_config=cfg, trainer_config=tcfg,
             )
+
+
+class TestTrainerObservationPreparation:
+    def test_reset_train_episode_uses_prepare_env_step_when_available(self, tmp_path):
+        cfg = R2DreamerConfig(obs_shape=(3, 64, 64), num_actions=4, buffer_capacity=8)
+        tcfg = TrainerConfig(
+            output_dir=str(tmp_path / "logdir"),
+            total_steps=1,
+            wandb_project=None,
+        )
+        obs_adapter = _PrepareOnlyAdapter()
+        trainer = Trainer(
+            agent=object(),
+            env=_DummyEnv(),
+            agent_config=cfg,
+            trainer_config=tcfg,
+            obs_adapter=obs_adapter,
+        )
+
+        _, buffer_obs, agent_obs = trainer._reset_train_episode()
+
+        assert obs_adapter.calls == 1
+        assert buffer_obs.shape == (3, 64, 64)
+        assert agent_obs["is_first"] is True
+
+
+class TestTrainerFullPipeline:
+    def test_cnn_observation_preparation_runs_through_training_pipeline(self, tmp_path):
+        cfg = _tiny_cnn_cfg(tmp_path)
+        agent = R2DreamerAgent(cfg, jax.random.PRNGKey(0))
+        env = _TinyCNNEnv()
+        trainer = Trainer(
+            agent=agent,
+            env=env,
+            agent_config=cfg,
+            trainer_config=TrainerConfig(
+                output_dir=str(tmp_path / "run"),
+                total_steps=4,
+                prefill_steps=4,
+                log_every=1,
+                checkpoint_every=100,
+                wandb_project=None,
+                val_every=0,
+            ),
+            obs_adapter=CNNObservationPreparation(),
+        )
+        before = [np.asarray(x).copy() for x in jax.tree.leaves(agent.params)]
+
+        trainer.run()
+
+        assert env.closed is True
+        assert trainer.buffer.size > 0
+        assert _tree_any_changed(before, agent.params)
 
 
 class TestTrainerMappingReplay:


### PR DESCRIPTION
## What changed
- Added `src/r2dreamer/observation_preparation/` with Observation Preparation contracts and `CNNObservationPreparation`.
- Routed the CNN launcher path through `CNNObservationPreparation` while preserving the existing adapter fallback for VGGT/hybrid modes.
- Made `Encoder.spec()` and `Trainer` prefer the Observation Preparation contract when present.
- Added contract, launcher, trainer-routing, and full CNN training-pipeline tests.

## Why
Linear issue: https://linear.app/3d-wm-objectnav/issue/3D-81/3d-route-cnn-through-observation-preparation-contract

This deepens the CNN input path around the Observation Preparation boundary so replay observations, agent-ready observations, and Encoder Module input are described by one explicit contract.

## Acceptance criteria checked
- CNN has an explicit Observation Preparation contract for env, replay, agent, encoder input, and decoder target forms.
- CNN launcher path resolves to `CNNObservationPreparation`.
- Trainer uses `prepare_env_step()` when available and still supports legacy adapters.
- Replay buffer allocation for contract-backed preparation uses the replay observation contract.
- A CPU full-pipeline smoke test exercises env → CNN Observation Preparation → Trainer → replay → `convert_batch` → real `R2DreamerAgent.train_step`.

## Verification
```bash
uv run pytest \
  tests/r2dreamer/launch/test_encoders.py \
  tests/r2dreamer/test_trainer.py \
  tests/r2dreamer/test_observation_preparation.py \
  -q -rs
```

Result: `33 passed, 2 skipped`.

Skipped: two GPU-only VGGT tests in `tests/r2dreamer/launch/test_encoders.py` because no JAX GPU backend was available.

## Risk
Medium-low. CNN path is now routed through a new contract-backed class, but behavior stays equivalent for RGB replay/agent observations. VGGT/hybrid continue through legacy adapter fallback.

## How to test
Run the verification command above. For GPU VGGT coverage, run the skipped tests under `srun` with a JAX GPU backend.

## Screenshots / preview
Not applicable.

## Intentionally not done
- Did not migrate VGGT/hybrid into Observation Preparation contracts in this PR.
- Did not rename public CLI flags from encoder to observation-preparation.
- Did not update Linear directly because the issue body/API was not accessible from this environment; the PR links the issue and records verification here.

## Agent involvement
AI-assisted implementation and testing.

## Follow-up issues created
None.
