### PR TITLE
3D-82: Route VGGT observation preparation variants through contract

### DIFF
--- a/src/r2dreamer/adapters/hybrid_adapter.py
+++ b/src/r2dreamer/adapters/hybrid_adapter.py
@@ -11,6 +11,7 @@ from src.r2dreamer.adapters.vggt_adapter import (
     flatten_world_points_camera_pose,
 )
 from src.r2dreamer.obs_batch import HYBRID_IMAGE_KEY, HYBRID_WP_CP_KEY
+from src.r2dreamer.observation_preparation.vggt import build_hybrid_contract
 from src.shared.video_utils import resize_chw_uint8
 
 
@@ -30,15 +31,27 @@ class HybridObsAdapter(ObsAdapter):
     still packs them into the legacy flat encoder input at the JAX boundary.
     """
 
-    def __init__(self, extractor):
+    def __init__(
+        self,
+        extractor,
+        *,
+        env_render_resolution: int | None = None,
+        encoder_module_cls=None,
+        agent_overrides=None,
+        design_notes: str = "",
+    ):
+        self.contract = build_hybrid_contract(
+            extractor,
+            env_render_resolution=env_render_resolution,
+            encoder_module_cls=encoder_module_cls,
+            agent_overrides=agent_overrides,
+            design_notes=design_notes,
+        )
         super().__init__(
-            buffer_dtype={HYBRID_IMAGE_KEY: "uint8", HYBRID_WP_CP_KEY: "float32"},
-            buffer_shape={
-                HYBRID_IMAGE_KEY: HYBRID_IMAGE_SHAPE,
-                HYBRID_WP_CP_KEY: (VGGT_FEATURE_DIM,),
-            },
-            normalize_on_sample={HYBRID_IMAGE_KEY: False, HYBRID_WP_CP_KEY: False},
-            agent_obs_shape=(HYBRID_FEATURE_DIM,),
+            buffer_dtype=self.contract.replay_observation.buffer_dtype(),
+            buffer_shape=self.contract.replay_observation.buffer_shape(),
+            normalize_on_sample=self.contract.replay_observation.buffer_normalize(),
+            agent_obs_shape=self.contract.encoder_input.shape,
             on_episode_reset=extractor.reset,
         )
         self._extractor = extractor

--- a/src/r2dreamer/adapters/vggt_adapter.py
+++ b/src/r2dreamer/adapters/vggt_adapter.py
@@ -2,17 +2,19 @@
 
 from __future__ import annotations
 
-from typing import Literal
-
 import jax.numpy as jnp
 import numpy as np
 
 from src.r2dreamer.adapters.obs_adapter import ObsAdapter
+from src.r2dreamer.observation_preparation.vggt import (
+    VGGTFeatureKind,
+    build_vggt_contract,
+    wp_cp_dim,
+)
 from src.vggt.jax.feature_extractor import JAXVGGTFeatureExtractor as VGGTFeatureExtractor
 
 
-VGGT_FEATURE_DIM = 4116  # 37*37*3 + 9
-VGGTFeatureKind = Literal["wp_cp", "aggregator", "wp_dense", "agg_raw"]
+VGGT_FEATURE_DIM = wp_cp_dim()  # 37*37*3 + 9
 
 # Raw aggregator readout: drop the 4 register tokens, keep camera(1) + patches.
 # At the default 518² / 37x37-patch / 1024-d config: 1 + 1369 = 1370 tokens.
@@ -92,38 +94,31 @@ def flatten_raw_aggregator(out: dict, expected_shape: tuple[int, ...]) -> jnp.nd
 class VGGTObsAdapter(ObsAdapter):
     """Runs VGGT extraction, returns features for both buffer and agent."""
 
-    def __init__(self, extractor: VGGTFeatureExtractor, feature_kind: VGGTFeatureKind = "wp_cp"):
-        if feature_kind == "wp_cp":
-            # WP grid is configurable (37 default, 64 for the hi-res variant);
-            # flat dim = K*K*3 world points + 9 camera-pose. Defaults to 4116.
-            k = int(getattr(extractor, "wp_pool_size", 37))
-            buffer_shape = (k * k * 3 + 9,)
-            buffer_dtype = "float32"
-        elif feature_kind == "aggregator":
-            embed_dim = int(extractor.aggregator_feature_shape[-1])
-            buffer_shape = (3 * embed_dim,)  # [cam | mean_patches | max_patches]
-            buffer_dtype = "float32"
-        elif feature_kind == "wp_dense":
-            # Full-res world-point map as a (3, H, W) image (3D-53). Stored as
-            # float16 to halve the per-frame cost (~3.2 MB -> ~1.6 MB at 518²).
-            img = int(extractor.image_size)
-            buffer_shape = (3, img, img)
-            buffer_dtype = "float16"
-        elif feature_kind == "agg_raw":
-            # Raw flattened aggregator: drop the 4 register tokens, keep
-            # cam(1) + patches -> (1 + (P - _PATCH_START_IDX)) * embed_dim.
-            # ~1.40M float16 = ~2.81 MB/frame at defaults; keep the buffer small.
-            shp = extractor.aggregator_feature_shape
-            n_tokens = 1 + (int(shp[0]) - _PATCH_START_IDX)
-            embed_dim = int(shp[-1])
-            buffer_shape = (n_tokens * embed_dim,)
-            buffer_dtype = "float16"
-        else:
-            raise ValueError(f"unknown VGGT feature_kind {feature_kind!r}")
+    def __init__(
+        self,
+        extractor: VGGTFeatureExtractor,
+        feature_kind: VGGTFeatureKind = "wp_cp",
+        *,
+        env_render_resolution: int | None = None,
+        encoder_type: str | None = None,
+        encoder_module_cls=None,
+        agent_overrides=None,
+        design_notes: str = "",
+    ):
+        self.contract = build_vggt_contract(
+            extractor,
+            feature_kind=feature_kind,
+            env_render_resolution=env_render_resolution,
+            encoder_type=encoder_type,
+            encoder_module_cls=encoder_module_cls,
+            agent_overrides=agent_overrides,
+            design_notes=design_notes,
+        )
         super().__init__(
-            buffer_dtype=buffer_dtype,
-            buffer_shape=buffer_shape,
-            normalize_on_sample=False,
+            buffer_dtype=self.contract.replay_observation.buffer_dtype(),
+            buffer_shape=self.contract.replay_observation.buffer_shape(),
+            normalize_on_sample=self.contract.replay_observation.buffer_normalize(),
+            agent_obs_shape=self.contract.encoder_input.shape,
             on_episode_reset=extractor.reset,
         )
         self._extractor = extractor

--- a/src/r2dreamer/encoders/specs.py
+++ b/src/r2dreamer/encoders/specs.py
@@ -283,7 +283,15 @@ class VGGTEncoder(Encoder):
         )  # device="cuda" default
 
     def _build_adapter(self) -> ObsAdapter:
-        return VGGTObsAdapter(self._extractor, feature_kind=self.feature_kind)
+        return VGGTObsAdapter(
+            self._extractor,
+            feature_kind=self.feature_kind,
+            env_render_resolution=self.env_render_resolution,
+            encoder_type=self.encoder_type,
+            encoder_module_cls=self.module_cls,
+            agent_overrides=self.agent_overrides,
+            design_notes=self.design_notes,
+        )
 
 
 class VGGTAggregatorMLPEncoder(VGGTEncoder):
@@ -306,7 +314,13 @@ class HybridEncoder(VGGTEncoder):
     def _build_adapter(self) -> ObsAdapter:
         from src.r2dreamer.adapters.hybrid_adapter import HybridObsAdapter
 
-        return HybridObsAdapter(self._extractor)
+        return HybridObsAdapter(
+            self._extractor,
+            env_render_resolution=self.env_render_resolution,
+            encoder_module_cls=self.module_cls,
+            agent_overrides=self.agent_overrides,
+            design_notes=self.design_notes,
+        )
 
 
 class VGGTWPCP64Encoder(VGGTEncoder):

--- a/src/r2dreamer/observation_preparation/__init__.py
+++ b/src/r2dreamer/observation_preparation/__init__.py
@@ -10,12 +10,26 @@ from src.r2dreamer.observation_preparation.cnn import (
     CNN_IMAGE_SHAPE,
     CNNObservationPreparation,
 )
+from src.r2dreamer.observation_preparation.vggt import (
+    HYBRID_FEATURE_DIM,
+    HYBRID_IMAGE_SHAPE,
+    VGGTFeatureKind,
+    VGGT_IMAGE_SHAPE,
+    build_hybrid_contract,
+    build_vggt_contract,
+)
 
 __all__ = [
     "CNN_IMAGE_SHAPE",
     "CNNObservationPreparation",
     "EncoderInputContract",
+    "HYBRID_FEATURE_DIM",
+    "HYBRID_IMAGE_SHAPE",
     "ObservationField",
     "ObservationFormContract",
     "PreparedObservation",
+    "VGGTFeatureKind",
+    "VGGT_IMAGE_SHAPE",
+    "build_hybrid_contract",
+    "build_vggt_contract",
 ]

--- a/src/r2dreamer/observation_preparation/vggt.py
+++ b/src/r2dreamer/observation_preparation/vggt.py
@@ -1,0 +1,202 @@
+"""VGGT-family Observation Preparation contracts."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Literal, Any
+
+import flax.linen as nn
+
+from src.r2dreamer.obs_batch import HYBRID_IMAGE_KEY, HYBRID_WP_CP_KEY
+from src.r2dreamer.observation_preparation.contracts import (
+    EncoderInputContract,
+    ObservationField,
+    ObservationFormContract,
+)
+from src.r2dreamer.world_model import encoders as wm_encoders
+
+
+VGGTFeatureKind = Literal["wp_cp", "aggregator", "wp_dense", "agg_raw"]
+
+VGGT_IMAGE_SIZE = 518
+VGGT_IMAGE_SHAPE = (3, VGGT_IMAGE_SIZE, VGGT_IMAGE_SIZE)
+VGGT_DEFAULT_WP_POOL_SIZE = 37
+VGGT_CAMERA_POSE_DIM = 9
+VGGT_XYZ_CHANNELS = 3
+VGGT_AGGREGATOR_POOL_COUNT = 3
+VGGT_AGGREGATOR_PATCH_START_IDX = 5
+
+HYBRID_IMAGE_SHAPE = (3, 64, 64)
+HYBRID_RGB_DIM = HYBRID_IMAGE_SHAPE[0] * HYBRID_IMAGE_SHAPE[1] * HYBRID_IMAGE_SHAPE[2]
+
+
+_DEFAULT_AGENT_OVERRIDES: dict[str, dict[str, Any]] = {
+    "vggt": {"buffer_capacity": 1_000_000},
+    "vggt_wp_cp_64": {"buffer_capacity": 1_000_000},
+    "vggt_aggregator_mlp": {
+        "buffer_capacity": 5_000,
+        "batch_size": 4,
+        "seq_len": 32,
+        "train_ratio": 128,
+    },
+    "vggt_wp_dense_cnn": {
+        "buffer_capacity": 5_000,
+        "batch_size": 4,
+        "seq_len": 32,
+        "train_ratio": 128,
+    },
+    "hybrid": {"buffer_capacity": 100_000},
+}
+
+
+def wp_cp_dim(wp_pool_size: int = VGGT_DEFAULT_WP_POOL_SIZE) -> int:
+    """Flat VGGT world-points + camera-pose feature dimension."""
+    return wp_pool_size * wp_pool_size * VGGT_XYZ_CHANNELS + VGGT_CAMERA_POSE_DIM
+
+
+def aggregator_pooled_dim(aggregator_feature_shape: tuple[int, ...]) -> int:
+    """Flat dimension after [camera, mean patches, max patches] pooling."""
+    return VGGT_AGGREGATOR_POOL_COUNT * int(aggregator_feature_shape[-1])
+
+
+def aggregator_raw_dim(aggregator_feature_shape: tuple[int, ...]) -> int:
+    """Flat dimension for camera + patch tokens with register tokens dropped."""
+    n_tokens = 1 + (int(aggregator_feature_shape[0]) - VGGT_AGGREGATOR_PATCH_START_IDX)
+    return n_tokens * int(aggregator_feature_shape[-1])
+
+
+def hybrid_feature_dim(wp_pool_size: int = VGGT_DEFAULT_WP_POOL_SIZE) -> int:
+    """Packed hybrid Encoder Module input dimension."""
+    return HYBRID_RGB_DIM + wp_cp_dim(wp_pool_size)
+
+
+HYBRID_FEATURE_DIM = hybrid_feature_dim()
+
+
+def _env_observation(env_render_resolution: int) -> ObservationFormContract:
+    return ObservationFormContract(
+        {
+            "image": ObservationField((3, env_render_resolution, env_render_resolution), "uint8"),
+            "is_first": ObservationField((), "bool"),
+        }
+    )
+
+
+def _agent_features_observation(shape: tuple[int, ...]) -> ObservationFormContract:
+    return ObservationFormContract(
+        {
+            "features": ObservationField(shape, "float32"),
+            "is_first": ObservationField((), "bool"),
+        }
+    )
+
+
+def _default_encoder_type(feature_kind: VGGTFeatureKind, wp_pool_size: int) -> str:
+    if feature_kind == "wp_cp":
+        return "vggt_wp_cp_64" if wp_pool_size == 64 else "vggt"
+    if feature_kind == "aggregator":
+        return "vggt_aggregator_mlp"
+    if feature_kind == "wp_dense":
+        return "vggt_wp_dense_cnn"
+    if feature_kind == "agg_raw":
+        return "vggt_agg_raw"
+    raise ValueError(f"unknown VGGT feature_kind {feature_kind!r}")
+
+
+def _default_module_cls(encoder_type: str, feature_kind: VGGTFeatureKind) -> type[nn.Module]:
+    if encoder_type == "vggt_aggregator_mlp" or feature_kind == "aggregator":
+        return wm_encoders.VGGTAggregatorMLPEncoder
+    if encoder_type == "vggt_wp_dense_cnn" or feature_kind == "wp_dense":
+        return wm_encoders.WPConvEncoder
+    if encoder_type == "hybrid":
+        return wm_encoders.HybridEncoder
+    return wm_encoders.VGGTEncoder
+
+
+def _vggt_shape_dtype(extractor: Any, feature_kind: VGGTFeatureKind) -> tuple[tuple[int, ...], str]:
+    if feature_kind == "wp_cp":
+        k = int(getattr(extractor, "wp_pool_size", VGGT_DEFAULT_WP_POOL_SIZE))
+        return (wp_cp_dim(k),), "float32"
+    if feature_kind == "aggregator":
+        return (aggregator_pooled_dim(tuple(extractor.aggregator_feature_shape)),), "float32"
+    if feature_kind == "wp_dense":
+        image_size = int(getattr(extractor, "image_size", VGGT_IMAGE_SIZE))
+        return (3, image_size, image_size), "float16"
+    if feature_kind == "agg_raw":
+        return (aggregator_raw_dim(tuple(extractor.aggregator_feature_shape)),), "float16"
+    raise ValueError(f"unknown VGGT feature_kind {feature_kind!r}")
+
+
+def build_vggt_contract(
+    extractor: Any,
+    *,
+    feature_kind: VGGTFeatureKind,
+    env_render_resolution: int | None = None,
+    encoder_type: str | None = None,
+    encoder_module_cls: type[nn.Module] | None = None,
+    agent_overrides: Mapping[str, Any] | None = None,
+    design_notes: str = "",
+) -> EncoderInputContract:
+    """Build the Encoder Input Contract for one VGGT readout variant."""
+    wp_pool_size = int(getattr(extractor, "wp_pool_size", VGGT_DEFAULT_WP_POOL_SIZE))
+    resolved_encoder_type = encoder_type or _default_encoder_type(feature_kind, wp_pool_size)
+    shape, dtype = _vggt_shape_dtype(extractor, feature_kind)
+    replay_field = ObservationField(shape, dtype, normalize_on_sample=False)
+    encoder_field = ObservationField(shape, "float32", normalize_on_sample=False)
+    resolved_overrides = dict(
+        agent_overrides
+        if agent_overrides is not None
+        else _DEFAULT_AGENT_OVERRIDES.get(resolved_encoder_type, {})
+    )
+
+    return EncoderInputContract(
+        observation_preparation_type=resolved_encoder_type,
+        encoder_type=resolved_encoder_type,
+        env_render_resolution=int(env_render_resolution or getattr(extractor, "image_size", VGGT_IMAGE_SIZE)),
+        encoder_module_cls=encoder_module_cls or _default_module_cls(resolved_encoder_type, feature_kind),
+        env_observation=_env_observation(int(env_render_resolution or getattr(extractor, "image_size", VGGT_IMAGE_SIZE))),
+        replay_observation=ObservationFormContract(replay_field),
+        agent_observation=_agent_features_observation(shape),
+        encoder_input=ObservationFormContract(encoder_field),
+        decoder_target=None,
+        agent_overrides=resolved_overrides,
+        design_notes=design_notes,
+    )
+
+
+def build_hybrid_contract(
+    extractor: Any,
+    *,
+    env_render_resolution: int | None = None,
+    encoder_module_cls: type[nn.Module] | None = None,
+    agent_overrides: Mapping[str, Any] | None = None,
+    design_notes: str = "",
+) -> EncoderInputContract:
+    """Build the Encoder Input Contract for the RGB + VGGT WP/CP hybrid."""
+    wp_pool_size = int(getattr(extractor, "wp_pool_size", VGGT_DEFAULT_WP_POOL_SIZE))
+    wp_cp_shape = (wp_cp_dim(wp_pool_size),)
+    render_resolution = int(env_render_resolution or getattr(extractor, "image_size", VGGT_IMAGE_SIZE))
+
+    replay_fields = {
+        HYBRID_IMAGE_KEY: ObservationField(HYBRID_IMAGE_SHAPE, "uint8", normalize_on_sample=False),
+        HYBRID_WP_CP_KEY: ObservationField(wp_cp_shape, "float32", normalize_on_sample=False),
+    }
+    agent_fields = {
+        HYBRID_IMAGE_KEY: ObservationField(HYBRID_IMAGE_SHAPE, "uint8", normalize_on_sample=False),
+        HYBRID_WP_CP_KEY: ObservationField(wp_cp_shape, "float32", normalize_on_sample=False),
+        "is_first": ObservationField((), "bool"),
+    }
+
+    return EncoderInputContract(
+        observation_preparation_type="hybrid",
+        encoder_type="hybrid",
+        env_render_resolution=render_resolution,
+        encoder_module_cls=encoder_module_cls or wm_encoders.HybridEncoder,
+        env_observation=_env_observation(render_resolution),
+        replay_observation=ObservationFormContract(replay_fields),
+        agent_observation=ObservationFormContract(agent_fields),
+        encoder_input=ObservationFormContract(ObservationField((hybrid_feature_dim(wp_pool_size),), "float32")),
+        decoder_target=ObservationFormContract(ObservationField(HYBRID_IMAGE_SHAPE, "float32")),
+        agent_overrides=dict(agent_overrides if agent_overrides is not None else _DEFAULT_AGENT_OVERRIDES["hybrid"]),
+        design_notes=design_notes,
+    )

--- a/tests/r2dreamer/launch/test_encoders.py
+++ b/tests/r2dreamer/launch/test_encoders.py
@@ -9,7 +9,7 @@ import pytest
 from src.r2dreamer.adapters import ObsAdapter, VGGTObsAdapter
 from src.r2dreamer.adapters.hybrid_adapter import HybridObsAdapter
 from src.r2dreamer.obs_batch import HYBRID_IMAGE_KEY, HYBRID_WP_CP_KEY
-from src.r2dreamer.observation_preparation import CNNObservationPreparation
+from src.r2dreamer.observation_preparation import CNNObservationPreparation, EncoderInputContract
 from src.r2dreamer.encoders import (
     CNNEncoder,
     EncoderSpec,
@@ -118,7 +118,13 @@ class TestVGGTEncoderConfiguration:
             "src.r2dreamer.encoders.specs.VGGTFeatureExtractor", FakeExtractor
         )
 
-        spec = VGGTEncoder(resolution=518).spec()
+        enc = VGGTEncoder(resolution=518)
+        adapter = enc.make_adapter()
+        spec = enc.spec()
+
+        assert isinstance(adapter.contract, EncoderInputContract)
+        assert adapter.contract.encoder_input.shape == (4116,)
+        assert adapter.contract.replay_observation.shape == (4116,)
         assert spec.encoder_type == "vggt"
         assert spec.obs_shape == (4116,)
         assert spec.env_render_resolution == 518
@@ -142,6 +148,9 @@ class TestVGGTEncoderConfiguration:
         adapter = enc.make_adapter()
         spec = enc.spec()
 
+        assert isinstance(adapter.contract, EncoderInputContract)
+        assert adapter.contract.encoder_type == "vggt_aggregator_mlp"
+        assert adapter.contract.encoder_input.shape == (3 * 128,)
         # Adapter stores [cam | mean_patches | max_patches] flat: 3 * embed_dim.
         assert adapter.buffer_shape == (3 * 128,)
         assert adapter.buffer_dtype == "float32"
@@ -175,6 +184,9 @@ class TestVGGTEncoderConfiguration:
         adapter = enc.make_adapter()
         spec = enc.spec()
 
+        assert isinstance(adapter.contract, EncoderInputContract)
+        assert adapter.contract.encoder_type == "vggt_wp_dense_cnn"
+        assert adapter.contract.replay_observation.dtype == "float16"
         # Dense WP is stored channel-first as a (3, 518, 518) float16 image.
         assert adapter.buffer_shape == (3, 518, 518)
         assert adapter.buffer_dtype == "float16"
@@ -235,6 +247,9 @@ class TestVGGTEncoderConfiguration:
         adapter = enc.make_adapter()
         spec = enc.spec()
 
+        assert isinstance(adapter.contract, EncoderInputContract)
+        assert adapter.contract.encoder_type == "vggt_wp_cp_64"
+        assert adapter.contract.encoder_input.shape == (12297,)
         # 64x64 WP grid: obs = 64*64*3 + 9 = 12297 (vs 4116 at 37x37).
         assert enc.wp_pool_size == 64
         assert adapter.buffer_shape == (64 * 64 * 3 + 9,)
@@ -347,7 +362,12 @@ class TestHybridEncoder:
             "src.r2dreamer.encoders.specs.VGGTFeatureExtractor", FakeExtractor
         )
 
-        spec = HybridEncoder().spec()
+        enc = HybridEncoder()
+        adapter = enc.make_adapter()
+        spec = enc.spec()
+        assert isinstance(adapter.contract, EncoderInputContract)
+        assert adapter.contract.encoder_type == "hybrid"
+        assert adapter.contract.decoder_target is not None
         assert isinstance(spec, EncoderSpec)
         assert spec.encoder_type == "hybrid"
         assert spec.obs_shape == (16404,)

--- a/tests/r2dreamer/test_observation_preparation.py
+++ b/tests/r2dreamer/test_observation_preparation.py
@@ -4,8 +4,14 @@ import numpy as np
 
 from src.r2dreamer.observation_preparation import (
     CNNObservationPreparation,
+    HYBRID_FEATURE_DIM,
+    HYBRID_IMAGE_SHAPE,
+    VGGTFeatureKind,
+    build_hybrid_contract,
+    build_vggt_contract,
     PreparedObservation,
 )
+from src.r2dreamer.obs_batch import HYBRID_IMAGE_KEY, HYBRID_WP_CP_KEY
 from src.r2dreamer.world_model import encoders as wm_encoders
 
 
@@ -53,3 +59,77 @@ class TestCNNObservationPreparation:
         np.testing.assert_array_equal(replay_obs, image)
         assert agent_obs["image"] is image
         assert agent_obs["is_first"] is False
+
+
+class TestVGGTObservationPreparationContracts:
+    class _Extractor:
+        aggregator_feature_shape = (86, 128)
+        image_size = 518
+        wp_pool_size = 37
+
+    def test_wp_cp_contract_declares_raw_env_replay_and_encoder_forms(self):
+        contract = build_vggt_contract(self._Extractor(), feature_kind="wp_cp")
+
+        assert contract.observation_preparation_type == "vggt"
+        assert contract.encoder_type == "vggt"
+        assert contract.env_render_resolution == 518
+        assert contract.encoder_module_cls is wm_encoders.VGGTEncoder
+        assert contract.env_observation.fields["image"].shape == (3, 518, 518)
+        assert contract.env_observation.fields["image"].dtype == "uint8"
+        assert contract.env_observation.fields["is_first"].dtype == "bool"
+
+        replay = contract.replay_observation
+        assert replay.shape == (37 * 37 * 3 + 9,)
+        assert replay.dtype == "float32"
+        assert replay.normalize_on_sample is False
+        assert contract.agent_observation.fields["features"].shape == replay.shape
+        assert contract.encoder_input.shape == replay.shape
+        assert contract.decoder_target is None
+        assert contract.agent_overrides == {"buffer_capacity": 1_000_000}
+
+    def test_variants_derive_contract_shapes_from_extractor_metadata(self):
+        cases: list[tuple[VGGTFeatureKind, str, tuple[int, ...], str, type]] = [
+            ("aggregator", "vggt_aggregator_mlp", (3 * 128,), "float32", wm_encoders.VGGTAggregatorMLPEncoder),
+            ("wp_dense", "vggt_wp_dense_cnn", (3, 518, 518), "float16", wm_encoders.WPConvEncoder),
+        ]
+
+        for feature_kind, encoder_type, shape, dtype, module_cls in cases:
+            contract = build_vggt_contract(self._Extractor(), feature_kind=feature_kind)
+
+            assert contract.observation_preparation_type == encoder_type
+            assert contract.encoder_type == encoder_type
+            assert contract.encoder_module_cls is module_cls
+            assert contract.replay_observation.shape == shape
+            assert contract.replay_observation.dtype == dtype
+            assert contract.encoder_input.shape == shape
+            assert contract.decoder_target is None
+
+    def test_wp_cp_64_contract_is_resolution_ablation(self):
+        class Extractor64(self._Extractor):
+            wp_pool_size = 64
+
+        contract = build_vggt_contract(Extractor64(), feature_kind="wp_cp")
+
+        assert contract.observation_preparation_type == "vggt_wp_cp_64"
+        assert contract.encoder_type == "vggt_wp_cp_64"
+        assert contract.replay_observation.shape == (64 * 64 * 3 + 9,)
+        assert contract.encoder_input.shape == (64 * 64 * 3 + 9,)
+        assert contract.encoder_module_cls is wm_encoders.VGGTEncoder
+
+    def test_hybrid_contract_declares_structured_replay_and_decoder_target(self):
+        contract = build_hybrid_contract(self._Extractor())
+
+        assert contract.observation_preparation_type == "hybrid"
+        assert contract.encoder_type == "hybrid"
+        assert contract.env_render_resolution == 518
+        assert contract.encoder_module_cls is wm_encoders.HybridEncoder
+        assert contract.env_observation.fields["image"].shape == (3, 518, 518)
+        assert contract.replay_observation.fields[HYBRID_IMAGE_KEY].shape == HYBRID_IMAGE_SHAPE
+        assert contract.replay_observation.fields[HYBRID_IMAGE_KEY].dtype == "uint8"
+        assert contract.replay_observation.fields[HYBRID_WP_CP_KEY].shape == (37 * 37 * 3 + 9,)
+        assert contract.replay_observation.fields[HYBRID_WP_CP_KEY].dtype == "float32"
+        assert contract.agent_observation.fields[HYBRID_IMAGE_KEY].shape == HYBRID_IMAGE_SHAPE
+        assert contract.agent_observation.fields[HYBRID_WP_CP_KEY].shape == (37 * 37 * 3 + 9,)
+        assert contract.encoder_input.shape == (HYBRID_FEATURE_DIM,)
+        assert contract.decoder_target is not None
+        assert contract.decoder_target.shape == HYBRID_IMAGE_SHAPE


### PR DESCRIPTION
## What changed

- Added VGGT-family Observation Preparation contract builders for WP/CP, pooled aggregator, dense world-points, WP/CP-64, and hybrid modes.
- Routed `VGGTObsAdapter` and `HybridObsAdapter` through `EncoderInputContract` for replay dtype/shape, normalization, agent input shape, module class, overrides, and design notes.
- Passed launcher variant metadata into adapters so `Encoder.spec()` resolves VGGT/hybrid variants from the contract path.
- Added contract and launcher tests for VGGT/hybrid variants.

## Why

3D-82 asks to route VGGT Observation Preparation variants through the contract so replay forms, agent-ready forms, and Encoder Module input metadata stay aligned instead of being duplicated across adapters and launcher specs.

## Linear issue

https://linear.app/3d-wm-objectnav/issue/3D-82/3d-route-vggt-observation-preparation-variants-through-the-contract

## Acceptance criteria checked

- VGGT WP/CP contract declares raw env observation, replay observation, agent observation, encoder input, module class, and overrides.
- VGGT aggregator/dense/WP-CP-64 variants derive contract shapes from extractor metadata.
- Hybrid contract declares structured replay fields and RGB decoder target.
- Launcher specs for VGGT/hybrid resolve through adapter contracts.
- Existing VGGT adapter behavior remains covered by CPU fake-extractor tests.

## Verification

- `JAX_PLATFORMS=cpu .venv/bin/python -m pytest tests/r2dreamer/test_observation_preparation.py tests/r2dreamer/launch/test_encoders.py tests/r2dreamer/launch/test_registries.py tests/r2dreamer/launch/test_presets.py tests/r2dreamer/test_trainer.py -q` → `53 passed, 2 skipped`
- `JAX_PLATFORMS=cpu .venv/bin/python -m pytest tests/r2dreamer/test_vggt_encoder.py -q` → `23 passed`
- `.venv/bin/python -m ruff check src/r2dreamer/observation_preparation/vggt.py src/r2dreamer/adapters/vggt_adapter.py src/r2dreamer/adapters/hybrid_adapter.py src/r2dreamer/encoders/specs.py tests/r2dreamer/test_observation_preparation.py tests/r2dreamer/launch/test_encoders.py` → `All checks passed!`

## Screenshots / Loom / preview URL

Not applicable.

## Risk

Medium: changes central VGGT/hybrid adapter metadata routing, but preserves transform behavior and covers variants with fake-extractor tests.

## How to test

Run the verification commands above from the PR branch worktree.

## Intentionally not done

- Did not rename public launcher CLI from `encoder` to `observation-preparation`; that is separate launcher-language migration work.
- Did not run GPU VGGT tests; this issue is contract routing and is covered with CPU fake extractors.

## Agent involvement

Implemented with an AI coding assistant under user direction.

## Follow-up issues created

None.
