### PR TITLE
3D-84: Persist encoder contract snapshots

### DIFF
--- a/src/r2dreamer/AGENTS.md
+++ b/src/r2dreamer/AGENTS.md
@@ -115,7 +115,8 @@ train_step(batch):
   `actor`, `critic`, optional `decoder`); modules are stateless Flax `nn.Module`s.
 - **JIT + PRNG.** `train_step`/`act` are `jax.jit`-compiled; always `jax.random.split` keys.
   `jax.lax.stop_gradient` gates imagination, the Barlow embed, and the prior in KL.
-- **Checkpoints are pickle** of `params + opt_state + slow_critic_params + ema_state + step`;
+- **Checkpoints are pickle** of `params + opt_state + slow_critic_params + ema_state + step`
+  plus a JSON-serializable `encoder_input_contract` snapshot when available;
   `_CheckpointUnpickler` tolerates moved/renamed optimiser classes.
 
 ## Dependencies

--- a/src/r2dreamer/agent.py
+++ b/src/r2dreamer/agent.py
@@ -25,6 +25,10 @@ import numpy as np
 import optax
 
 from .config import R2DreamerConfig
+from .observation_preparation.contracts import (
+    normalize_encoder_module_kwargs,
+    recover_encoder_input_contract,
+)
 from .world_model.rssm import R2RSSM
 from .world_model.encoders import (
     ConvEncoder,
@@ -147,7 +151,17 @@ def _validate_encoder_config(cfg: R2DreamerConfig, cls) -> None:
         )
 
 
+def _contract_encoder_kwargs(cfg: R2DreamerConfig) -> dict[str, Any]:
+    snapshot = getattr(cfg, "encoder_input_contract", None)
+    if snapshot is None:
+        return {}
+    return normalize_encoder_module_kwargs(snapshot.get("encoder_module_kwargs", {}))
+
+
 def _make_conv_encoder(cfg: R2DreamerConfig):
+    kwargs = _contract_encoder_kwargs(cfg)
+    if kwargs:
+        return ConvEncoder(**kwargs)
     return ConvEncoder(
         depth=cfg.encoder_depth,
         kernel_size=cfg.encoder_kernel,
@@ -158,6 +172,9 @@ def _make_conv_encoder(cfg: R2DreamerConfig):
 def _make_wp_conv_encoder(cfg: R2DreamerConfig):
     # Full-res world-point map -> conv stack -> embed_dim (3D-53). Reuses the
     # RGB conv hyperparameters; symlog (not /255) handles the metric XYZ range.
+    kwargs = _contract_encoder_kwargs(cfg)
+    if kwargs:
+        return WPConvEncoder(**kwargs)
     return WPConvEncoder(
         embed_dim=cfg.vggt_embed_dim,
         depth=cfg.encoder_depth,
@@ -181,6 +198,9 @@ def _make_hybrid_encoder(cfg: R2DreamerConfig):
             f"{HYBRID_VGGT_DIM}, got obs_shape={cfg.obs_shape}, "
             f"vggt_feature_dim={cfg.vggt_feature_dim}"
         )
+    kwargs = _contract_encoder_kwargs(cfg)
+    if kwargs:
+        return WMHybridEncoder(**kwargs)
     return WMHybridEncoder(
         cnn_depth=cfg.encoder_depth,
         cnn_kernel=cfg.encoder_kernel,
@@ -193,6 +213,9 @@ def _make_hybrid_encoder(cfg: R2DreamerConfig):
 
 def _make_mlp_encoder(cfg: R2DreamerConfig, cls):
     # wp_cp + aggregator MLP encoders: depth from cfg.vggt_mlp_layers (3D-52).
+    kwargs = _contract_encoder_kwargs(cfg)
+    if kwargs:
+        return cls(**kwargs)
     return cls(
         embed_dim=cfg.vggt_embed_dim,
         hidden=cfg.vggt_embed_dim,
@@ -293,7 +316,7 @@ class R2DreamerAgent:
         cls,
         path: str | Path,
         *,
-        obs_shape: tuple[int, ...],
+        obs_shape: tuple[int, ...] | None = None,
         num_actions: int,
         seed: int,
         **config_kwargs: Any,
@@ -302,16 +325,31 @@ class R2DreamerAgent:
 
         Extra ``config_kwargs`` flow into :class:`R2DreamerConfig` so callers
         that need ``encoder_type`` / ``encoder_module_cls`` (e.g. evaluate)
-        can pass them through. The loaded checkpoint's ``step`` is stashed on
-        the returned agent as ``checkpoint_step`` (``-1`` if absent).
+        can pass them through. When the checkpoint contains a durable Encoder
+        Input Contract snapshot, missing encoder config is recovered from it.
+        The loaded checkpoint's ``step`` is stashed on the returned agent as
+        ``checkpoint_step`` (``-1`` if absent).
         """
+        ckpt = load_policy_checkpoint(path)
+        contract_snapshot = ckpt.get("encoder_input_contract")
+        if contract_snapshot is not None:
+            contract = recover_encoder_input_contract(contract_snapshot)
+            if obs_shape is None:
+                obs_shape = contract.encoder_input.shape
+            config_kwargs.setdefault("encoder_type", contract.encoder_type)
+            config_kwargs.setdefault("encoder_module_cls", contract.encoder_module_cls)
+            config_kwargs.setdefault("encoder_input_contract", contract_snapshot)
+        if obs_shape is None:
+            raise ValueError(
+                "obs_shape must be provided when checkpoint has no Encoder Input "
+                "Contract snapshot"
+            )
         config = R2DreamerConfig(
             obs_shape=obs_shape, num_actions=num_actions, **config_kwargs,
         )
         rng_key = jax.random.PRNGKey(seed)
         rng_key, init_key = jax.random.split(rng_key)
         agent = cls(config, init_key)
-        ckpt = load_policy_checkpoint(path)
         agent.params = jax.tree.map(jnp.asarray, ckpt["params"])
         agent.slow_critic_params = jax.tree.map(jnp.asarray, ckpt["slow_critic_params"])
         agent.checkpoint_step = int(ckpt.get("step", -1))

--- a/src/r2dreamer/config.py
+++ b/src/r2dreamer/config.py
@@ -53,6 +53,10 @@ class R2DreamerConfig:
     decoder: bool = False         # build a ConvDecoder + add a reconstruction loss
     scale_decoder: float = 1.0    # weight of the reconstruction MSE in total loss
     design_notes: str = ""
+    # JSON-serializable Encoder Input Contract snapshot persisted to durable
+    # run metadata. Runtime config may still hold encoder_module_cls; snapshots
+    # use stable module names, shapes, dtypes, booleans, and overrides.
+    encoder_input_contract: dict[str, Any] | None = None
 
     # --- MLP heads ---
     mlp_units: int = 256

--- a/src/r2dreamer/encoders/specs.py
+++ b/src/r2dreamer/encoders/specs.py
@@ -38,6 +38,7 @@ class EncoderSpec:
     module_cls: type[nn.Module]
     agent_overrides: dict[str, Any] = field(default_factory=dict)
     design_notes: str = ""
+    contract_snapshot: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -209,6 +210,7 @@ class Encoder(ABC):
                 module_cls=contract.encoder_module_cls,
                 agent_overrides=dict(contract.agent_overrides),
                 design_notes=contract.design_notes,
+                contract_snapshot=contract.to_snapshot(),
             )
         return EncoderSpec(
             obs_shape=adapter.encoder_obs_shape,

--- a/src/r2dreamer/launch/evaluate.py
+++ b/src/r2dreamer/launch/evaluate.py
@@ -17,6 +17,7 @@ from src.r2dreamer.launch.registries import env_registry
 from src.r2dreamer.launch._helpers import resolve_curriculum_path
 from src.r2dreamer.agent import R2DreamerAgent
 from src.r2dreamer.config import R2DreamerConfig
+from src.r2dreamer.observation_preparation import recover_encoder_input_contract
 from src.shared.video_utils import (
     compose_frame,
     log_episode_video,
@@ -145,11 +146,21 @@ def _load_arch_overrides_from_manifest(eff_checkpoint: str | None) -> dict:
         "mlp_layers_cont", "mlp_layers_actor", "mlp_layers_critic",
         "twohot_bins", "decoder",
     )
-    return {
+    overrides = {
         key: tuple(saved[key]) if key == "encoder_mults" else saved[key]
         for key in arch_fields
         if key in saved
     }
+    contract_snapshot = saved.get("encoder_input_contract")
+    if contract_snapshot is not None:
+        contract = recover_encoder_input_contract(contract_snapshot)
+        overrides.update(
+            encoder_type=contract.encoder_type,
+            encoder_module_cls=contract.encoder_module_cls,
+            obs_shape=contract.encoder_input.shape,
+            encoder_input_contract=contract_snapshot,
+        )
+    return overrides
 
 
 def _agent_config_kwargs(encoder_spec, *, args, eff_checkpoint: str | None) -> dict:

--- a/src/r2dreamer/launch/train.py
+++ b/src/r2dreamer/launch/train.py
@@ -129,7 +129,12 @@ def _make_agent_config(
     *, args: Any, encoder_spec: Any, num_actions: int, output_dir: str,
     agent_overrides: dict[str, Any], config_cls: type,
 ):
-    return config_cls(
+    from src.r2dreamer.observation_preparation import (
+        encoder_module_kwargs_from_config,
+        recover_encoder_input_contract,
+    )
+
+    config = config_cls(
         encoder_type=encoder_spec.encoder_type,
         encoder_module_cls=encoder_spec.module_cls,
         obs_shape=encoder_spec.obs_shape,
@@ -141,8 +146,16 @@ def _make_agent_config(
         log_every=args.log_every,
         logdir=output_dir,
         design_notes=encoder_spec.design_notes,
+        encoder_input_contract=encoder_spec.contract_snapshot,
         **agent_overrides,
     )
+    if config.encoder_input_contract is not None:
+        contract = recover_encoder_input_contract(config.encoder_input_contract)
+        config.encoder_input_contract = dict(config.encoder_input_contract)
+        config.encoder_input_contract["encoder_module_kwargs"] = (
+            encoder_module_kwargs_from_config(config, contract.encoder_module_cls)
+        )
+    return config
 
 
 def _make_trainer_config(

--- a/src/r2dreamer/observation_preparation/__init__.py
+++ b/src/r2dreamer/observation_preparation/__init__.py
@@ -5,6 +5,10 @@ from src.r2dreamer.observation_preparation.contracts import (
     ObservationField,
     ObservationFormContract,
     PreparedObservation,
+    encoder_module_kwargs_from_config,
+    module_class_path,
+    normalize_encoder_module_kwargs,
+    recover_encoder_input_contract,
 )
 from src.r2dreamer.observation_preparation.cnn import (
     CNN_IMAGE_SHAPE,
@@ -28,6 +32,10 @@ __all__ = [
     "ObservationField",
     "ObservationFormContract",
     "PreparedObservation",
+    "encoder_module_kwargs_from_config",
+    "module_class_path",
+    "normalize_encoder_module_kwargs",
+    "recover_encoder_input_contract",
     "VGGTFeatureKind",
     "VGGT_IMAGE_SHAPE",
     "build_hybrid_contract",

--- a/src/r2dreamer/observation_preparation/contracts.py
+++ b/src/r2dreamer/observation_preparation/contracts.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from importlib import import_module
 from typing import Any
 
 import flax.linen as nn
@@ -17,6 +18,72 @@ import numpy as np
 
 
 ObservationValue = np.ndarray | dict[str, np.ndarray]
+ContractSnapshot = dict[str, Any]
+
+
+def module_class_path(cls: type) -> str:
+    """Return a stable import path for durable contract snapshots."""
+    return f"{cls.__module__}.{cls.__qualname__}"
+
+
+def _import_class(path: str) -> type:
+    module_name, _, class_name = path.rpartition(".")
+    if not module_name or not class_name:
+        raise ValueError(f"invalid class path {path!r}")
+    module = import_module(module_name)
+    resolved: Any = module
+    for part in class_name.split("."):
+        resolved = getattr(resolved, part)
+    if not isinstance(resolved, type):
+        raise TypeError(f"{path!r} did not resolve to a class")
+    return resolved
+
+
+def _tuple_value(config: Any, name: str) -> tuple[int, ...]:
+    return tuple(getattr(config, name))
+
+
+def encoder_module_kwargs_from_config(
+    config: Any, encoder_module_cls: type,
+) -> dict[str, Any]:
+    """Resolve Encoder Module constructor kwargs from an effective config."""
+    class_name = encoder_module_cls.__name__
+    if class_name == "ConvEncoder":
+        return {
+            "depth": int(config.encoder_depth),
+            "kernel_size": int(config.encoder_kernel),
+            "mults": _tuple_value(config, "encoder_mults"),
+        }
+    if class_name == "WPConvEncoder":
+        return {
+            "embed_dim": int(config.vggt_embed_dim),
+            "depth": int(config.encoder_depth),
+            "kernel_size": int(config.encoder_kernel),
+            "mults": _tuple_value(config, "encoder_mults"),
+        }
+    if class_name == "HybridEncoder":
+        return {
+            "cnn_depth": int(config.encoder_depth),
+            "cnn_kernel": int(config.encoder_kernel),
+            "cnn_mults": _tuple_value(config, "encoder_mults"),
+            "vggt_embed_dim": int(config.vggt_embed_dim),
+            "mlp_hidden": int(config.mlp_vggt_hidden),
+            "mlp_layers": int(config.mlp_vggt_layers),
+        }
+    return {
+        "embed_dim": int(config.vggt_embed_dim),
+        "hidden": int(config.vggt_embed_dim),
+        "num_layers": int(config.vggt_mlp_layers),
+    }
+
+
+def normalize_encoder_module_kwargs(kwargs: Mapping[str, Any]) -> dict[str, Any]:
+    """Recover tuple-valued constructor kwargs after JSON round-trips."""
+    normalized = dict(kwargs)
+    for key in ("mults", "cnn_mults"):
+        if key in normalized:
+            normalized[key] = tuple(normalized[key])
+    return normalized
 
 
 @dataclass(frozen=True)
@@ -26,6 +93,21 @@ class ObservationField:
     shape: tuple[int, ...]
     dtype: str
     normalize_on_sample: bool = False
+
+    def to_snapshot(self) -> ContractSnapshot:
+        return {
+            "shape": list(self.shape),
+            "dtype": self.dtype,
+            "normalize_on_sample": self.normalize_on_sample,
+        }
+
+    @classmethod
+    def from_snapshot(cls, snapshot: Mapping[str, Any]) -> "ObservationField":
+        return cls(
+            shape=tuple(int(dim) for dim in snapshot["shape"]),
+            dtype=str(snapshot["dtype"]),
+            normalize_on_sample=bool(snapshot.get("normalize_on_sample", False)),
+        )
 
 
 @dataclass(frozen=True)
@@ -71,6 +153,30 @@ class ObservationFormContract:
             }
         return self.fields.normalize_on_sample
 
+    def to_snapshot(self) -> ContractSnapshot:
+        if isinstance(self.fields, Mapping):
+            return {
+                "kind": "structured",
+                "fields": {
+                    key: field.to_snapshot() for key, field in self.fields.items()
+                },
+            }
+        return {"kind": "single", "field": self.fields.to_snapshot()}
+
+    @classmethod
+    def from_snapshot(
+        cls, snapshot: Mapping[str, Any],
+    ) -> "ObservationFormContract":
+        kind = snapshot["kind"]
+        if kind == "single":
+            return cls(ObservationField.from_snapshot(snapshot["field"]))
+        if kind == "structured":
+            return cls({
+                key: ObservationField.from_snapshot(field_snapshot)
+                for key, field_snapshot in snapshot["fields"].items()
+            })
+        raise ValueError(f"unknown observation form snapshot kind {kind!r}")
+
 
 @dataclass(frozen=True)
 class EncoderInputContract:
@@ -86,7 +192,73 @@ class EncoderInputContract:
     encoder_input: ObservationFormContract
     decoder_target: ObservationFormContract | None
     agent_overrides: Mapping[str, Any] = field(default_factory=dict)
+    encoder_module_kwargs: Mapping[str, Any] = field(default_factory=dict)
     design_notes: str = ""
+
+    def to_snapshot(self) -> ContractSnapshot:
+        return {
+            "version": 1,
+            "observation_preparation_type": self.observation_preparation_type,
+            "encoder_type": self.encoder_type,
+            "env_render_resolution": self.env_render_resolution,
+            "encoder_module": module_class_path(self.encoder_module_cls),
+            "env_observation": self.env_observation.to_snapshot(),
+            "replay_observation": self.replay_observation.to_snapshot(),
+            "agent_observation": self.agent_observation.to_snapshot(),
+            "encoder_input": self.encoder_input.to_snapshot(),
+            "decoder_target": (
+                None if self.decoder_target is None else self.decoder_target.to_snapshot()
+            ),
+            "agent_overrides": dict(self.agent_overrides),
+            "encoder_module_kwargs": dict(self.encoder_module_kwargs),
+            "design_notes": self.design_notes,
+        }
+
+    @classmethod
+    def from_snapshot(
+        cls, snapshot: Mapping[str, Any],
+    ) -> "EncoderInputContract":
+        if int(snapshot.get("version", 1)) != 1:
+            raise ValueError(
+                f"unsupported Encoder Input Contract snapshot version "
+                f"{snapshot.get('version')!r}"
+            )
+        decoder_target = snapshot.get("decoder_target")
+        return cls(
+            observation_preparation_type=str(snapshot["observation_preparation_type"]),
+            encoder_type=str(snapshot["encoder_type"]),
+            env_render_resolution=int(snapshot["env_render_resolution"]),
+            encoder_module_cls=_import_class(str(snapshot["encoder_module"])),
+            env_observation=ObservationFormContract.from_snapshot(
+                snapshot["env_observation"]
+            ),
+            replay_observation=ObservationFormContract.from_snapshot(
+                snapshot["replay_observation"]
+            ),
+            agent_observation=ObservationFormContract.from_snapshot(
+                snapshot["agent_observation"]
+            ),
+            encoder_input=ObservationFormContract.from_snapshot(
+                snapshot["encoder_input"]
+            ),
+            decoder_target=(
+                None
+                if decoder_target is None
+                else ObservationFormContract.from_snapshot(decoder_target)
+            ),
+            agent_overrides=dict(snapshot.get("agent_overrides", {})),
+            encoder_module_kwargs=normalize_encoder_module_kwargs(
+                snapshot.get("encoder_module_kwargs", {})
+            ),
+            design_notes=str(snapshot.get("design_notes", "")),
+        )
+
+
+def recover_encoder_input_contract(
+    snapshot: Mapping[str, Any],
+) -> EncoderInputContract:
+    """Recover a runtime Encoder Input Contract from its durable snapshot."""
+    return EncoderInputContract.from_snapshot(snapshot)
 
 
 @dataclass(frozen=True)

--- a/src/r2dreamer/trainer.py
+++ b/src/r2dreamer/trainer.py
@@ -24,6 +24,12 @@ from src.buffer.replay_buffer import BufferConfig, ReplayBuffer
 from src.shared.video_utils import compose_frame, log_episode_video, render_topdown_frame
 from src.r2dreamer.adapters import ObsAdapter  # noqa: F401 — re-exported for callers
 from src.r2dreamer.manifest import write_manifest_end, write_manifest_start
+from src.r2dreamer.observation_preparation import (
+    CNNObservationPreparation,
+    encoder_module_kwargs_from_config,
+    module_class_path,
+    recover_encoder_input_contract,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -34,6 +40,42 @@ class Env(Protocol):
     def reset(self) -> dict: ...
     def step(self, action: int) -> dict: ...
     def close(self) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# Serializable metadata snapshots
+# ---------------------------------------------------------------------------
+
+def config_snapshot(config: Any) -> dict[str, Any]:
+    """Return a JSON-serializable run config snapshot for manifests/W&B."""
+    snapshot = (
+        asdict(config)
+        if is_dataclass(config)
+        else dict(vars(config)) if hasattr(config, "__dict__") else {}
+    )
+    encoder_module_cls = snapshot.pop("encoder_module_cls", None)
+    runtime_cls = getattr(config, "encoder_module_cls", None)
+    if runtime_cls is not None:
+        snapshot["encoder_module"] = module_class_path(runtime_cls)
+    elif encoder_module_cls is not None:
+        snapshot["encoder_module"] = str(encoder_module_cls)
+    snapshot["encoder_input_contract"] = encoder_input_contract_snapshot(config)
+    return snapshot
+
+
+def encoder_input_contract_snapshot(config: Any) -> dict[str, Any] | None:
+    """Extract or derive the durable Encoder Input Contract snapshot from config."""
+    snapshot = getattr(config, "encoder_input_contract", None)
+    if snapshot is None:
+        if getattr(config, "encoder_type", None) != "cnn":
+            return None
+        snapshot = CNNObservationPreparation().contract.to_snapshot()
+    snapshot = dict(snapshot)
+    contract = recover_encoder_input_contract(snapshot)
+    snapshot["encoder_module_kwargs"] = encoder_module_kwargs_from_config(
+        config, contract.encoder_module_cls,
+    )
+    return snapshot
 
 
 # ---------------------------------------------------------------------------
@@ -77,6 +119,9 @@ def save_checkpoint(agent: Any, step: int, output_dir: str) -> str:
         "slow_critic_params": jax.tree.map(np.array, agent.slow_critic_params),
         "ema_state": jax.tree.map(np.array, agent.ema_state),
     }
+    contract_snapshot = encoder_input_contract_snapshot(agent.cfg)
+    if contract_snapshot is not None:
+        data["encoder_input_contract"] = contract_snapshot
     with open(path, "wb") as f:
         pickle.dump(data, f)
     print(f"Checkpoint saved: {path}")
@@ -292,7 +337,7 @@ class Trainer:
             init_kwargs: dict[str, Any] = dict(
                 project=trainer_config.wandb_project,
                 name=trainer_config.wandb_name,
-                config=vars(agent_config) if hasattr(agent_config, "__dict__") else {},
+                config=config_snapshot(agent_config),
                 tags=trainer_config.wandb_tags,
             )
             if trainer_config.wandb_id is not None:
@@ -309,8 +354,7 @@ class Trainer:
         csv_path = os.path.join(tcfg.output_dir, "metrics.csv")
 
         # MANIFEST.json — emit on start, finalize in finally with run status.
-        cfg_snapshot = asdict(acfg) if is_dataclass(acfg) else dict(vars(acfg))
-        write_manifest_start(Path(tcfg.output_dir), cfg_snapshot)
+        write_manifest_start(Path(tcfg.output_dir), config_snapshot(acfg))
         status = "failed"
 
         rng_key = jax.random.PRNGKey(tcfg.seed)

--- a/tests/r2dreamer/launch/test_encoders.py
+++ b/tests/r2dreamer/launch/test_encoders.py
@@ -1,6 +1,7 @@
 """L2 (construction) and L3 (adapter behavior) tests for Encoder classes."""
 
 import ast
+import json
 from pathlib import Path
 
 import numpy as np
@@ -63,6 +64,8 @@ class TestCNNEncoder:
         assert spec.env_render_resolution == 64
         assert spec.module_cls is wm_encoders.ConvEncoder
         assert spec.agent_overrides == {}
+        assert spec.contract_snapshot["encoder_type"] == "cnn"
+        json.dumps(spec.contract_snapshot)
 
     def test_cnn_adapter_passthrough(self):
         adapter = CNNEncoder().make_adapter()

--- a/tests/r2dreamer/launch/test_evaluate_manifest.py
+++ b/tests/r2dreamer/launch/test_evaluate_manifest.py
@@ -1,9 +1,15 @@
+import json
 from types import SimpleNamespace
 
 import jax
 
 from src.r2dreamer.launch import evaluate as eval_module
-from src.r2dreamer.launch.evaluate import _find_manifest_for_checkpoint
+from src.r2dreamer.launch.evaluate import (
+    _find_manifest_for_checkpoint,
+    _load_arch_overrides_from_manifest,
+)
+from src.r2dreamer.observation_preparation import CNNObservationPreparation
+from src.r2dreamer.world_model import encoders as wm_encoders
 
 
 def test_find_manifest_next_to_checkpoint(tmp_path):
@@ -24,6 +30,26 @@ def test_find_manifest_in_run_dir_for_checkpoints_subdir(tmp_path):
     manifest.write_text('{"config": {}}')
 
     assert _find_manifest_for_checkpoint(ckpt) == manifest.resolve()
+
+
+def test_load_arch_overrides_recovers_encoder_input_contract_from_manifest(tmp_path):
+    ckpt_dir = tmp_path / "checkpoints"
+    ckpt_dir.mkdir()
+    ckpt = ckpt_dir / "step_000000010.pkl"
+    ckpt.touch()
+    manifest = tmp_path / "MANIFEST.json"
+    manifest.write_text(json.dumps({
+        "config": {
+            "encoder_input_contract": CNNObservationPreparation().contract.to_snapshot(),
+        }
+    }))
+
+    overrides = _load_arch_overrides_from_manifest(str(ckpt))
+
+    assert overrides["obs_shape"] == (3, 64, 64)
+    assert overrides["encoder_type"] == "cnn"
+    assert overrides["encoder_module_cls"] is wm_encoders.ConvEncoder
+    assert overrides["encoder_input_contract"]["encoder_module_kwargs"] == {}
 
 
 def test_run_eval_episode_updates_obs_after_nonterminal_step(monkeypatch, tmp_path):

--- a/tests/r2dreamer/test_observation_preparation.py
+++ b/tests/r2dreamer/test_observation_preparation.py
@@ -1,5 +1,7 @@
 """Observation Preparation contract tests."""
 
+import json
+
 import numpy as np
 
 from src.r2dreamer.observation_preparation import (
@@ -10,6 +12,7 @@ from src.r2dreamer.observation_preparation import (
     build_hybrid_contract,
     build_vggt_contract,
     PreparedObservation,
+    recover_encoder_input_contract,
 )
 from src.r2dreamer.obs_batch import HYBRID_IMAGE_KEY, HYBRID_WP_CP_KEY
 from src.r2dreamer.world_model import encoders as wm_encoders
@@ -38,6 +41,26 @@ class TestCNNObservationPreparation:
         assert decoder is not None
         assert decoder.shape == (3, 64, 64)
         assert decoder.dtype == "float32"
+
+    def test_contract_snapshot_is_json_serializable_and_recoverable(self):
+        contract = CNNObservationPreparation().contract
+
+        snapshot = contract.to_snapshot()
+        encoded = json.loads(json.dumps(snapshot))
+        recovered = recover_encoder_input_contract(encoded)
+
+        assert encoded["encoder_module"] == "src.r2dreamer.world_model.encoders.ConvEncoder"
+        assert "encoder_module_cls" not in encoded
+        assert encoded["encoder_module_kwargs"] == {}
+        assert encoded["replay_observation"] == {
+            "kind": "single",
+            "field": {
+                "shape": [3, 64, 64],
+                "dtype": "uint8",
+                "normalize_on_sample": True,
+            },
+        }
+        assert recovered == contract
 
     def test_prepare_env_step_returns_replay_and_agent_observations(self):
         prep = CNNObservationPreparation()

--- a/tests/r2dreamer/test_trainer.py
+++ b/tests/r2dreamer/test_trainer.py
@@ -1,5 +1,6 @@
 """Tests for src/r2dreamer/trainer.py — convert_batch and checkpoint."""
 
+import json
 import os
 import tempfile
 
@@ -18,6 +19,7 @@ from src.r2dreamer.observation_preparation import (
 from src.r2dreamer.trainer import (
     Trainer,
     TrainerConfig,
+    config_snapshot,
     convert_batch,
     load_checkpoint,
     save_checkpoint,
@@ -231,6 +233,91 @@ class TestCheckpoint:
                 lambda a, b: np.testing.assert_allclose(a, b, atol=1e-6),
                 agent.slow_critic_params, data["slow_critic_params"],
             )
+
+    def test_checkpoint_persists_serializable_encoder_input_contract(self):
+        cfg = R2DreamerConfig(obs_shape=(3, 64, 64), num_actions=4)
+        agent = R2DreamerAgent(cfg, jax.random.PRNGKey(42))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = save_checkpoint(agent, step=10, output_dir=tmpdir)
+            data = load_checkpoint(path)
+
+        snapshot = data["encoder_input_contract"]
+        assert snapshot["encoder_module"] == "src.r2dreamer.world_model.encoders.ConvEncoder"
+        assert snapshot["encoder_module_kwargs"] == {
+            "depth": 16,
+            "kernel_size": 5,
+            "mults": (2, 3, 4, 4),
+        }
+        json.dumps(snapshot)
+
+    def test_agent_from_checkpoint_recovers_encoder_contract_when_shape_omitted(self):
+        cfg = R2DreamerConfig(
+            obs_shape=(3, 64, 64),
+            num_actions=4,
+            encoder_input_contract=CNNObservationPreparation().contract.to_snapshot(),
+        )
+        agent = R2DreamerAgent(cfg, jax.random.PRNGKey(42))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = save_checkpoint(agent, step=10, output_dir=tmpdir)
+            recovered = R2DreamerAgent.from_checkpoint(
+                path, num_actions=4, seed=0,
+            )
+
+        assert recovered.cfg.obs_shape == (3, 64, 64)
+        assert recovered.cfg.encoder_type == "cnn"
+        assert recovered.cfg.encoder_input_contract["encoder_type"] == "cnn"
+
+    def test_agent_instantiates_encoder_module_from_contract_kwargs(self):
+        contract = CNNObservationPreparation().contract.to_snapshot()
+        contract["encoder_module_kwargs"] = {
+            "depth": 8,
+            "kernel_size": 3,
+            "mults": (2, 2),
+        }
+        cfg = R2DreamerConfig(
+            obs_shape=(3, 64, 64),
+            num_actions=4,
+            encoder_depth=16,
+            encoder_kernel=5,
+            encoder_mults=(2, 3, 4, 4),
+            encoder_input_contract=contract,
+        )
+
+        agent = R2DreamerAgent(cfg, jax.random.PRNGKey(42))
+
+        assert agent.encoder_mod.depth == 8
+        assert agent.encoder_mod.kernel_size == 3
+        assert agent.encoder_mod.mults == (2, 2)
+
+
+class TestConfigSnapshot:
+    def test_config_snapshot_uses_serializable_encoder_contract_and_module_name(self):
+        cfg = R2DreamerConfig(
+            obs_shape=(3, 64, 64),
+            num_actions=4,
+            encoder_module_cls=CNNObservationPreparation().contract.encoder_module_cls,
+            encoder_input_contract=CNNObservationPreparation().contract.to_snapshot(),
+        )
+
+        snapshot = config_snapshot(cfg)
+
+        assert snapshot["encoder_module"] == "src.r2dreamer.world_model.encoders.ConvEncoder"
+        assert "encoder_module_cls" not in snapshot
+        assert snapshot["encoder_input_contract"]["encoder_type"] == "cnn"
+        assert snapshot["encoder_input_contract"]["encoder_module_kwargs"] == {
+            "depth": 16,
+            "kernel_size": 5,
+            "mults": (2, 3, 4, 4),
+        }
+        json.dumps(snapshot)
+
+    def test_config_snapshot_derives_default_cnn_contract(self):
+        snapshot = config_snapshot(R2DreamerConfig(obs_shape=(3, 64, 64), num_actions=4))
+
+        assert snapshot["encoder_input_contract"]["encoder_type"] == "cnn"
+        json.dumps(snapshot)
 
 
 class TestResume:


### PR DESCRIPTION
## What changed
- Added JSON-serializable Encoder Input Contract snapshots, including observation forms, Encoder Module import path, agent overrides, and resolved Encoder Module constructor kwargs.
- Persisted contract snapshots into checkpoints, MANIFEST/W&B config snapshots, and launcher-created `R2DreamerConfig`.
- Added checkpoint and manifest recovery paths so evaluation/agent loading can recover encoder shape/module metadata from durable snapshots.
- Updated Encoder Module construction to use resolved contract kwargs when present, with legacy config fallback.
- Added regression coverage for snapshot round-trips, checkpoint persistence/recovery, manifest recovery, and contract-driven Encoder Module construction.

## Why
Linear issue: https://linear.app/3d-wm-objectnav/issue/3D-84/3d-persist-and-recover-serializable-encoder-input-contract-snapshots

Durable metadata should not rely on stringified Python class objects. Runtime config may still hold class objects, but manifests/checkpoints/W&B need stable names, shapes, booleans, and resolved construction metadata.

## Acceptance criteria checked
- Encoder Input Contract snapshots are JSON-serializable.
- Snapshots omit `encoder_module_cls` and store a stable `encoder_module` import path.
- Checkpoints persist `encoder_input_contract`.
- Manifest/W&B config snapshots use serializable metadata.
- Checkpoint loading can recover missing encoder config from snapshots.
- Manifest loading for evaluation can recover encoder config from snapshots.
- Resolved Encoder Module constructor kwargs are persisted and used for module construction.

## Verification
- `uv run pytest tests/r2dreamer/test_observation_preparation.py tests/r2dreamer/test_trainer.py tests/r2dreamer/launch/test_evaluate_manifest.py tests/r2dreamer/launch/test_encoders.py::TestCNNEncoder tests/r2dreamer/launch/test_presets.py tests/r2dreamer/launch/test_registries.py -q`
- `git diff --check`

## Risk
Medium. Touches training metadata, checkpoint serialization, evaluation manifest recovery, and Encoder Module construction. Existing direct configs keep config-field fallback behavior when no contract kwargs are available.

## How to test
Run the verification command above. For full confidence, run a short launcher smoke that writes a MANIFEST and checkpoint, then evaluate from that checkpoint.

## Screenshots / preview
Not applicable.

## Intentionally not done
- No public CLI rename from `encoder` to `observation-preparation`; this issue focuses on serializable contract persistence/recovery.
- No GPU/Habitat smoke run was executed in this session.

## Agent involvement
Implemented with automated coding assistance.

## Follow-up issues created
None.
