### PR TITLE
Refactor checkpoint helpers and remove lint dead code

### DIFF
--- a/src/r2dreamer/checkpointing.py
+++ b/src/r2dreamer/checkpointing.py
@@ -1,0 +1,91 @@
+"""Checkpoint and serializable config snapshot helpers for R2-Dreamer."""
+
+from __future__ import annotations
+
+import os
+import pickle
+from dataclasses import asdict, is_dataclass
+from typing import Any, Protocol
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from src.r2dreamer.observation_preparation import (
+    CNNObservationPreparation,
+    encoder_module_kwargs_from_config,
+    module_class_path,
+    recover_encoder_input_contract,
+)
+
+
+class CheckpointAgentLike(Protocol):
+    """Agent state required by checkpoint serialization."""
+
+    cfg: Any
+    params: Any
+    opt_state: Any
+    slow_critic_params: Any
+    ema_state: Any
+
+
+def config_snapshot(config: Any) -> dict[str, Any]:
+    """Return a JSON-serializable run config snapshot for manifests/W&B."""
+    snapshot = (
+        asdict(config)
+        if is_dataclass(config)
+        else dict(vars(config)) if hasattr(config, "__dict__") else {}
+    )
+    encoder_module_cls = snapshot.pop("encoder_module_cls", None)
+    runtime_cls = getattr(config, "encoder_module_cls", None)
+    if runtime_cls is not None:
+        snapshot["encoder_module"] = module_class_path(runtime_cls)
+    elif encoder_module_cls is not None:
+        snapshot["encoder_module"] = str(encoder_module_cls)
+    snapshot["encoder_input_contract"] = encoder_input_contract_snapshot(config)
+    return snapshot
+
+
+def encoder_input_contract_snapshot(config: Any) -> dict[str, Any] | None:
+    """Extract or derive the durable Encoder Input Contract snapshot from config."""
+    snapshot = getattr(config, "encoder_input_contract", None)
+    if snapshot is None:
+        if getattr(config, "encoder_type", None) != "cnn":
+            return None
+        snapshot = CNNObservationPreparation().contract.to_snapshot()
+    snapshot = dict(snapshot)
+    contract = recover_encoder_input_contract(snapshot)
+    snapshot["encoder_module_kwargs"] = encoder_module_kwargs_from_config(
+        config, contract.encoder_module_cls,
+    )
+    return snapshot
+
+
+def save_checkpoint(agent: CheckpointAgentLike, step: int, output_dir: str) -> str:
+    """Save full agent state including ema_state. Returns path."""
+    ckpt_dir = os.path.join(output_dir, "checkpoints")
+    os.makedirs(ckpt_dir, exist_ok=True)
+    path = os.path.join(ckpt_dir, f"step_{step:09d}.pkl")
+    data = {
+        "step": step,
+        "params": jax.tree.map(np.array, agent.params),
+        "opt_state": jax.tree.map(
+            lambda x: np.array(x) if isinstance(x, jnp.ndarray) else x,
+            agent.opt_state,
+        ),
+        "slow_critic_params": jax.tree.map(np.array, agent.slow_critic_params),
+        "ema_state": jax.tree.map(np.array, agent.ema_state),
+    }
+    contract_snapshot = encoder_input_contract_snapshot(agent.cfg)
+    if contract_snapshot is not None:
+        data["encoder_input_contract"] = contract_snapshot
+    with open(path, "wb") as f:
+        pickle.dump(data, f)
+    print(f"Checkpoint saved: {path}")
+    return path
+
+
+def load_checkpoint(path: str) -> dict[str, Any]:
+    """Load checkpoint dict from disk. Returns raw dict — caller restores."""
+    with open(path, "rb") as f:
+        return pickle.load(f)

--- a/src/r2dreamer/config.py
+++ b/src/r2dreamer/config.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Tuple
 
 

--- a/src/r2dreamer/heldout_eval.py
+++ b/src/r2dreamer/heldout_eval.py
@@ -68,7 +68,7 @@ def _k_step_rollout_error(
     post_stochs = forward["post_stochs"]  # (B, T, C, K)
     post_deters = forward["post_deters"]  # (B, T, D)
 
-    B, T = post_stochs.shape[0], post_stochs.shape[1]
+    T = post_stochs.shape[1]
     max_k = max(k_values)
     if T < max_k + 1:
         raise ValueError(

--- a/src/r2dreamer/launch/parity/train_parity.py
+++ b/src/r2dreamer/launch/parity/train_parity.py
@@ -13,7 +13,6 @@ import os
 import sys
 import time
 
-import numpy as np
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
 EXT = os.path.join(ROOT, "external", "r2dreamer")

--- a/src/r2dreamer/launch/train.py
+++ b/src/r2dreamer/launch/train.py
@@ -89,49 +89,41 @@ def _make_env_instances(
 def _agent_overrides_from_args(args: Any, encoder_spec: Any, latent_presets: dict[str, dict]):
     agent_overrides = dict(encoder_spec.agent_overrides)
     # Diagnostic CLI overrides (None => keep config default / encoder override).
-    if args.actor_loss_weight is not None:
-        agent_overrides["scale_policy"] = args.actor_loss_weight
-    if args.value_loss_weight is not None:
-        agent_overrides["scale_value"] = args.value_loss_weight
-    if args.repval_loss_weight is not None:
-        agent_overrides["scale_repval"] = args.repval_loss_weight
+    for attr, override in (
+        ("actor_loss_weight", "scale_policy"),
+        ("value_loss_weight", "scale_value"),
+        ("repval_loss_weight", "scale_repval"),
+        ("batch_size", "batch_size"),
+        ("seq_len", "seq_len"),
+        ("lr", "lr"),
+        ("mlp_layers", "vggt_mlp_layers"),
+    ):
+        value = getattr(args, attr)
+        if value is not None:
+            agent_overrides[override] = value
+    for name in ("train_ratio", "buffer_capacity"):
+        value = getattr(args, name, None)
+        if value is not None:
+            agent_overrides[name] = value
     if args.barlow_grad_to_encoder:
         agent_overrides["barlow_stop_grad"] = False
-    if args.batch_size is not None:
-        agent_overrides["batch_size"] = args.batch_size
-    if args.seq_len is not None:
-        agent_overrides["seq_len"] = args.seq_len
-    if args.lr is not None:
-        agent_overrides["lr"] = args.lr
-    if args.mlp_layers is not None:
-        agent_overrides["vggt_mlp_layers"] = args.mlp_layers
-    if getattr(args, "train_ratio", None) is not None:
-        agent_overrides["train_ratio"] = args.train_ratio
-    if getattr(args, "buffer_capacity", None) is not None:
-        agent_overrides["buffer_capacity"] = args.buffer_capacity
 
     # Latent-size ablation (3D-50): preset from the LATENT_PRESETS table, then
     # explicit flags win.
     preset = getattr(args, "latent_preset", "default")
     agent_overrides.update(latent_presets.get(preset, {}))
-    for name in ("deter_size", "stoch_classes", "stoch_discrete", "mlp_vggt_hidden", "mlp_vggt_layers"):
-        value = getattr(args, name, None)
-        if value is not None:
-            agent_overrides[name] = value
-    if getattr(args, "decoder", False):
-        agent_overrides["decoder"] = True
-    if getattr(args, "scale_decoder", None) is not None:
-        agent_overrides["scale_decoder"] = args.scale_decoder
     for name in (
-        "vggt_token_transformer_layers",
-        "vggt_token_transformer_heads",
-        "vggt_token_projection_dim",
-        "vggt_token_transformer_mlp_ratio",
+        "deter_size", "stoch_classes", "stoch_discrete",
+        "mlp_vggt_hidden", "mlp_vggt_layers", "scale_decoder",
+        "vggt_token_transformer_layers", "vggt_token_transformer_heads",
+        "vggt_token_projection_dim", "vggt_token_transformer_mlp_ratio",
         "vggt_token_transformer_dropout",
     ):
         value = getattr(args, name, None)
         if value is not None:
             agent_overrides[name] = value
+    if getattr(args, "decoder", False):
+        agent_overrides["decoder"] = True
     if getattr(args, "vggt_drop_register_tokens", False):
         agent_overrides["vggt_keep_register_tokens"] = False
     return agent_overrides

--- a/src/r2dreamer/manifest.py
+++ b/src/r2dreamer/manifest.py
@@ -13,7 +13,6 @@ import os
 import platform
 import socket
 import subprocess
-import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any

--- a/src/r2dreamer/trainer.py
+++ b/src/r2dreamer/trainer.py
@@ -9,10 +9,9 @@ from __future__ import annotations
 
 import csv
 import os
-import pickle
 import sys
 import time
-from dataclasses import asdict, dataclass, field, is_dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Protocol
 
@@ -23,14 +22,13 @@ import numpy as np
 from src.buffer.replay_buffer import BufferConfig, ReplayBuffer
 from src.shared.video_utils import compose_frame, log_episode_video, render_topdown_frame
 from src.r2dreamer.adapters import ObsAdapter  # noqa: F401 — re-exported for callers
+from src.r2dreamer.checkpointing import (
+    config_snapshot,
+    load_checkpoint,
+    save_checkpoint,
+)
 from src.r2dreamer.config import R2DreamerConfig
 from src.r2dreamer.manifest import write_manifest_end, write_manifest_start
-from src.r2dreamer.observation_preparation import (
-    CNNObservationPreparation,
-    encoder_module_kwargs_from_config,
-    module_class_path,
-    recover_encoder_input_contract,
-)
 
 
 # ---------------------------------------------------------------------------
@@ -70,42 +68,6 @@ class R2DreamerAgentLike(Protocol):
 
 
 # ---------------------------------------------------------------------------
-# Serializable metadata snapshots
-# ---------------------------------------------------------------------------
-
-def config_snapshot(config: Any) -> dict[str, Any]:
-    """Return a JSON-serializable run config snapshot for manifests/W&B."""
-    snapshot = (
-        asdict(config)
-        if is_dataclass(config)
-        else dict(vars(config)) if hasattr(config, "__dict__") else {}
-    )
-    encoder_module_cls = snapshot.pop("encoder_module_cls", None)
-    runtime_cls = getattr(config, "encoder_module_cls", None)
-    if runtime_cls is not None:
-        snapshot["encoder_module"] = module_class_path(runtime_cls)
-    elif encoder_module_cls is not None:
-        snapshot["encoder_module"] = str(encoder_module_cls)
-    snapshot["encoder_input_contract"] = encoder_input_contract_snapshot(config)
-    return snapshot
-
-
-def encoder_input_contract_snapshot(config: Any) -> dict[str, Any] | None:
-    """Extract or derive the durable Encoder Input Contract snapshot from config."""
-    snapshot = getattr(config, "encoder_input_contract", None)
-    if snapshot is None:
-        if getattr(config, "encoder_type", None) != "cnn":
-            return None
-        snapshot = CNNObservationPreparation().contract.to_snapshot()
-    snapshot = dict(snapshot)
-    contract = recover_encoder_input_contract(snapshot)
-    snapshot["encoder_module_kwargs"] = encoder_module_kwargs_from_config(
-        config, contract.encoder_module_cls,
-    )
-    return snapshot
-
-
-# ---------------------------------------------------------------------------
 # convert_batch
 # ---------------------------------------------------------------------------
 
@@ -125,40 +87,6 @@ def convert_batch(batch: dict[str, Any],
         "is_last": batch["dones"],
         "is_terminal": batch["terminals"],
     }
-
-
-# ---------------------------------------------------------------------------
-# Checkpointing
-# ---------------------------------------------------------------------------
-
-def save_checkpoint(agent: R2DreamerAgentLike, step: int, output_dir: str) -> str:
-    """Save full agent state including ema_state. Returns path."""
-    ckpt_dir = os.path.join(output_dir, "checkpoints")
-    os.makedirs(ckpt_dir, exist_ok=True)
-    path = os.path.join(ckpt_dir, f"step_{step:09d}.pkl")
-    data = {
-        "step": step,
-        "params": jax.tree.map(np.array, agent.params),
-        "opt_state": jax.tree.map(
-            lambda x: np.array(x) if isinstance(x, jnp.ndarray) else x,
-            agent.opt_state,
-        ),
-        "slow_critic_params": jax.tree.map(np.array, agent.slow_critic_params),
-        "ema_state": jax.tree.map(np.array, agent.ema_state),
-    }
-    contract_snapshot = encoder_input_contract_snapshot(agent.cfg)
-    if contract_snapshot is not None:
-        data["encoder_input_contract"] = contract_snapshot
-    with open(path, "wb") as f:
-        pickle.dump(data, f)
-    print(f"Checkpoint saved: {path}")
-    return path
-
-
-def load_checkpoint(path: str) -> dict[str, Any]:
-    """Load checkpoint dict from disk. Returns raw dict — caller restores."""
-    with open(path, "rb") as f:
-        return pickle.load(f)
 
 
 # ---------------------------------------------------------------------------

--- a/src/vggt/jax/block.py
+++ b/src/vggt/jax/block.py
@@ -12,7 +12,6 @@ callers express that by passing ``init_values=None``.
 
 from __future__ import annotations
 
-from typing import Any
 
 import flax.linen as nn
 import jax

--- a/src/vggt/jax/rope.py
+++ b/src/vggt/jax/rope.py
@@ -13,7 +13,6 @@ jit-friendly without a stateful frequency cache.
 
 from __future__ import annotations
 
-import jax
 import jax.numpy as jnp
 
 

--- a/tests/buffer/test_replay_buffer.py
+++ b/tests/buffer/test_replay_buffer.py
@@ -1,6 +1,5 @@
 """Tests for the unified ReplayBuffer with BufferConfig."""
 
-import tempfile
 
 import numpy as np
 import jax.numpy as jnp
@@ -183,7 +182,7 @@ class TestReplayBufferMappingObs:
         assert jnp.allclose(batch["obs"]["features"], 255.0)
 
 
-class TestReplayBufferMappingObs:
+class TestReplayBufferMappingObsNormalization:
     def test_sample_mapping_observations_with_per_field_normalization(self):
         cfg = BufferConfig(
             capacity=20,

--- a/tests/environments/test_habitat.py
+++ b/tests/environments/test_habitat.py
@@ -1,13 +1,10 @@
 """Tests for Habitat environment. Skipped if habitat-sim is not installed."""
 
+import importlib.util
+
 import pytest
 
-try:
-    import habitat_sim
-
-    HAS_HABITAT = True
-except ImportError:
-    HAS_HABITAT = False
+HAS_HABITAT = importlib.util.find_spec("habitat_sim") is not None
 
 skip_no_habitat = pytest.mark.skipif(
     not HAS_HABITAT,

--- a/tests/environments/test_softspl.py
+++ b/tests/environments/test_softspl.py
@@ -9,7 +9,6 @@ import pytest
 
 from src.shared.configs import DreamerConfig
 from src.environments.habitat import (
-    GOAL_RADIUS,
     HabitatObjectNavEnv,
 )
 

--- a/tests/environments/test_spl.py
+++ b/tests/environments/test_spl.py
@@ -9,11 +9,10 @@ import os
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
-import numpy as np
 import pytest
 from habitat.tasks.nav.shortest_path_follower import ShortestPathFollower
 from src.shared.configs import DreamerConfig
-from src.environments.habitat import HabitatObjectNavEnv, GOAL_RADIUS
+from src.environments.habitat import HabitatObjectNavEnv
 
 
 @pytest.mark.gpu

--- a/tests/r2dreamer/test_optim.py
+++ b/tests/r2dreamer/test_optim.py
@@ -3,7 +3,6 @@
 import jax
 import jax.numpy as jnp
 import optax
-import pytest
 
 from src.shared.optim import laprop, agc
 

--- a/tests/vggt/test_jax_integration.py
+++ b/tests/vggt/test_jax_integration.py
@@ -8,7 +8,6 @@ PyTorch extractor to within the production tolerance.
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import jax

--- a/tests/vggt/test_jax_parity.py
+++ b/tests/vggt/test_jax_parity.py
@@ -229,7 +229,6 @@ class TestLevel2SharedBlockParity:
 
         # --- JAX module ---
         from src.vggt.jax.block import Block as JxBlock
-        from src.vggt.jax.rope import compute_1d_rope_tables
         from src.vggt.jax.weight_transfer import load_pytorch_weights
 
         jx_block = JxBlock(


### PR DESCRIPTION
## What changed

- Extracted checkpoint/config snapshot helpers from `src/r2dreamer/trainer.py` into `src/r2dreamer/checkpointing.py`.
- Kept compatibility imports from `src.r2dreamer.trainer` for `save_checkpoint`, `load_checkpoint`, and `config_snapshot`.
- Simplified repetitive launch override collection in `src/r2dreamer/launch/train.py`.
- Removed Ruff-proven unused imports/locals across `src/` and tests.
- Renamed a duplicate replay-buffer test class and replaced a Habitat availability import probe with `importlib.util.find_spec`.

## Why

Reduce dead code and make the largest trainer file easier to navigate while preserving checkpoint format, replay layout, training-loop semantics, and public trainer imports.

## Linear issue

No linked Linear issue; requested directly in chat as a junior-engineer LOC/dead-code cleanup worktree.

## Acceptance criteria checked

- Checkpoint helper extraction preserves trainer import compatibility.
- Ruff cleanup leaves no `F401`, `F841`, `F821`, or `F811` findings in `src`/`tests`.
- Narrow tests covering changed areas pass.

## Verification

```bash
uv run python -m compileall -q src tests
uv run ruff check src tests --select F401,F841,F821,F811
uv run pytest tests/buffer/test_replay_buffer.py \
  tests/environments/test_habitat.py \
  tests/r2dreamer/test_optim.py \
  tests/r2dreamer/test_trainer.py \
  tests/r2dreamer/launch/test_parser.py -q
```

Result: `57 passed`.

## Risk

Low. Most changes are mechanical extraction or lint-proven dead-code removal. No checkpoint schema, replay data layout, Flax module names, or training-loop behavior intentionally changed.

## How to test

Run the verification commands above. For broader confidence, run:

```bash
uv run pytest tests/r2dreamer/ -m "not gpu" -q
```

## Intentionally not done

- Did not remove potentially stale VGGT raw/hybrid encoder classes because checkpoint/experiment compatibility needs manual review.
- Did not attempt large trainer splitting beyond checkpoint helper extraction.
- Did not delete ignored local `__pycache__` files, since they are not tracked by git.

## Follow-up issues created

None.
