### PR TITLE
3D-87: Default compute dtype to bf16

### DIFF
--- a/src/r2dreamer/config.py
+++ b/src/r2dreamer/config.py
@@ -72,9 +72,9 @@ class R2DreamerConfig:
     # use stable module names, shapes, dtypes, booleans, and overrides.
     encoder_input_contract: dict[str, Any] | None = None
     # Compute dtype for large encoder activations. Official DreamerV3 uses
-    # bfloat16 compute; keep float32 by default for backward-compatible tests and
-    # enable bf16 explicitly for memory ablations.
-    compute_dtype: str = "float32"
+    # bfloat16 compute; explicit fp32 probe configs can still override this for
+    # comparison hygiene.
+    compute_dtype: str = "bfloat16"
 
     # --- MLP heads ---
     mlp_units: int = 256

--- a/tests/r2dreamer/test_shapes.py
+++ b/tests/r2dreamer/test_shapes.py
@@ -8,6 +8,7 @@ class TestR2DreamerConfig:
         assert cfg.stoch_size == 32 * 16  # 512
         assert cfg.feat_size == 2048 + 512  # 2560
         assert cfg.deter_size == 2048
+        assert cfg.compute_dtype == "bfloat16"
 
     def test_size25m(self):
         cfg = R2DreamerConfig.size25M()


### PR DESCRIPTION
## What changed
- Changed R2DreamerConfig.compute_dtype default from float32 to bfloat16.
- Updated the config default test to lock the new behavior.
- Kept explicit fp32 override support for probe/config comparison runs.

## Verification
- Red: test default failed before config change.
- Green: uv run pytest tests/r2dreamer/test_shapes.py tests/r2dreamer/launch/test_parser.py tests/r2dreamer/test_agent.py tests/r2dreamer/test_vggt_encoder.py tests/slurm/test_launch.py -q — 108 passed, 24 warnings.
- git diff --check — passed.
