### PR TITLE
Refactor VGGT readout preparation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "master-thesis-3d-vla"
 version = "0.1.0"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.13"
 dependencies = [
     # VGGT deps
     "torch>=2.7",

--- a/src/r2dreamer/AGENTS.md
+++ b/src/r2dreamer/AGENTS.md
@@ -47,8 +47,13 @@ src/r2dreamer/
 │
 ├── adapters/           env-obs → buffer/agent bridge
 │   ├── obs_adapter.py .. ObsAdapter base (RGB passthrough)
-│   ├── vggt_adapter.py . VGGTObsAdapter + VGGT_FEATURE_DIM=4116, flatten/pool helpers
+│   ├── vggt_adapter.py . VGGTObsAdapter + VGGT_FEATURE_DIM=4116, delegates readouts
 │   └── hybrid_adapter.py HybridObsAdapter + HYBRID_FEATURE_DIM=16404
+│
+├── observation_preparation/ encoder-input contracts and env→replay/agent prep
+│   ├── cnn.py .......... CNNObservationPreparation
+│   ├── vggt.py ......... VGGT-family contract/dimension helpers
+│   └── vggt_readouts.py  VGGT head/token readout adapters and pooling/flattening
 │
 ├── encoders/__init__.py launcher-side Encoder/EncoderSpec specs (CNN, VGGT*, Hybrid)
 │

--- a/src/r2dreamer/adapters/hybrid_adapter.py
+++ b/src/r2dreamer/adapters/hybrid_adapter.py
@@ -7,11 +7,9 @@ import jax
 import numpy as np
 
 from src.r2dreamer.adapters.obs_adapter import ObsAdapter
-from src.r2dreamer.adapters.vggt_adapter import (
-    AGG_TOKEN_TOKENS,
-    VGGT_FEATURE_DIM,
-    full_aggregator_tokens,
+from src.r2dreamer.observation_preparation.vggt_readouts import (
     flatten_world_points_camera_pose,
+    full_aggregator_tokens,
 )
 from src.r2dreamer.obs_batch import (
     FULL_TOKENS_KEY,
@@ -19,7 +17,14 @@ from src.r2dreamer.obs_batch import (
     HYBRID_IMAGE_KEY,
     HYBRID_WP_CP_KEY,
 )
-from src.r2dreamer.observation_preparation.vggt import build_hybrid_contract
+from src.r2dreamer.observation_preparation.vggt import (
+    HYBRID_FEATURE_DIM,
+    HYBRID_IMAGE_SHAPE,
+    HYBRID_RGB_DIM,
+    VGGT_AGGREGATOR_TOKEN_COUNT,
+    VGGT_FULL_TOKEN_EMBED_DIM,
+    build_hybrid_contract,
+)
 from src.shared.video_utils import resize_chw_uint8
 from src.r2dreamer.world_model.encoders import (
     HOUSE_CONTEXT_DIM,
@@ -27,13 +32,8 @@ from src.r2dreamer.world_model.encoders import (
 )
 
 
-# Derived, not hand-typed: RGB branch (3*64*64, flattened) + the VGGT WP/CP vector.
-# VGGT_FEATURE_DIM is the single source of truth for the 4116 term (see vggt_adapter),
-# so a grid-size ablation that changes it stays consistent here automatically.
-HYBRID_FEATURE_DIM = 3 * 64 * 64 + VGGT_FEATURE_DIM  # 12288 RGB + 4116 WP/CP = 16404
-HYBRID_IMAGE_SHAPE = (3, 64, 64)
-HOUSE_CONTEXT_FEATURE_DIM = 3 * 64 * 64 + HOUSE_CONTEXT_DIM
-FULL_TOKEN_SHAPE = (AGG_TOKEN_TOKENS, 2048)
+HOUSE_CONTEXT_FEATURE_DIM = HYBRID_RGB_DIM + HOUSE_CONTEXT_DIM
+FULL_TOKEN_SHAPE = (VGGT_AGGREGATOR_TOKEN_COUNT, VGGT_FULL_TOKEN_EMBED_DIM)
 
 
 class HybridObsAdapter(ObsAdapter):

--- a/src/r2dreamer/adapters/vggt_adapter.py
+++ b/src/r2dreamer/adapters/vggt_adapter.py
@@ -2,15 +2,10 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
-import jax.numpy as jnp
 import numpy as np
 
 from src.r2dreamer.adapters.obs_adapter import ObsAdapter
-from src.r2dreamer.obs_batch import CAMERA_POSE_KEY, WORLD_POINTS_KEY
 from src.r2dreamer.observation_preparation.vggt import (
-    VGGT_AGGREGATOR_PATCH_START_IDX,
     VGGT_AGGREGATOR_TOKEN_COUNT,
     VGGT_DEFAULT_AGGREGATOR_SHAPE,
     VGGT_FULL_TOKEN_EMBED_DIM,
@@ -18,10 +13,9 @@ from src.r2dreamer.observation_preparation.vggt import (
     aggregator_raw_dim,
     aggregator_token_dim,
     build_vggt_contract,
-    contract_world_points_hwc_shape,
-    head_readout_spec,
     wp_cp_dim,
 )
+from src.r2dreamer.observation_preparation.vggt_readouts import make_vggt_readout
 from src.vggt.jax.feature_extractor import JAXVGGTFeatureExtractor as VGGTFeatureExtractor
 
 
@@ -34,207 +28,6 @@ AGG_RAW_TOKENS = AGG_RAW_DIM // VGGT_DEFAULT_AGGREGATOR_SHAPE[-1]
 AGG_TOKEN_TOKENS = VGGT_AGGREGATOR_TOKEN_COUNT
 AGG_TOKEN_DIM = aggregator_token_dim(VGGT_DEFAULT_AGGREGATOR_SHAPE)
 FULL_TOKEN_DIM = AGG_TOKEN_TOKENS * VGGT_FULL_TOKEN_EMBED_DIM
-
-
-def flatten_world_points_camera_pose(out: dict) -> jnp.ndarray:
-    """Flatten structured VGGT world-points + camera-pose for MLP encoders."""
-    wp = out[WORLD_POINTS_KEY].reshape(-1)
-    cp = out[CAMERA_POSE_KEY].reshape(-1)
-    return jnp.concatenate([wp, cp]).astype(jnp.float32)
-
-
-def structured_world_points_camera_pose(
-    out: dict,
-    *,
-    expected_hwc_shape: tuple[int, int, int],
-    world_points_key: str = "world_points",
-) -> dict[str, jnp.ndarray]:
-    """Return VGGT world points and camera pose as explicit fields.
-
-    ``expected_hwc_shape`` is derived from the Encoder Input Contract. The
-    adapter validates against the contract rather than owning VGGT dimensions.
-    """
-    world_points = out[world_points_key]
-    if tuple(world_points.shape) != expected_hwc_shape:
-        raise ValueError(
-            f"expected {world_points_key} shape {expected_hwc_shape}, "
-            f"got {tuple(world_points.shape)}"
-        )
-    return {
-        WORLD_POINTS_KEY: jnp.transpose(world_points, (2, 0, 1)).astype(jnp.float32),
-        CAMERA_POSE_KEY: out["camera_pose"].astype(jnp.float32),
-    }
-
-
-def _checked_feature(out: dict, key: str, expected_shape: tuple[int, ...]) -> jnp.ndarray:
-    """Return a float32 VGGT readout after validating its contract shape."""
-    features = out[key]
-    if features.shape != expected_shape:
-        raise ValueError(f"expected {key} shape {expected_shape}, got {features.shape}")
-    return features.astype(jnp.float32)
-
-
-def pool_aggregator_tokens(out: dict, expected_shape: tuple[int, ...]) -> jnp.ndarray:
-    """Return three pre-head pools concatenated as a single (3*D,) vector.
-
-    Layout matches the aggregator's ``[camera, register, patches]`` ordering
-    (see ``src/vggt/jax/aggregator.py``): the camera token at index 0 is
-    the embedding VGGT's own ``camera_head`` reads to predict pose, so we keep
-    it unmixed. Register tokens (1:5) are attention sinks and dropped. Patches
-    (5:) are reduced with both mean (smooth global) and max (salient features)
-    so the encoder sees signals at different scales.
-    """
-    features = _checked_feature(out, "aggregator_features", expected_shape)
-    cam = features[0]
-    patches = features[VGGT_AGGREGATOR_PATCH_START_IDX:]
-    mean_p = patches.mean(axis=0)
-    max_p = patches.max(axis=0)
-    return jnp.concatenate([cam, mean_p, max_p], axis=0)
-
-
-def flatten_raw_aggregator(out: dict, expected_shape: tuple[int, ...]) -> jnp.ndarray:
-    """Flatten the RAW aggregator tokens, dropping the 4 register tokens (JAX).
-
-    Unlike ``pool_aggregator_tokens`` (which collapses patches to mean+max), this
-    keeps every token: camera token (idx 0) + all patch tokens (idx
-    ``VGGT_AGGREGATOR_PATCH_START_IDX:``) = ``1 + (P-5)`` tokens, flattened
-    row-major to ``(n_tokens * embed_dim,)`` — 1370*1024 = 1,402,880 at the
-    default config. The 4 register tokens (idx 1:5) are attention sinks and dropped, matching the
-    pooled path. Stored float16 in replay (~2.81 MB/frame).
-    """
-    features = _checked_feature(out, "aggregator_features", expected_shape)
-    cam = features[0:1]                          # (1, D)
-    patches = features[VGGT_AGGREGATOR_PATCH_START_IDX:]  # (P-5, D)
-    kept = jnp.concatenate([cam, patches], axis=0)  # (1 + P-5, D)
-    return kept.reshape(-1)                       # (n_tokens * D,)
-
-
-def flatten_full_aggregator_tokens(out: dict, expected_shape: tuple[int, ...]) -> jnp.ndarray:
-    """Flatten all VGGT aggregator tokens, keeping camera, register, and patches.
-
-    This is the 3D-75 token-Transformer replay layout. It intentionally differs
-    from ``flatten_raw_aggregator`` by preserving register tokens so the trainable
-    encoder sees the full frozen VGGT token sequence: ``(1374, 1024)`` at the
-    default 518px / 37x37-patch configuration. Replay stores the flattened vector
-    as float16; the Flax encoder upcasts before attention.
-    """
-    return _checked_feature(out, "aggregator_features", expected_shape).reshape(-1)
-
-
-def full_aggregator_tokens(out: dict, expected_shape: tuple[int, ...]) -> jnp.ndarray:
-    """Return full-width VGGT aggregator tokens for the 3D-77 context path."""
-    return _checked_feature(out, "aggregator_full_tokens", expected_shape)
-
-
-AGGREGATOR_READOUTS = {
-    "aggregator": pool_aggregator_tokens,
-    "agg_raw": flatten_raw_aggregator,
-    "agg_tokens": flatten_full_aggregator_tokens,
-}
-
-
-@dataclass(frozen=True)
-class VGGTHeadReadout:
-    """Readout family for VGGT heads: world-points plus camera-pose."""
-
-    expected_hwc_shape: tuple[int, int, int]
-    replay_dtype: dict[str, str]
-    world_points_key: str = "world_points"
-    return_dense: bool = False
-
-    def extract(self, extractor: VGGTFeatureExtractor, image: np.ndarray) -> dict:
-        if self.return_dense:
-            return extractor.extract(image, return_dense=True)
-        return extractor.extract(image)
-
-    def read(self, out: dict) -> dict[str, jnp.ndarray]:
-        return structured_world_points_camera_pose(
-            out,
-            expected_hwc_shape=self.expected_hwc_shape,
-            world_points_key=self.world_points_key,
-        )
-
-    def to_obs(
-        self,
-        features: dict[str, jnp.ndarray],
-        *,
-        is_first: bool,
-    ) -> tuple[dict[str, np.ndarray], dict]:
-        replay = {
-            WORLD_POINTS_KEY: np.asarray(
-                features[WORLD_POINTS_KEY],
-                dtype=np.dtype(self.replay_dtype[WORLD_POINTS_KEY]),
-            ),
-            CAMERA_POSE_KEY: np.asarray(
-                features[CAMERA_POSE_KEY],
-                dtype=np.dtype(self.replay_dtype[CAMERA_POSE_KEY]),
-            ),
-        }
-        agent_obs = {
-            WORLD_POINTS_KEY: features[WORLD_POINTS_KEY].astype(jnp.float32),
-            CAMERA_POSE_KEY: features[CAMERA_POSE_KEY].astype(jnp.float32),
-            "is_first": is_first,
-        }
-        return replay, agent_obs
-
-
-@dataclass(frozen=True)
-class VGGTAggregatorReadout:
-    """Readout family for VGGT pre-head aggregator tokens."""
-
-    kind: VGGTFeatureKind
-    expected_shape: tuple[int, ...]
-    replay_dtype: str
-
-    def extract(self, extractor: VGGTFeatureExtractor, image: np.ndarray) -> dict:
-        return extractor.extract(image)
-
-    def read(self, out: dict) -> jnp.ndarray:
-        if self.kind not in AGGREGATOR_READOUTS:
-            raise ValueError(f"unknown VGGT aggregator readout {self.kind!r}")
-        return AGGREGATOR_READOUTS[self.kind](out, self.expected_shape)
-
-    def to_obs(
-        self,
-        features: jnp.ndarray,
-        *,
-        is_first: bool,
-    ) -> tuple[np.ndarray, dict]:
-        replay = np.asarray(features, dtype=np.dtype(self.replay_dtype))
-        agent_obs = {
-            "features": features.astype(jnp.float32),
-            "is_first": is_first,
-        }
-        return replay, agent_obs
-
-
-def make_vggt_readout(
-    *,
-    feature_kind: VGGTFeatureKind,
-    extractor: VGGTFeatureExtractor,
-    contract,
-) -> VGGTHeadReadout | VGGTAggregatorReadout:
-    replay_dtype = contract.replay_observation.buffer_dtype()
-    if spec := head_readout_spec(feature_kind):
-        if not isinstance(replay_dtype, dict):
-            raise ValueError("VGGT head readouts require per-field replay dtypes")
-        return VGGTHeadReadout(
-            expected_hwc_shape=contract_world_points_hwc_shape(contract),
-            replay_dtype=replay_dtype,
-            world_points_key=(
-                "dense_world_points" if spec.use_dense_world_points else "world_points"
-            ),
-            return_dense=spec.use_dense_world_points,
-        )
-    if feature_kind in AGGREGATOR_READOUTS:
-        if isinstance(replay_dtype, dict):
-            raise ValueError("VGGT aggregator readouts require a scalar replay dtype")
-        return VGGTAggregatorReadout(
-            kind=feature_kind,
-            expected_shape=tuple(getattr(extractor, "aggregator_feature_shape", ())),
-            replay_dtype=replay_dtype,
-        )
-    raise ValueError(f"unknown VGGT feature_kind {feature_kind!r}")
 
 
 class VGGTObsAdapter(ObsAdapter):
@@ -275,9 +68,8 @@ class VGGTObsAdapter(ObsAdapter):
         )
 
     def transform(self, obs_dict: dict) -> tuple[np.ndarray | dict[str, np.ndarray], dict]:
-        out = self._readout.extract(self._extractor, obs_dict["image"])
-        features = self._readout.read(out)
-        return self._readout.to_obs(
-            features,
+        return self._readout.prepare(
+            self._extractor,
+            obs_dict["image"],
             is_first=obs_dict.get("is_first", False),
         )

--- a/src/r2dreamer/observation_preparation/vggt_readouts.py
+++ b/src/r2dreamer/observation_preparation/vggt_readouts.py
@@ -1,0 +1,213 @@
+"""Internal VGGT readout implementations.
+
+This module groups the VGGT-specific extraction/readout rules behind one small
+``prepare(extractor, image, is_first=...)`` interface. The public adapter only
+wires a readout and delegates to it; shape validation, token pooling, flattening,
+and replay dtype conversion stay local here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import jax.numpy as jnp
+import numpy as np
+
+from src.r2dreamer.obs_batch import CAMERA_POSE_KEY, WORLD_POINTS_KEY
+from src.r2dreamer.observation_preparation.vggt import (
+    VGGT_AGGREGATOR_PATCH_START_IDX,
+    VGGTFeatureKind,
+    contract_world_points_hwc_shape,
+    head_readout_spec,
+)
+
+
+class VGGTReadout(Protocol):
+    """Small seam for all VGGT readout families."""
+
+    def prepare(
+        self,
+        extractor: Any,
+        image: np.ndarray,
+        *,
+        is_first: bool,
+    ) -> tuple[np.ndarray | dict[str, np.ndarray], dict]:
+        """Extract one frame and return replay + agent observations."""
+
+
+def flatten_world_points_camera_pose(out: dict) -> jnp.ndarray:
+    """Flatten structured VGGT world-points + camera-pose for MLP encoders."""
+    wp = out[WORLD_POINTS_KEY].reshape(-1)
+    cp = out[CAMERA_POSE_KEY].reshape(-1)
+    return jnp.concatenate([wp, cp]).astype(jnp.float32)
+
+
+def _structured_world_points_camera_pose(
+    out: dict,
+    *,
+    expected_hwc_shape: tuple[int, int, int],
+    world_points_key: str = "world_points",
+) -> dict[str, jnp.ndarray]:
+    """Return VGGT world points and camera pose as explicit fields."""
+    world_points = out[world_points_key]
+    if tuple(world_points.shape) != expected_hwc_shape:
+        raise ValueError(
+            f"expected {world_points_key} shape {expected_hwc_shape}, "
+            f"got {tuple(world_points.shape)}"
+        )
+    return {
+        WORLD_POINTS_KEY: jnp.transpose(world_points, (2, 0, 1)).astype(jnp.float32),
+        CAMERA_POSE_KEY: out["camera_pose"].astype(jnp.float32),
+    }
+
+
+def _checked_feature(out: dict, key: str, expected_shape: tuple[int, ...]) -> jnp.ndarray:
+    """Return a float32 VGGT readout after validating its contract shape."""
+    features = out[key]
+    if tuple(features.shape) != expected_shape:
+        raise ValueError(f"expected {key} shape {expected_shape}, got {features.shape}")
+    return features.astype(jnp.float32)
+
+
+def _pool_aggregator_tokens(features: jnp.ndarray) -> jnp.ndarray:
+    """Pool camera + patch summaries from pre-head aggregator tokens.
+
+    Layout matches the aggregator's ``[camera, register, patches]`` ordering
+    (see ``src/vggt/jax/aggregator.py``): keep the camera token unmixed, drop
+    register tokens (1:5), and reduce patches with mean + max.
+    """
+    cam = features[0]
+    patches = features[VGGT_AGGREGATOR_PATCH_START_IDX:]
+    mean_p = patches.mean(axis=0)
+    max_p = patches.max(axis=0)
+    return jnp.concatenate([cam, mean_p, max_p], axis=0)
+
+
+def _flatten_raw_aggregator(features: jnp.ndarray) -> jnp.ndarray:
+    """Flatten camera + patch tokens, dropping the 4 register tokens."""
+    cam = features[0:1]
+    patches = features[VGGT_AGGREGATOR_PATCH_START_IDX:]
+    kept = jnp.concatenate([cam, patches], axis=0)
+    return kept.reshape(-1)
+
+
+def _flatten_full_aggregator_tokens(features: jnp.ndarray) -> jnp.ndarray:
+    """Flatten camera, register, and patch tokens for token-Transformer replay."""
+    return features.reshape(-1)
+
+
+def full_aggregator_tokens(out: dict, expected_shape: tuple[int, ...]) -> jnp.ndarray:
+    """Return full-width VGGT aggregator tokens for live context paths."""
+    return _checked_feature(out, "aggregator_full_tokens", expected_shape)
+
+
+AggregatorProjection = Callable[[jnp.ndarray], jnp.ndarray]
+
+
+AGGREGATOR_PROJECTIONS: dict[str, AggregatorProjection] = {
+    "aggregator": _pool_aggregator_tokens,
+    "agg_raw": _flatten_raw_aggregator,
+    "agg_tokens": _flatten_full_aggregator_tokens,
+}
+
+
+@dataclass(frozen=True)
+class VGGTHeadReadout:
+    """Readout family for VGGT heads: world-points plus camera-pose."""
+
+    expected_hwc_shape: tuple[int, int, int]
+    replay_dtype: dict[str, str]
+    world_points_key: str = "world_points"
+    return_dense: bool = False
+
+    def prepare(
+        self,
+        extractor: Any,
+        image: np.ndarray,
+        *,
+        is_first: bool,
+    ) -> tuple[dict[str, np.ndarray], dict]:
+        out = (
+            extractor.extract(image, return_dense=True)
+            if self.return_dense
+            else extractor.extract(image)
+        )
+        features = _structured_world_points_camera_pose(
+            out,
+            expected_hwc_shape=self.expected_hwc_shape,
+            world_points_key=self.world_points_key,
+        )
+        replay = {
+            WORLD_POINTS_KEY: np.asarray(
+                features[WORLD_POINTS_KEY],
+                dtype=np.dtype(self.replay_dtype[WORLD_POINTS_KEY]),
+            ),
+            CAMERA_POSE_KEY: np.asarray(
+                features[CAMERA_POSE_KEY],
+                dtype=np.dtype(self.replay_dtype[CAMERA_POSE_KEY]),
+            ),
+        }
+        agent_obs = {
+            WORLD_POINTS_KEY: features[WORLD_POINTS_KEY].astype(jnp.float32),
+            CAMERA_POSE_KEY: features[CAMERA_POSE_KEY].astype(jnp.float32),
+            "is_first": is_first,
+        }
+        return replay, agent_obs
+
+
+@dataclass(frozen=True)
+class VGGTAggregatorReadout:
+    """Readout family for VGGT pre-head aggregator tokens."""
+
+    expected_shape: tuple[int, ...]
+    replay_dtype: str
+    project: AggregatorProjection
+
+    def prepare(
+        self,
+        extractor: Any,
+        image: np.ndarray,
+        *,
+        is_first: bool,
+    ) -> tuple[np.ndarray, dict]:
+        out = extractor.extract(image)
+        features = _checked_feature(out, "aggregator_features", self.expected_shape)
+        readout = self.project(features).astype(jnp.float32)
+        replay = np.asarray(readout, dtype=np.dtype(self.replay_dtype))
+        agent_obs = {
+            "features": readout.astype(jnp.float32),
+            "is_first": is_first,
+        }
+        return replay, agent_obs
+
+
+def make_vggt_readout(
+    *,
+    feature_kind: VGGTFeatureKind,
+    extractor: Any,
+    contract,
+) -> VGGTReadout:
+    """Build the internal readout adapter for one VGGT feature kind."""
+    replay_dtype = contract.replay_observation.buffer_dtype()
+    if spec := head_readout_spec(feature_kind):
+        if not isinstance(replay_dtype, dict):
+            raise ValueError("VGGT head readouts require per-field replay dtypes")
+        return VGGTHeadReadout(
+            expected_hwc_shape=contract_world_points_hwc_shape(contract),
+            replay_dtype=replay_dtype,
+            world_points_key=(
+                "dense_world_points" if spec.use_dense_world_points else "world_points"
+            ),
+            return_dense=spec.use_dense_world_points,
+        )
+    if feature_kind in AGGREGATOR_PROJECTIONS:
+        if isinstance(replay_dtype, dict):
+            raise ValueError("VGGT aggregator readouts require a scalar replay dtype")
+        return VGGTAggregatorReadout(
+            expected_shape=tuple(getattr(extractor, "aggregator_feature_shape", ())),
+            replay_dtype=replay_dtype,
+            project=AGGREGATOR_PROJECTIONS[feature_kind],
+        )
+    raise ValueError(f"unknown VGGT feature_kind {feature_kind!r}")

--- a/src/vggt/AGENTS.md
+++ b/src/vggt/AGENTS.md
@@ -13,7 +13,9 @@ aggregator tokens used as features. There are two implementations:
 - a **JAX/Flax port** (`jax/`) with an explicit streaming KV-cache and dynamic budget
   eviction — this is the **production** path that feeds R2Dreamer's VGGT encoders.
 
-It is consumed by `src/r2dreamer/adapters/vggt_adapter.py` and
+It is consumed by the R2Dreamer VGGT observation-preparation path
+(`src/r2dreamer/adapters/vggt_adapter.py`,
+`src/r2dreamer/observation_preparation/vggt_readouts.py`) and
 `src/r2dreamer/encoders/__init__.py`.
 
 ## Layout
@@ -68,9 +70,10 @@ from src.vggt.feature_extractor import VGGTFeatureExtractor
 
 ## How R2Dreamer consumes it
 
-- `VGGTObsAdapter` (`src/r2dreamer/adapters/vggt_adapter.py`) calls `extract()` per frame
-  and pools outputs with `flatten_world_points_camera_pose()` (→ 4116-d WP/CP) or
-  `pool_aggregator_tokens()` (cam + mean-patch + max-patch).
+- `VGGTObsAdapter` (`src/r2dreamer/adapters/vggt_adapter.py`) delegates each frame to
+  the readout adapters in `src/r2dreamer/observation_preparation/vggt_readouts.py`,
+  which call `extract()` and emit WP/CP, dense point-map, pooled aggregator, or
+  full-token replay observations.
 - Encoder variants (`src/r2dreamer/encoders/__init__.py`): `vggt` (WP/CP MLP),
   `vggt_aggregator_mlp` (pre-head tokens, `compute_heads=False`), `vggt_wp_dense_cnn`
   (dense 518² point map → conv), `vggt_wp_cp_64` (64×64 pool), `hybrid` (CNN + gated MLP).
@@ -101,7 +104,8 @@ from src.vggt.feature_extractor import VGGTFeatureExtractor
 
 - JAX path: `jax`, `flax.linen`, `numpy`, `huggingface_hub` (checkpoint `lch01/StreamVGGT`).
 - PyTorch path: `torch`, `external/InfiniteVGGT/src/streamvggt` (StreamVGGT reference).
-- Consumers: `src.r2dreamer.adapters.vggt_adapter`, `src.r2dreamer.encoders`.
+- Consumers: `src.r2dreamer.adapters.vggt_adapter`,
+  `src.r2dreamer.observation_preparation.vggt_readouts`, `src.r2dreamer.encoders`.
 
 ## Running & testing
 

--- a/tests/r2dreamer/launch/test_encoders.py
+++ b/tests/r2dreamer/launch/test_encoders.py
@@ -540,7 +540,7 @@ class TestHybridEncoder:
 
     def test_hybrid_adapter_builds_rgb_wp_cp_layout(self):
         # Fake VGGT extractor: extract() -> world_points (37,37,3) + camera_pose (9,)
-        # so flatten_world_points_camera_pose yields 37*37*3 + 9 = 4116.
+        # so the hybrid WP/CP readout yields 37*37*3 + 9 = 4116.
         world_points = np.arange(37 * 37 * 3, dtype=np.float32).reshape(37, 37, 3)
         camera_pose = np.arange(9, dtype=np.float32) + 100.0
 

--- a/tests/r2dreamer/test_vggt_encoder.py
+++ b/tests/r2dreamer/test_vggt_encoder.py
@@ -21,7 +21,7 @@ from src.r2dreamer.world_model.encoders import (
     VGGTAggregatorMLPEncoder,
     WP64CNNCPMLPEncoder,
 )
-from src.r2dreamer.adapters.vggt_adapter import full_aggregator_tokens
+from src.r2dreamer.observation_preparation.vggt_readouts import full_aggregator_tokens
 from src.buffer.replay_buffer import VGGTReplayBuffer
 
 


### PR DESCRIPTION
## What changed
- Moved VGGT head/token readout behavior from `vggt_adapter.py` into `observation_preparation/vggt_readouts.py` behind a single `prepare(...)` interface.
- Slimmed `VGGTObsAdapter.transform()` to delegate extraction/readout conversion.
- Pointed hybrid/context callers at the readout module instead of importing readout helpers from the adapter.
- Capped `requires-python` at `<3.13` so uv does not choose Python 3.13, which is incompatible with open3d 0.19 wheels.
- Updated scoped AGENTS docs for the new readout location.

## Why
Deepen the VGGT observation-preparation module: keep pooling, flattening, validation, and replay dtype conversion local to readouts instead of exposing them from the adapter seam.

## Linear issue
None; requested interactively.

## Acceptance criteria checked
- VGGT adapter still emits the same replay/agent observations for head, dense WP, pooled aggregator, and token variants.
- Hybrid/context adapters still consume WP/CP and full-token readouts.
- Worktree uv environment no longer selects Python 3.13 after the pyproject cap; setup_worktree symlink reuses the parent venv.

## Verification
- `uv run python -m pytest tests/r2dreamer/launch/test_encoders.py -m 'not gpu' -q` — 24 passed, 2 deselected
- `uv run python -m pytest tests/r2dreamer/test_observation_preparation.py tests/r2dreamer/test_vggt_encoder.py tests/r2dreamer/test_dims_consistency.py -q` — 49 passed
- `uv run python -m ruff check ...` — skipped/blocked: ruff is not installed in the shared venv

## Risk
Low/medium: pure refactor of readout placement plus Python version cap. No replay shape or dtype contract should change.

## How to test
Run the verification commands above from a bootstrapped worktree.

## Intentionally not done
- Did not move the VGGT variant registry; this PR only extracts readout behavior.
- Did not run GPU VGGT tests.

## Agent involvement
Implemented and verified with coding-agent assistance.

## Follow-up issues created
None.