### PR TITLE
Fix src lint errors

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,2 +1,1 @@
 """Top-level package for the 3D VLA ObjectNav codebase."""
-

--- a/src/analysis/invariance_metrics.py
+++ b/src/analysis/invariance_metrics.py
@@ -12,6 +12,7 @@ These helpers quantify three things between a forward and a backward run:
 
 No torch/jax — safe to run on the login node / inside the CPU analysis notebook.
 """
+
 from __future__ import annotations
 
 import numpy as np
@@ -53,15 +54,19 @@ def umeyama(src: np.ndarray, dst: np.ndarray, with_scale: bool = True):
     sgn = np.sign(np.linalg.det(u @ vt))
     dmat = np.diag([1.0, 1.0, sgn])
     r = u @ dmat @ vt
-    var_s = (xs ** 2).sum() / n
+    var_s = (xs**2).sum() / n
     s = float((d_diag * np.array([1.0, 1.0, sgn])).sum() / var_s) if with_scale else 1.0
     t = mu_d - s * (r @ mu_s)
     aligned = (s * (r @ src.T)).T + t
     rmse_before = float(np.sqrt(((src - dst) ** 2).sum(1).mean()))
     rmse_after = float(np.sqrt(((aligned - dst) ** 2).sum(1).mean()))
     return {
-        "R": r, "t": t, "s": s, "aligned": aligned,
-        "rmse_before": rmse_before, "rmse_after": rmse_after,
+        "R": r,
+        "t": t,
+        "s": s,
+        "aligned": aligned,
+        "rmse_before": rmse_before,
+        "rmse_after": rmse_after,
         "residual_ratio": rmse_after / rmse_before if rmse_before > 0 else 0.0,
     }
 
@@ -69,8 +74,7 @@ def umeyama(src: np.ndarray, dst: np.ndarray, with_scale: bool = True):
 # --------------------------------------------------------------------------- #
 # Frame matching by physical position
 # --------------------------------------------------------------------------- #
-def match_by_position(fwd_pos: np.ndarray, bwd_pos: np.ndarray,
-                      max_dist: float = 0.3):
+def match_by_position(fwd_pos: np.ndarray, bwd_pos: np.ndarray, max_dist: float = 0.3):
     """Match each forward frame to its nearest backward frame by 3D position.
 
     Returns (pairs, dists) where pairs is a list of (i, j) and dists the
@@ -121,15 +125,27 @@ def quat_to_R(q_xyzw: np.ndarray) -> np.ndarray:
     if n == 0.0:
         return np.eye(3)
     s = 2.0 / n
-    return np.array([
-        [1 - s * (y * y + z * z), s * (x * y - z * w),     s * (x * z + y * w)],
-        [s * (x * y + z * w),     1 - s * (x * x + z * z), s * (y * z - x * w)],
-        [s * (x * z - y * w),     s * (y * z + x * w),     1 - s * (x * x + y * y)],
-    ])
+    return np.array(
+        [
+            [1 - s * (y * y + z * z), s * (x * y - z * w), s * (x * z + y * w)],
+            [s * (x * y + z * w), 1 - s * (x * x + z * z), s * (y * z - x * w)],
+            [s * (x * z - y * w), s * (y * z + x * w), 1 - s * (x * x + y * y)],
+        ]
+    )
 
 
-def compare_pair(fwd_wp, bwd_wp, fwd_cp, bwd_cp, fwd_logit, bwd_logit,
-                 fwd_deter, bwd_deter, fwd_embed=None, bwd_embed=None):
+def compare_pair(
+    fwd_wp,
+    bwd_wp,
+    fwd_cp,
+    bwd_cp,
+    fwd_logit,
+    bwd_logit,
+    fwd_deter,
+    bwd_deter,
+    fwd_embed=None,
+    bwd_embed=None,
+):
     """Full metric bundle for one matched (forward, backward) frame pair."""
     fwp = np.asarray(fwd_wp).reshape(-1, 3)
     bwp = np.asarray(bwd_wp).reshape(-1, 3)

--- a/src/baselines/random_agent.py
+++ b/src/baselines/random_agent.py
@@ -20,12 +20,23 @@ from src.environments.habitat import ACTIONS, HabitatObjectNavEnv
 
 
 _CSV_HEADER = [
-    "episode", "scene", "category", "steps", "reward",
-    "success", "spl", "stop_pct", "forward_pct", "left_pct", "right_pct",
+    "episode",
+    "scene",
+    "category",
+    "steps",
+    "reward",
+    "success",
+    "spl",
+    "stop_pct",
+    "forward_pct",
+    "left_pct",
+    "right_pct",
 ]
 
 
-def _build_eval_env(curriculum_path: str, max_episode_steps: int) -> HabitatObjectNavEnv:
+def _build_eval_env(
+    curriculum_path: str, max_episode_steps: int
+) -> HabitatObjectNavEnv:
     """Construct the Habitat ObjectNav env in eval mode for the curriculum."""
     config = DreamerConfig(
         obs_shape=(3, 64, 64),
@@ -42,21 +53,31 @@ def _build_eval_env(curriculum_path: str, max_episode_steps: int) -> HabitatObje
 def _episode_csv_row(ep_idx: int, result: dict) -> list:
     """Format one episode result as a CSV row matching ``_CSV_HEADER``."""
     steps = result["steps"]
-    pcts = {name: result["action_counts"][idx] / steps * 100
-            for idx, name in ACTIONS.items()}
+    pcts = {
+        name: result["action_counts"][idx] / steps * 100
+        for idx, name in ACTIONS.items()
+    }
     return [
-        ep_idx, result["scene"], result["category"], steps,
-        f"{result['reward']:.4f}", f"{result['success']:.0f}",
+        ep_idx,
+        result["scene"],
+        result["category"],
+        steps,
+        f"{result['reward']:.4f}",
+        f"{result['success']:.0f}",
         f"{result['spl']:.4f}",
-        f"{pcts['STOP']:.1f}", f"{pcts['MOVE_FORWARD']:.1f}",
-        f"{pcts['TURN_LEFT']:.1f}", f"{pcts['TURN_RIGHT']:.1f}",
+        f"{pcts['STOP']:.1f}",
+        f"{pcts['MOVE_FORWARD']:.1f}",
+        f"{pcts['TURN_LEFT']:.1f}",
+        f"{pcts['TURN_RIGHT']:.1f}",
     ]
 
 
-def _print_summary(summary: dict, csv_path: str, json_path: str, elapsed: float) -> None:
+def _print_summary(
+    summary: dict, csv_path: str, json_path: str, elapsed: float
+) -> None:
     """Print the human-readable run summary."""
     print(f"\n--- Summary ({summary['episodes']} episodes, {elapsed:.0f}s) ---")
-    print(f"Success Rate: {summary['sr']*100:.2f}%")
+    print(f"Success Rate: {summary['sr'] * 100:.2f}%")
     print(f"SPL:          {summary['spl']:.4f}")
     print(f"Mean Reward:  {summary['mean_reward']:.2f} ± {summary['std_reward']:.2f}")
     print(f"Mean Steps:   {summary['mean_steps']:.0f} ± {summary['std_steps']:.0f}")
@@ -113,9 +134,7 @@ def _aggregate_results(
     spls = [r["spl"] for r in all_results]
     rewards = [r["reward"] for r in all_results]
     steps_list = [r["steps"] for r in all_results]
-    total_actions = sum(
-        sum(r["action_counts"].values()) for r in all_results
-    )
+    total_actions = sum(sum(r["action_counts"].values()) for r in all_results)
     agg_action_counts = {name: 0 for name in ACTIONS.values()}
     for r in all_results:
         for idx, name in ACTIONS.items():
@@ -174,8 +193,10 @@ def run_random_baseline(
             if (ep_idx + 1) % 50 == 0 or ep_idx == num_episodes - 1:
                 elapsed = time.time() - t_start
                 sr_so_far = np.mean([r["success"] for r in all_results]) * 100
-                print(f"  [{ep_idx+1}/{num_episodes}] SR={sr_so_far:.1f}%  "
-                      f"elapsed={elapsed:.0f}s")
+                print(
+                    f"  [{ep_idx + 1}/{num_episodes}] SR={sr_so_far:.1f}%  "
+                    f"elapsed={elapsed:.0f}s"
+                )
 
     env.close()
 
@@ -199,19 +220,27 @@ def main():
         description="Random-action baseline for Habitat ObjectNav"
     )
     parser.add_argument(
-        "--curriculum_path", type=str, required=True,
+        "--curriculum_path",
+        type=str,
+        required=True,
         help="Path to curriculum JSON (e.g. data/curriculum/level1_1house_1goal.json)",
     )
     parser.add_argument(
-        "--output_dir", type=str, required=True,
+        "--output_dir",
+        type=str,
+        required=True,
         help="Directory to save episodes.csv and summary.json",
     )
     parser.add_argument(
-        "--max_episode_steps", type=int, default=500,
+        "--max_episode_steps",
+        type=int,
+        default=500,
         help="Max steps per episode (default: 500)",
     )
     parser.add_argument(
-        "--seed", type=int, default=42,
+        "--seed",
+        type=int,
+        default=42,
         help="Random seed (default: 42)",
     )
     args = parser.parse_args()

--- a/src/buffer/__init__.py
+++ b/src/buffer/__init__.py
@@ -3,4 +3,3 @@
 from src.buffer.replay_buffer import BufferConfig, ReplayBuffer, ValReplayDataset
 
 __all__ = ["BufferConfig", "ReplayBuffer", "ValReplayDataset"]
-

--- a/src/buffer/replay_buffer.py
+++ b/src/buffer/replay_buffer.py
@@ -27,6 +27,7 @@ class BufferConfig:
         normalize_obs: If True and obs_dtype is "uint8", divide by 255.0 on
             sample. Mapping configs can choose this per field.
     """
+
     capacity: int
     obs_shape: ObsShape
     obs_dtype: ObsDType = "uint8"
@@ -197,9 +198,7 @@ class ReplayBuffer:
                 key: np.zeros((cap, *spec.shape), dtype=_np_dtype(spec.dtype))
                 for key, spec in field_specs.items()
             }
-            self._normalize = {
-                key: spec.normalize for key, spec in field_specs.items()
-            }
+            self._normalize = {key: spec.normalize for key, spec in field_specs.items()}
             self._keep_uint8_on_sample = {
                 key: spec.keep_uint8_on_sample for key, spec in field_specs.items()
             }
@@ -211,9 +210,14 @@ class ReplayBuffer:
         self.idx = 0
         self.size = 0
 
-    def add(self, obs: np.ndarray | Mapping[str, np.ndarray],
-            action: int, reward: float, done: bool,
-            terminal: bool = False) -> None:
+    def add(
+        self,
+        obs: np.ndarray | Mapping[str, np.ndarray],
+        action: int,
+        reward: float,
+        done: bool,
+        terminal: bool = False,
+    ) -> None:
         if isinstance(self.obs, Mapping):
             if not isinstance(obs, Mapping):
                 raise TypeError("mapping replay buffer requires mapping obs")
@@ -236,8 +240,15 @@ class ReplayBuffer:
     def sample(self, batch_size: int, seq_len: int) -> dict[str, jnp.ndarray]:
         starts = self._sample_starts(batch_size, seq_len)
         return _gather_sequence_batch(
-            starts, seq_len, self.obs, self.actions, self.rewards,
-            self.dones, self.terminals, self._normalize, self._keep_uint8_on_sample,
+            starts,
+            seq_len,
+            self.obs,
+            self.actions,
+            self.rewards,
+            self.dones,
+            self.terminals,
+            self._normalize,
+            self._keep_uint8_on_sample,
         )
 
     def _sample_starts(self, batch_size: int, seq_len: int) -> np.ndarray:
@@ -274,10 +285,10 @@ class ValReplayDataset:
     def __init__(self, path: str, normalize: bool = True):
         self._normalize = normalize
         data = np.load(path)
-        self.obs = data["obs"]          # (N, ...) uint8 or float32
+        self.obs = data["obs"]  # (N, ...) uint8 or float32
         self.actions = data["actions"]  # (N,) int32
         self.rewards = data["rewards"]  # (N,) float32
-        self.dones = data["dones"]      # (N,) bool
+        self.dones = data["dones"]  # (N,) bool
         self.terminals = data["terminals"]  # (N,) bool
 
         # Reconstruct episode boundaries from dones
@@ -288,10 +299,12 @@ class ValReplayDataset:
         self._ep_starts = self._ep_starts[self._ep_starts < len(self.obs)]
         # Episode lengths
         ends = np.concatenate([done_indices + 1, [len(self.obs)]])
-        self._ep_lengths = ends[:len(self._ep_starts)] - self._ep_starts
+        self._ep_lengths = ends[: len(self._ep_starts)] - self._ep_starts
 
-        print(f"ValReplayDataset: {len(self.obs)} steps, "
-              f"{len(self._ep_starts)} episodes from {path}")
+        print(
+            f"ValReplayDataset: {len(self.obs)} steps, "
+            f"{len(self._ep_starts)} episodes from {path}"
+        )
 
     def sample(self, batch_size: int, seq_len: int) -> dict:
         """Sample random subsequences, same format as ReplayBuffer.sample()."""
@@ -306,21 +319,30 @@ class ValReplayDataset:
         ep_idx = np.random.choice(valid, size=batch_size)
         ep_starts = self._ep_starts[ep_idx]
         ep_lens = self._ep_lengths[ep_idx]
-        offsets = np.array([
-            np.random.randint(0, l - seq_len + 1) for l in ep_lens
-        ])
+        offsets = np.array(
+            [np.random.randint(0, ep_len - seq_len + 1) for ep_len in ep_lens]
+        )
         starts = ep_starts + offsets
         return _gather_sequence_batch(
-            starts, seq_len, self.obs, self.actions, self.rewards,
-            self.dones, self.terminals, self._normalize, False,
+            starts,
+            seq_len,
+            self.obs,
+            self.actions,
+            self.rewards,
+            self.dones,
+            self.terminals,
+            self._normalize,
+            False,
         )
 
 
 def VGGTReplayBuffer(capacity: int, feature_dim: int = 4116) -> ReplayBuffer:
     """Backward-compat factory. Use ReplayBuffer(BufferConfig(...)) directly."""
-    return ReplayBuffer(BufferConfig(
-        capacity=capacity,
-        obs_shape=(feature_dim,),
-        obs_dtype="float32",
-        normalize_obs=False,
-    ))
+    return ReplayBuffer(
+        BufferConfig(
+            capacity=capacity,
+            obs_shape=(feature_dim,),
+            obs_dtype="float32",
+            normalize_obs=False,
+        )
+    )

--- a/src/environments/crafter.py
+++ b/src/environments/crafter.py
@@ -6,6 +6,7 @@ import numpy as np
 class CrafterEnv:
     def __init__(self, size=(64, 64), seed=None):
         import crafter
+
         self._env = crafter.Env(size=size, reward=True, seed=seed)
         self.num_actions = self._env.action_space.n  # 17
 

--- a/src/environments/habitat.py
+++ b/src/environments/habitat.py
@@ -26,12 +26,13 @@ GOAL_RADIUS = 0.2
 
 def _validate_goal_distance(dist: float) -> float:
     if dist is None:
-        raise ValueError("distance_to_goal must be a finite non-negative value, got None")
+        raise ValueError(
+            "distance_to_goal must be a finite non-negative value, got None"
+        )
     dist = float(dist)
     if not np.isfinite(dist) or dist < 0.0:
         raise ValueError(
-            "distance_to_goal must be a finite non-negative value, "
-            f"got {dist!r}"
+            f"distance_to_goal must be a finite non-negative value, got {dist!r}"
         )
     return dist
 
@@ -52,9 +53,7 @@ def find_nearest_viewpoint(env):
     for gi, goal in enumerate(env.current_episode.goals):
         if goal.view_points:
             for vp in goal.view_points:
-                d = env.sim.geodesic_distance(
-                    agent_pos, vp.agent_state.position
-                )
+                d = env.sim.geodesic_distance(agent_pos, vp.agent_state.position)
                 if d < best_dist:
                     best_dist = d
                     best_pos = vp.agent_state.position
@@ -86,17 +85,25 @@ def sample_navmesh(env, resolution: float = 0.05) -> dict:
 
     return {
         "grid": grid,
-        "x_min": float(x_min), "x_max": float(x_max),
-        "z_min": float(z_min), "z_max": float(z_max),
+        "x_min": float(x_min),
+        "x_max": float(x_max),
+        "z_min": float(z_min),
+        "z_max": float(z_max),
         "resolution": resolution,
     }
 
 
 class HabitatObjectNavEnv:
-    def __init__(self, config: DreamerConfig, max_geodesic: float | None = None,
-                 step_counts_path: str | None = None, semantic: bool = False,
-                 curriculum_path: str | None = None,
-                 curriculum_mode: str = "train", seed: int | None = None):
+    def __init__(
+        self,
+        config: DreamerConfig,
+        max_geodesic: float | None = None,
+        step_counts_path: str | None = None,
+        semantic: bool = False,
+        curriculum_path: str | None = None,
+        curriculum_mode: str = "train",
+        seed: int | None = None,
+    ):
         import habitat
         from omegaconf import OmegaConf
 
@@ -108,13 +115,12 @@ class HabitatObjectNavEnv:
         curriculum = None
         if curriculum_path is not None:
             import json
+
             split = "train"
             with open(curriculum_path) as f:
                 curriculum = json.load(f)
 
-        hab_cfg = habitat.get_config(
-            "benchmark/nav/objectnav/objectnav_hm3d.yaml"
-        )
+        hab_cfg = habitat.get_config("benchmark/nav/objectnav/objectnav_hm3d.yaml")
         with habitat.config.read_write(hab_cfg):
             hab_cfg.habitat.dataset.split = split
             if seed is not None:
@@ -143,15 +149,20 @@ class HabitatObjectNavEnv:
             self._env.seed(int(seed))
 
         if curriculum is not None:
-
             # Keys are [episode_id, object_category, scene_name] triples
-            key_set = {(k[0], k[1], k[2])
-                       for k in curriculum[f"{curriculum_mode}_episode_keys"]}
+            key_set = {
+                (k[0], k[1], k[2])
+                for k in curriculum[f"{curriculum_mode}_episode_keys"]
+            }
             before = len(self._env._dataset.episodes)
             self._env._dataset.episodes = [
-                ep for ep in self._env._dataset.episodes
-                if (ep.episode_id, ep.object_category,
-                    ep.scene_id.split("/")[-1].replace(".basis.glb", ""))
+                ep
+                for ep in self._env._dataset.episodes
+                if (
+                    ep.episode_id,
+                    ep.object_category,
+                    ep.scene_id.split("/")[-1].replace(".basis.glb", ""),
+                )
                 in key_set
             ]
             after = len(self._env._dataset.episodes)
@@ -161,13 +172,16 @@ class HabitatObjectNavEnv:
             )
             self._env._setup_episode_iterator()
             self._env.current_episode = next(self._env.episode_iterator)
-            print(f"Curriculum [{curriculum['name']}] {curriculum_mode}: "
-                  f"{before} → {after} episodes")
+            print(
+                f"Curriculum [{curriculum['name']}] {curriculum_mode}: "
+                f"{before} → {after} episodes"
+            )
         else:
             if max_geodesic is not None:
                 before = len(self._env._dataset.episodes)
                 self._env._dataset.episodes = [
-                    ep for ep in self._env._dataset.episodes
+                    ep
+                    for ep in self._env._dataset.episodes
                     if ep.info is not None
                     and ep.info.get("geodesic_distance", float("inf")) < max_geodesic
                 ]
@@ -177,17 +191,21 @@ class HabitatObjectNavEnv:
                 )
                 self._env._setup_episode_iterator()
                 self._env.current_episode = next(self._env.episode_iterator)
-                print(f"Filtered: {before} → {after} "
-                      f"episodes (geodesic < {max_geodesic}m)")
+                print(
+                    f"Filtered: {before} → {after} "
+                    f"episodes (geodesic < {max_geodesic}m)"
+                )
 
             if step_counts_path is not None:
                 import json
+
                 with open(step_counts_path) as f:
                     step_counts = json.load(f)
                 split_counts = step_counts.get(config.split, {})
                 before = len(self._env._dataset.episodes)
                 self._env._dataset.episodes = [
-                    ep for ep in self._env._dataset.episodes
+                    ep
+                    for ep in self._env._dataset.episodes
                     if split_counts.get(ep.episode_id, 0) < 200
                 ]
                 after = len(self._env._dataset.episodes)
@@ -196,8 +214,9 @@ class HabitatObjectNavEnv:
                 )
                 self._env._setup_episode_iterator()
                 self._env.current_episode = next(self._env.episode_iterator)
-                print(f"Filtered (step count): {before} → "
-                      f"{after} episodes (steps < 200)")
+                print(
+                    f"Filtered (step count): {before} → {after} episodes (steps < 200)"
+                )
 
         self._prev_dist = 0.0
         self._step_count = 0
@@ -301,9 +320,7 @@ class HabitatObjectNavEnv:
 
     def _invalid_goal_distance_transition(self, obs, raw_dist: object) -> dict:
         image = self._obs_to_image(obs)
-        fallback_dist = (
-            self._prev_dist if np.isfinite(float(self._prev_dist)) else 0.0
-        )
+        fallback_dist = self._prev_dist if np.isfinite(float(self._prev_dist)) else 0.0
         return {
             "image": image,
             "reward": self._cfg.step_penalty,

--- a/src/environments/habitat_r2dreamer.py
+++ b/src/environments/habitat_r2dreamer.py
@@ -1,4 +1,5 @@
 """Habitat ObjectNav env adapter for PyTorch r2dreamer's interface."""
+
 import math
 
 import numpy as np
@@ -24,18 +25,37 @@ def build_agent_state(
         [0..15]:  4x4 camera-to-world extrinsics
         [16..24]: 3x3 intrinsics K (fx=fy from hfov, cx=W/2, cy=H/2)
     """
-    qx, qy, qz, qw = (float(quat_xyzw[0]), float(quat_xyzw[1]),
-                      float(quat_xyzw[2]), float(quat_xyzw[3]))
+    qx, qy, qz, qw = (
+        float(quat_xyzw[0]),
+        float(quat_xyzw[1]),
+        float(quat_xyzw[2]),
+        float(quat_xyzw[3]),
+    )
     n = math.sqrt(qx * qx + qy * qy + qz * qz + qw * qw)
     if n == 0.0:
         raise ValueError("quaternion has zero norm")
     qx, qy, qz, qw = qx / n, qy / n, qz / n, qw / n
 
-    R = np.array([
-        [1 - 2 * (qy * qy + qz * qz), 2 * (qx * qy - qz * qw), 2 * (qx * qz + qy * qw)],
-        [2 * (qx * qy + qz * qw), 1 - 2 * (qx * qx + qz * qz), 2 * (qy * qz - qx * qw)],
-        [2 * (qx * qz - qy * qw), 2 * (qy * qz + qx * qw), 1 - 2 * (qx * qx + qy * qy)],
-    ], dtype=np.float32)
+    R = np.array(
+        [
+            [
+                1 - 2 * (qy * qy + qz * qz),
+                2 * (qx * qy - qz * qw),
+                2 * (qx * qz + qy * qw),
+            ],
+            [
+                2 * (qx * qy + qz * qw),
+                1 - 2 * (qx * qx + qz * qz),
+                2 * (qy * qz - qx * qw),
+            ],
+            [
+                2 * (qx * qz - qy * qw),
+                2 * (qy * qz + qx * qw),
+                1 - 2 * (qx * qx + qy * qy),
+            ],
+        ],
+        dtype=np.float32,
+    )
 
     extrinsics = np.eye(4, dtype=np.float32)
     extrinsics[:3, :3] = R
@@ -46,24 +66,38 @@ def build_agent_state(
     fy = fx  # square pixels in Habitat
     cx = width / 2.0
     cy = height / 2.0
-    intrinsics = np.array([
-        [fx, 0.0, cx],
-        [0.0, fy, cy],
-        [0.0, 0.0, 1.0],
-    ], dtype=np.float32)
+    intrinsics = np.array(
+        [
+            [fx, 0.0, cx],
+            [0.0, fy, cy],
+            [0.0, 0.0, 1.0],
+        ],
+        dtype=np.float32,
+    )
 
-    return np.concatenate([extrinsics.reshape(-1), intrinsics.reshape(-1)]).astype(np.float32)
+    return np.concatenate([extrinsics.reshape(-1), intrinsics.reshape(-1)]).astype(
+        np.float32
+    )
 
 
 class HabitatR2DreamerEnv:
-    def __init__(self, obs_size=64, split="train", max_episode_steps=500,
-                 max_geodesic=None, reward_type="geodesic_delta"):
+    def __init__(
+        self,
+        obs_size=64,
+        split="train",
+        max_episode_steps=500,
+        max_geodesic=None,
+        reward_type="geodesic_delta",
+    ):
         from src.shared.configs import DreamerConfig
         from src.environments.habitat import HabitatObjectNavEnv
+
         config = DreamerConfig(
             obs_shape=(3, obs_size, obs_size),
             max_episode_steps=max_episode_steps,
-            split=split, reward_type=reward_type)
+            split=split,
+            reward_type=reward_type,
+        )
         self._env = HabitatObjectNavEnv(config, max_geodesic=max_geodesic)
         self.num_actions = 4
         self._H = obs_size
@@ -84,7 +118,8 @@ class HabitatR2DreamerEnv:
         rotation = sensor_state.rotation
         # habitat_sim quaternion: .x .y .z .w
         quat_xyzw = np.array(
-            [rotation.x, rotation.y, rotation.z, rotation.w], dtype=np.float32)
+            [rotation.x, rotation.y, rotation.z, rotation.w], dtype=np.float32
+        )
         # hfov is set per-sensor; default 90 deg if introspection fails
         try:
             hfov_deg = float(sim._sensors["rgb"].specification().hfov)
@@ -95,9 +130,14 @@ class HabitatR2DreamerEnv:
     def reset(self):
         obs = self._env.reset()
         image = np.transpose(obs["image"], (1, 2, 0))  # CHW->HWC
-        return {"image": image, "reward": np.float32(0.0),
-                "is_first": True, "is_last": False, "is_terminal": False,
-                "agent_state": self._agent_state()}
+        return {
+            "image": image,
+            "reward": np.float32(0.0),
+            "is_first": True,
+            "is_last": False,
+            "is_terminal": False,
+            "agent_state": self._agent_state(),
+        }
 
     def step(self, action):
         if isinstance(action, np.ndarray):
@@ -106,11 +146,16 @@ class HabitatR2DreamerEnv:
         image = np.transpose(obs["image"], (1, 2, 0))
         done = obs["done"]
         success = obs.get("success", 0.0) > 0
-        return {"image": image, "reward": np.float32(obs["reward"]),
-                "is_first": False, "is_last": done, "is_terminal": success,
-                "success": obs.get("success", 0.0),
-                "spl": obs.get("spl", 0.0),
-                "agent_state": self._agent_state()}
+        return {
+            "image": image,
+            "reward": np.float32(obs["reward"]),
+            "is_first": False,
+            "is_last": done,
+            "is_terminal": success,
+            "success": obs.get("success", 0.0),
+            "spl": obs.get("spl", 0.0),
+            "agent_state": self._agent_state(),
+        }
 
     def close(self):
         self._env.close()

--- a/src/main.py
+++ b/src/main.py
@@ -31,11 +31,20 @@ def _build_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     train_parser = subparsers.add_parser("train", help="Train R2Dreamer end to end.")
-    train_parser.add_argument("--env", default="habitat", choices=["habitat", "crafter"])
+    train_parser.add_argument(
+        "--env", default="habitat", choices=["habitat", "crafter"]
+    )
     train_parser.add_argument(
         "--encoder",
         default="cnn",
-        choices=["cnn", "vggt", "vggt_aggregator_mlp", "vggt_wp_dense_cnn", "vggt_wp_cp_64", "hybrid"],
+        choices=[
+            "cnn",
+            "vggt",
+            "vggt_aggregator_mlp",
+            "vggt_wp_dense_cnn",
+            "vggt_wp_cp_64",
+            "hybrid",
+        ],
     )
     train_parser.add_argument("--curriculum", default=None)
 
@@ -44,7 +53,14 @@ def _build_parser() -> argparse.ArgumentParser:
     eval_parser.add_argument(
         "--encoder",
         default="cnn",
-        choices=["cnn", "vggt", "vggt_aggregator_mlp", "vggt_wp_dense_cnn", "vggt_wp_cp_64", "hybrid"],
+        choices=[
+            "cnn",
+            "vggt",
+            "vggt_aggregator_mlp",
+            "vggt_wp_dense_cnn",
+            "vggt_wp_cp_64",
+            "hybrid",
+        ],
     )
     eval_parser.add_argument("--curriculum", default=None)
     eval_parser.add_argument("--checkpoint", default=None)

--- a/src/r2dreamer/adapters/hybrid_adapter.py
+++ b/src/r2dreamer/adapters/hybrid_adapter.py
@@ -18,7 +18,6 @@ from src.r2dreamer.obs_batch import (
     HYBRID_WP_CP_KEY,
 )
 from src.r2dreamer.observation_preparation.vggt import (
-    HYBRID_FEATURE_DIM,
     HYBRID_IMAGE_SHAPE,
     HYBRID_RGB_DIM,
     VGGT_AGGREGATOR_TOKEN_COUNT,
@@ -170,7 +169,9 @@ class VGGTHouseContextObsAdapter(ObsAdapter):
             on_episode_reset=None,
         )
         self._extractor = extractor
-        self._context_transformer = context_transformer or VGGTFullTokenContextTransformer()
+        self._context_transformer = (
+            context_transformer or VGGTFullTokenContextTransformer()
+        )
         self._context_params = None
         self._rng = jax.random.PRNGKey(rng_seed)
         self._context: np.ndarray | None = None

--- a/src/r2dreamer/adapters/obs_adapter.py
+++ b/src/r2dreamer/adapters/obs_adapter.py
@@ -21,6 +21,7 @@ class ObsAdapter:
     Default: extracts obs["image"] for buffer (uint8), passes obs dict
     through to agent unchanged.
     """
+
     buffer_dtype: BufferDType = "uint8"
     buffer_shape: BufferShape = (3, 64, 64)
     normalize_on_sample: BufferNormalize = True
@@ -38,7 +39,9 @@ class ObsAdapter:
             )
         return self.buffer_shape
 
-    def transform(self, obs_dict: dict) -> tuple[np.ndarray | dict[str, np.ndarray], dict]:
+    def transform(
+        self, obs_dict: dict
+    ) -> tuple[np.ndarray | dict[str, np.ndarray], dict]:
         """Returns (buffer_obs, agent_obs_dict)."""
         return obs_dict["image"], obs_dict
 

--- a/src/r2dreamer/adapters/vggt_adapter.py
+++ b/src/r2dreamer/adapters/vggt_adapter.py
@@ -16,7 +16,9 @@ from src.r2dreamer.observation_preparation.vggt import (
     wp_cp_dim,
 )
 from src.r2dreamer.observation_preparation.vggt_readouts import make_vggt_readout
-from src.vggt.jax.feature_extractor import JAXVGGTFeatureExtractor as VGGTFeatureExtractor
+from src.vggt.jax.feature_extractor import (
+    JAXVGGTFeatureExtractor as VGGTFeatureExtractor,
+)
 
 
 VGGT_FEATURE_DIM = wp_cp_dim()  # 37*37*3 + 9
@@ -67,7 +69,9 @@ class VGGTObsAdapter(ObsAdapter):
             contract=self.contract,
         )
 
-    def transform(self, obs_dict: dict) -> tuple[np.ndarray | dict[str, np.ndarray], dict]:
+    def transform(
+        self, obs_dict: dict
+    ) -> tuple[np.ndarray | dict[str, np.ndarray], dict]:
         return self._readout.prepare(
             self._extractor,
             obs_dict["image"],

--- a/src/r2dreamer/agent.py
+++ b/src/r2dreamer/agent.py
@@ -351,7 +351,8 @@ def _add_encoder_l2_metric(metrics: dict[str, Any], params: dict[str, Any]) -> N
     # toggle is actually moving the encoder weights.
     enc_sq = jax.tree_util.tree_reduce(
         lambda acc, x: acc + jnp.sum(jnp.square(x)),
-        params["encoder"], 0.0,
+        params["encoder"],
+        0.0,
     )
     metrics["params/encoder_l2"] = jnp.sqrt(enc_sq)
 
@@ -374,8 +375,8 @@ def _add_hybrid_contribution_metrics(
     cnn_e = embed_flat[:, :cnn_dim]
     vggt_e = embed_flat[:, cnn_dim:]
     gate = params["encoder"]["params"]["gate"]
-    cnn_l2 = jnp.sqrt(jnp.mean(jnp.sum(cnn_e ** 2, axis=-1)))
-    vggt_l2 = jnp.sqrt(jnp.mean(jnp.sum(vggt_e ** 2, axis=-1)))
+    cnn_l2 = jnp.sqrt(jnp.mean(jnp.sum(cnn_e**2, axis=-1)))
+    vggt_l2 = jnp.sqrt(jnp.mean(jnp.sum(vggt_e**2, axis=-1)))
     denom = cnn_l2 + vggt_l2 + 1e-8
     metrics["hybrid/gate"] = gate
     metrics["hybrid/cnn_l2"] = cnn_l2
@@ -475,7 +476,9 @@ class R2DreamerAgent:
                 "Contract snapshot"
             )
         config = R2DreamerConfig(
-            obs_shape=obs_shape, num_actions=num_actions, **config_kwargs,
+            obs_shape=obs_shape,
+            num_actions=num_actions,
+            **config_kwargs,
         )
         rng_key = jax.random.PRNGKey(seed)
         rng_key, init_key = jax.random.split(rng_key)
@@ -507,7 +510,8 @@ class R2DreamerAgent:
         embed0 = jnp.zeros((1, self.embed_size))
         rng_key, k_sample = jax.random.split(rng_key)
         rssm_params = self.rssm_mod.init(
-            {"params": k2, "sample": k_sample}, stoch0, deter0, action0, embed0)
+            {"params": k2, "sample": k_sample}, stoch0, deter0, action0, embed0
+        )
 
         # Projector: feat_size -> embed_size
         self.proj_mod = Projector(out_dim=self.embed_size)
@@ -555,7 +559,10 @@ class R2DreamerAgent:
         dec_params = None
         if config.decoder:
             if config.encoder_type not in (
-                "cnn", "hybrid", "vggt_house_context", "vggt_house_full_tokens_nogate"
+                "cnn",
+                "hybrid",
+                "vggt_house_context",
+                "vggt_house_full_tokens_nogate",
             ):
                 raise ValueError(
                     "decoder=True requires an RGB-bearing encoder_type — the "
@@ -635,7 +642,9 @@ class R2DreamerAgent:
     # Acting
     # ------------------------------------------------------------------
 
-    def act(self, obs_dict: Dict[str, Any], rng_key: jnp.ndarray, training: bool = True) -> int:
+    def act(
+        self, obs_dict: Dict[str, Any], rng_key: jnp.ndarray, training: bool = True
+    ) -> int:
         """Select an action for a single environment step.
 
         Args:
@@ -668,9 +677,7 @@ class R2DreamerAgent:
 
         self._act_stoch = np.array(new_stoch)
         self._act_deter = np.array(new_deter)
-        self._act_prev_action = np.zeros(
-            (1, self.cfg.num_actions), dtype=np.float32
-        )
+        self._act_prev_action = np.zeros((1, self.cfg.num_actions), dtype=np.float32)
         self._act_prev_action[0, action_int] = 1.0
 
         return action_int
@@ -680,7 +687,11 @@ class R2DreamerAgent:
         embed = self.encoder_mod.apply(params["encoder"], obs)
         rng_key, k_sample = jax.random.split(rng_key)
         new_stoch, new_deter, _ = self.rssm_mod.apply(
-            params["rssm"], stoch, deter, prev_action, embed,
+            params["rssm"],
+            stoch,
+            deter,
+            prev_action,
+            embed,
             rngs={"sample": k_sample},
         )
         feat = self.rssm_mod.apply(
@@ -716,14 +727,20 @@ class R2DreamerAgent:
         obs_flat = encoder_obs_from_batch(batch, self.cfg)
         embed = self.encoder_mod.apply(params["encoder"], obs_flat).reshape(B, T, -1)
         stoch0, deter0 = self.rssm_mod.apply(
-            params["rssm"], B, method=self.rssm_mod.initial_state)
+            params["rssm"], B, method=self.rssm_mod.initial_state
+        )
         post_stochs, post_deters, _ = self.rssm_mod.apply(
-            params["rssm"], embed, batch["actions"], (stoch0, deter0),
-            batch["is_first"], method=self.rssm_mod.observe,
+            params["rssm"],
+            embed,
+            batch["actions"],
+            (stoch0, deter0),
+            batch["is_first"],
+            method=self.rssm_mod.observe,
             rngs={"sample": jax.random.PRNGKey(0)},
         )
         feat = self.rssm_mod.apply(
-            params["rssm"], post_stochs, post_deters, method=self.rssm_mod.get_feat)
+            params["rssm"], post_stochs, post_deters, method=self.rssm_mod.get_feat
+        )
         recon = self.decoder_mod.apply(params["decoder"], feat.reshape(B * T, -1))
         target = decoder_rgb_target(batch, self.cfg)
         return np.asarray(target), np.asarray(recon)
@@ -732,7 +749,9 @@ class R2DreamerAgent:
     # Training
     # ------------------------------------------------------------------
 
-    def train_step(self, batch: Dict[str, jnp.ndarray], rng_key: jnp.ndarray) -> Dict[str, float]:
+    def train_step(
+        self, batch: Dict[str, jnp.ndarray], rng_key: jnp.ndarray
+    ) -> Dict[str, float]:
         """One LaProp step on `batch`. Returns Python-float metrics."""
         self.train_state, metrics = self._jitted_train_step(
             self.train_state,
@@ -777,13 +796,19 @@ class R2DreamerAgent:
 
         # Roll back to pre-update state on NaN/inf
         new_params = jax.tree.map(
-            lambda new, old: jnp.where(is_finite, new, old), new_params, params)
+            lambda new, old: jnp.where(is_finite, new, old), new_params, params
+        )
         new_opt_state = jax.tree.map(
-            lambda new, old: jnp.where(is_finite, new, old), new_opt_state, opt_state)
+            lambda new, old: jnp.where(is_finite, new, old), new_opt_state, opt_state
+        )
         new_slow = jax.tree.map(
-            lambda new, old: jnp.where(is_finite, new, old), updated_slow, slow_critic_params)
+            lambda new, old: jnp.where(is_finite, new, old),
+            updated_slow,
+            slow_critic_params,
+        )
         new_ema_state = jax.tree.map(
-            lambda new, old: jnp.where(is_finite, new, old), new_ema_state, ema_state)
+            lambda new, old: jnp.where(is_finite, new, old), new_ema_state, ema_state
+        )
 
         metrics = aux["metrics"]
         metrics["opt_loss"] = total_loss
@@ -815,26 +840,36 @@ class R2DreamerAgent:
         embed = self.encoder_mod.apply(params["encoder"], obs_flat).reshape(B, T, -1)
 
         stoch0, deter0 = self.rssm_mod.apply(
-            params["rssm"], B, method=self.rssm_mod.initial_state)
+            params["rssm"], B, method=self.rssm_mod.initial_state
+        )
 
         rng_key, k_obs = jax.random.split(rng_key)
         post_stochs, post_deters, post_logits = self.rssm_mod.apply(
-            params["rssm"], embed, batch["actions"], (stoch0, deter0),
-            batch["is_first"], method=self.rssm_mod.observe,
+            params["rssm"],
+            embed,
+            batch["actions"],
+            (stoch0, deter0),
+            batch["is_first"],
+            method=self.rssm_mod.observe,
             rngs={"sample": k_obs},
         )
 
         rng_key, k_prior = jax.random.split(rng_key)
         _, prior_logits_flat = self.rssm_mod.apply(
-            params["rssm"], post_deters.reshape(B * T, -1),
+            params["rssm"],
+            post_deters.reshape(B * T, -1),
             method=self.rssm_mod.prior,
             rngs={"sample": k_prior},
         )
         prior_logits = prior_logits_flat.reshape(
-            B, T, cfg.stoch_classes, cfg.stoch_discrete)
+            B, T, cfg.stoch_classes, cfg.stoch_discrete
+        )
 
         feat = self.rssm_mod.apply(
-            params["rssm"], post_stochs, post_deters, method=self.rssm_mod.get_feat,
+            params["rssm"],
+            post_stochs,
+            post_deters,
+            method=self.rssm_mod.get_feat,
         )
 
         return {
@@ -860,24 +895,40 @@ class R2DreamerAgent:
         forward = self._world_model_forward(params, batch, k_fwd)
 
         wm_losses, wm_metrics = world_model_loss(
-            forward=forward, params=params, batch=batch,
-            modules=self._modules, cfg=cfg, twohot=self.twohot,
+            forward=forward,
+            params=params,
+            batch=batch,
+            modules=self._modules,
+            cfg=cfg,
+            twohot=self.twohot,
         )
 
         rng_key, k_behavior = jax.random.split(rng_key)
         bh_losses, bh_metrics, imag_ret = behavior_loss(
-            forward=forward, params=params, modules=self._modules,
-            cfg=cfg, twohot=self.twohot,
-            slow_critic_params=slow_critic_params, ema_state=ema_state,
-            return_ema=self.return_ema, rng_key=k_behavior,
-            B=B, T=T,
+            forward=forward,
+            params=params,
+            modules=self._modules,
+            cfg=cfg,
+            twohot=self.twohot,
+            slow_critic_params=slow_critic_params,
+            ema_state=ema_state,
+            return_ema=self.return_ema,
+            rng_key=k_behavior,
+            B=B,
+            T=T,
         )
 
         rep_losses, rep_metrics = representation_loss(
-            forward=forward, batch=batch, params=params, modules=self._modules,
-            cfg=cfg, twohot=self.twohot,
-            slow_critic_params=slow_critic_params, imag_ret=imag_ret,
-            B=B, T=T,
+            forward=forward,
+            batch=batch,
+            params=params,
+            modules=self._modules,
+            cfg=cfg,
+            twohot=self.twohot,
+            slow_critic_params=slow_critic_params,
+            imag_ret=imag_ret,
+            B=B,
+            T=T,
         )
 
         losses = {**wm_losses, **bh_losses, **rep_losses}
@@ -902,7 +953,12 @@ class R2DreamerAgent:
         # opens over training; `*_frac` is each branch's share of the embed norm.
         if cfg.encoder_type in ("hybrid", "vggt_house_context"):
             _add_hybrid_contribution_metrics(
-                metrics, cfg=cfg, params=params, forward=forward, B=B, T=T,
+                metrics,
+                cfg=cfg,
+                params=params,
+                forward=forward,
+                B=B,
+                T=T,
             )
 
         aux = {

--- a/src/r2dreamer/behavior/imagination.py
+++ b/src/r2dreamer/behavior/imagination.py
@@ -10,8 +10,16 @@ import jax
 import jax.numpy as jnp
 
 
-def _imagine(rssm_params, actor_params, rssm_mod, actor_mod,
-             start_stoch, start_deter, horizon, rng_key):
+def _imagine(
+    rssm_params,
+    actor_params,
+    rssm_mod,
+    actor_mod,
+    start_stoch,
+    start_deter,
+    horizon,
+    rng_key,
+):
     """Imagination rollout in latent space (no gradients).
 
     Matches PyTorch: imagination is fully detached (@torch.no_grad).
@@ -59,7 +67,11 @@ def _imagine(rssm_params, actor_params, rssm_mod, actor_mod,
 
         rng_key, k_img = jax.random.split(rng_key)
         stoch, deter = rssm_mod.apply(
-            frozen_rssm_params, stoch, deter, action, method=rssm_mod.img_step,
+            frozen_rssm_params,
+            stoch,
+            deter,
+            action,
+            method=rssm_mod.img_step,
             rngs={"sample": k_img},
         )
 
@@ -84,9 +96,7 @@ def _lambda_return(last, term, reward, value, boot, disc, lamb):
         return val, val
 
     init = boot[..., -1, :]
-    _, outs = jax.lax.scan(
-        _scan_fn, init, jnp.arange(T_minus_1)
-    )
+    _, outs = jax.lax.scan(_scan_fn, init, jnp.arange(T_minus_1))
     # outs: (T_minus_1, ..., 1) — need to reverse and transpose
     outs = jnp.flip(outs, axis=0)
     ndim = outs.ndim

--- a/src/r2dreamer/behavior/loss.py
+++ b/src/r2dreamer/behavior/loss.py
@@ -14,8 +14,20 @@ import jax.numpy as jnp
 from .imagination import _imagine, _lambda_return
 
 
-def behavior_loss(*, forward, params, modules, cfg, twohot,
-                  slow_critic_params, ema_state, return_ema, rng_key, B, T):
+def behavior_loss(
+    *,
+    forward,
+    params,
+    modules,
+    cfg,
+    twohot,
+    slow_critic_params,
+    ema_state,
+    return_ema,
+    rng_key,
+    B,
+    T,
+):
     """Compute policy + value losses on an imagined rollout.
 
     Args:
@@ -47,10 +59,14 @@ def behavior_loss(*, forward, params, modules, cfg, twohot,
     )
 
     imag_feats, imag_actions, _ = _imagine(
-        params["rssm"], params["actor"],
-        modules["rssm"], modules["actor"],
-        start_stoch, start_deter,
-        cfg_horizon, rng_key,
+        params["rssm"],
+        params["actor"],
+        modules["rssm"],
+        modules["actor"],
+        start_stoch,
+        start_deter,
+        cfg_horizon,
+        rng_key,
     )
     # Already-frozen inside _imagine, but guard at the boundary too
     imag_feats = jax.lax.stop_gradient(imag_feats)
@@ -60,15 +76,18 @@ def behavior_loss(*, forward, params, modules, cfg, twohot,
 
     # Frozen reward/cont/critic heads scoring the imagined trajectory
     imag_rew_logits = modules["reward"].apply(
-        jax.lax.stop_gradient(params["reward"]), imag_feat_flat)
+        jax.lax.stop_gradient(params["reward"]), imag_feat_flat
+    )
     imag_reward = twohot.pred(imag_rew_logits).reshape(B * T, cfg_horizon, 1)
 
     imag_cont_logits = modules["cont"].apply(
-        jax.lax.stop_gradient(params["cont"]), imag_feat_flat)
+        jax.lax.stop_gradient(params["cont"]), imag_feat_flat
+    )
     imag_cont = jax.nn.sigmoid(imag_cont_logits).reshape(B * T, cfg_horizon, 1)
 
     imag_val_logits = modules["critic"].apply(
-        jax.lax.stop_gradient(params["critic"]), imag_feat_flat)
+        jax.lax.stop_gradient(params["critic"]), imag_feat_flat
+    )
     imag_value = twohot.pred(imag_val_logits).reshape(B * T, cfg_horizon, 1)
 
     imag_slow_logits = modules["critic"].apply(slow_critic_params, imag_feat_flat)
@@ -80,16 +99,24 @@ def behavior_loss(*, forward, params, modules, cfg, twohot,
     last = jnp.zeros_like(imag_cont)
     term = 1.0 - imag_cont
     ret = _lambda_return(
-        last, term, imag_reward, imag_value, imag_value, disc, cfg.lamb,
+        last,
+        term,
+        imag_reward,
+        imag_value,
+        imag_value,
+        disc,
+        cfg.lamb,
     )  # (BT, H-1, 1)
 
     _, ret_scale = return_ema.get_stats(ema_state)
     adv = (ret - imag_value[:, :-1]) / ret_scale
 
     # ---- Actor loss: re-evaluate unfrozen actor on detached imagined feats ----
-    actor_logits = modules["actor"].apply(
-        params["actor"], imag_feat_flat
-    ).reshape(B * T, cfg_horizon, cfg.num_actions)
+    actor_logits = (
+        modules["actor"]
+        .apply(params["actor"], imag_feat_flat)
+        .reshape(B * T, cfg_horizon, cfg.num_actions)
+    )
 
     # Unimix mixing — matches PyTorch OneHotDist
     probs = jax.nn.softmax(actor_logits, axis=-1)
@@ -107,12 +134,15 @@ def behavior_loss(*, forward, params, modules, cfg, twohot,
     )
 
     # ---- Critic loss on imagined features ----
-    cri_logits_imag = modules["critic"].apply(
-        params["critic"], imag_feat_flat
-    ).reshape(B * T, cfg_horizon, cfg.twohot_bins)
+    cri_logits_imag = (
+        modules["critic"]
+        .apply(params["critic"], imag_feat_flat)
+        .reshape(B * T, cfg_horizon, cfg.twohot_bins)
+    )
 
     tar_padded = jnp.concatenate(
-        [ret, jnp.zeros_like(ret[:, -1:])], axis=1)  # (BT, H, 1)
+        [ret, jnp.zeros_like(ret[:, -1:])], axis=1
+    )  # (BT, H, 1)
 
     critic_loss_tar = twohot.loss(cri_logits_imag[:, :-1], tar_padded[:, :-1, 0])
     critic_loss_slow = twohot.loss(
@@ -120,8 +150,7 @@ def behavior_loss(*, forward, params, modules, cfg, twohot,
         jax.lax.stop_gradient(imag_slow_value[:, :-1, 0]),
     )
     losses["value"] = jnp.mean(
-        jax.lax.stop_gradient(weight[:, :-1, 0])
-        * (critic_loss_tar + critic_loss_slow)
+        jax.lax.stop_gradient(weight[:, :-1, 0]) * (critic_loss_tar + critic_loss_slow)
     )
 
     return losses, {}, ret

--- a/src/r2dreamer/behavior/return_ema.py
+++ b/src/r2dreamer/behavior/return_ema.py
@@ -19,10 +19,12 @@ class ReturnEMA:
         return jnp.zeros(2)
 
     def update(self, state, returns):
-        quantiles = jnp.array([
-            jnp.percentile(returns, 5),
-            jnp.percentile(returns, 95),
-        ])
+        quantiles = jnp.array(
+            [
+                jnp.percentile(returns, 5),
+                jnp.percentile(returns, 95),
+            ]
+        )
         return self.alpha * quantiles + (1 - self.alpha) * state
 
     def get_stats(self, state):

--- a/src/r2dreamer/checkpointing.py
+++ b/src/r2dreamer/checkpointing.py
@@ -34,7 +34,9 @@ def config_snapshot(config: Any) -> dict[str, Any]:
     snapshot = (
         asdict(config)
         if is_dataclass(config)
-        else dict(vars(config)) if hasattr(config, "__dict__") else {}
+        else dict(vars(config))
+        if hasattr(config, "__dict__")
+        else {}
     )
     encoder_module_cls = snapshot.pop("encoder_module_cls", None)
     runtime_cls = getattr(config, "encoder_module_cls", None)
@@ -56,7 +58,8 @@ def encoder_input_contract_snapshot(config: Any) -> dict[str, Any] | None:
     snapshot = dict(snapshot)
     contract = recover_encoder_input_contract(snapshot)
     snapshot["encoder_module_kwargs"] = encoder_module_kwargs_from_config(
-        config, contract.encoder_module_cls,
+        config,
+        contract.encoder_module_cls,
     )
     return snapshot
 

--- a/src/r2dreamer/config.py
+++ b/src/r2dreamer/config.py
@@ -15,8 +15,12 @@ LATENT_PRESETS: dict[str, dict[str, int]] = {
 @dataclass
 class R2DreamerConfig:
     # --- Environment ---
-    obs_shape: Tuple[int, ...] | Mapping[str, Tuple[int, ...]] = (3, 64, 64)  # CHW format or structured fields
-    num_actions: int = 4   # Habitat default (STOP, FORWARD, TURN_LEFT, TURN_RIGHT); Crafter overrides to 17 in train.py
+    obs_shape: Tuple[int, ...] | Mapping[str, Tuple[int, ...]] = (
+        3,
+        64,
+        64,
+    )  # CHW format or structured fields
+    num_actions: int = 4  # Habitat default (STOP, FORWARD, TURN_LEFT, TURN_RIGHT); Crafter overrides to 17 in train.py
     max_episode_steps: int = 1000
 
     # --- RSSM ---
@@ -30,8 +34,12 @@ class R2DreamerConfig:
     img_layers: int = 2
 
     # --- Encoder ---
-    encoder_type: str = "cnn"  # canonical set: encoder_registry in src.r2dreamer.launch.registries
-    encoder_module_cls: Any = None  # Flax nn.Module class; sourced from EncoderSpec.module_cls
+    encoder_type: str = (
+        "cnn"  # canonical set: encoder_registry in src.r2dreamer.launch.registries
+    )
+    encoder_module_cls: Any = (
+        None  # Flax nn.Module class; sourced from EncoderSpec.module_cls
+    )
     encoder_depth: int = 16
     encoder_kernel: int = 5
     encoder_mults: Tuple[int, ...] = (2, 3, 4, 4)
@@ -58,14 +66,14 @@ class R2DreamerConfig:
     # --- Hybrid encoder (CNN on RGB + MLP on WP/CP, gated; 3D-50/51/52) ---
     # The hybrid's WP/CP branch has its own width/depth knobs (vggt_mlp_layers
     # above governs the standalone vggt/aggregator encoders).
-    mlp_vggt_hidden: int = 1024   # hidden width of the hybrid VGGT-branch MLP
-    mlp_vggt_layers: int = 2      # depth of the hybrid VGGT-branch MLP
+    mlp_vggt_hidden: int = 1024  # hidden width of the hybrid VGGT-branch MLP
+    mlp_vggt_layers: int = 2  # depth of the hybrid VGGT-branch MLP
     # --- Debug decoder probe (image reconstruction; OFF by default; 3D-51) ---
     # When enabled, trains a ConvDecoder from stop-gradient RSSM features for
     # W&B visualisation. It does not backprop reconstruction loss into the
     # encoder/RSSM/actor-critic objective.
-    decoder: bool = False         # build a ConvDecoder visualisation probe
-    scale_decoder: float = 1.0    # weight of decoder-only reconstruction loss
+    decoder: bool = False  # build a ConvDecoder visualisation probe
+    scale_decoder: float = 1.0  # weight of decoder-only reconstruction loss
     design_notes: str = ""
     # JSON-serializable Encoder Input Contract snapshot persisted to durable
     # run metadata. Runtime config may still hold encoder_module_cls; snapshots

--- a/src/r2dreamer/encoders/specs.py
+++ b/src/r2dreamer/encoders/specs.py
@@ -20,7 +20,9 @@ from src.r2dreamer.adapters.obs_adapter import ObsAdapter
 from src.r2dreamer.adapters.vggt_adapter import VGGTFeatureKind, VGGTObsAdapter
 from src.r2dreamer.observation_preparation import CNNObservationPreparation
 from src.r2dreamer.world_model import encoders as wm_encoders
-from src.vggt.jax.feature_extractor import JAXVGGTFeatureExtractor as VGGTFeatureExtractor
+from src.vggt.jax.feature_extractor import (
+    JAXVGGTFeatureExtractor as VGGTFeatureExtractor,
+)
 
 
 @dataclass(frozen=True)
@@ -419,19 +421,23 @@ class VGGTHouseContextEncoder(VGGTEncoder):
             resolution=args.render_resolution,
             transformer_layers=(
                 args.vggt_token_transformer_layers
-                if args.vggt_token_transformer_layers is not None else 2
+                if args.vggt_token_transformer_layers is not None
+                else 2
             ),
             transformer_heads=(
                 args.vggt_token_transformer_heads
-                if args.vggt_token_transformer_heads is not None else 8
+                if args.vggt_token_transformer_heads is not None
+                else 8
             ),
             transformer_mlp_ratio=(
                 args.vggt_token_transformer_mlp_ratio
-                if args.vggt_token_transformer_mlp_ratio is not None else 2
+                if args.vggt_token_transformer_mlp_ratio is not None
+                else 2
             ),
             transformer_dropout=(
                 args.vggt_token_transformer_dropout
-                if args.vggt_token_transformer_dropout is not None else 0.0
+                if args.vggt_token_transformer_dropout is not None
+                else 0.0
             ),
         )
 

--- a/src/r2dreamer/heldout_eval.py
+++ b/src/r2dreamer/heldout_eval.py
@@ -44,9 +44,14 @@ def _reward_mse(agent: Any, batch: dict, rng_key: jnp.ndarray) -> float:
     forward = agent._world_model_forward(params, batch, rng_key)
     B, T = obs_leading_shape(batch["obs"])
     feat = forward["feat"]
-    rew_logits = agent._modules["reward"].apply(
-        params["reward"], feat.reshape(B * T, -1),
-    ).reshape(B, T, -1)
+    rew_logits = (
+        agent._modules["reward"]
+        .apply(
+            params["reward"],
+            feat.reshape(B * T, -1),
+        )
+        .reshape(B, T, -1)
+    )
     pred = agent.twohot.pred(rew_logits).reshape(B, T)
     err = pred - batch["rewards"]
     return float(jnp.mean(err * err))
@@ -86,14 +91,19 @@ def _k_step_rollout_error(
     errors: dict[int, float] = {}
     for step in range(1, max_k + 1):
         stoch, deter = rssm.apply(
-            rssm_params, stoch, deter, actions[:, step - 1],
+            rssm_params,
+            stoch,
+            deter,
+            actions[:, step - 1],
             method=rssm.img_step,
             rngs={"sample": jax.random.fold_in(rng_key, step)},
         )
         if step in k_values:
             feat_pred = rssm.apply(rssm_params, stoch, deter, method=rssm.get_feat)
             feat_gt = rssm.apply(
-                rssm_params, post_stochs[:, step], post_deters[:, step],
+                rssm_params,
+                post_stochs[:, step],
+                post_deters[:, step],
                 method=rssm.get_feat,
             )
             err = jnp.mean(jnp.square(feat_pred - feat_gt))
@@ -125,7 +135,9 @@ def compute_heldout_metrics(
         for k, v in metrics.items():
             eval_sums[k] = eval_sums.get(k, 0.0) + float(v)
         rew_mse_sum += _reward_mse(agent, batch, k_rew)
-        for k, v in _k_step_rollout_error(agent, batch, k_roll, k_values=k_values).items():
+        for k, v in _k_step_rollout_error(
+            agent, batch, k_roll, k_values=k_values
+        ).items():
             rollout_sums[k] += v
         n += 1
 
@@ -136,7 +148,9 @@ def compute_heldout_metrics(
     out["heldout/reward_mse"] = rew_mse_sum / n
     for k, total in rollout_sums.items():
         out[f"heldout/k_step_rollout_mse/k{k}"] = total / n
-    out["heldout/reconstruction_nll"] = float("nan")  # No decoder — see module docstring.
+    out["heldout/reconstruction_nll"] = float(
+        "nan"
+    )  # No decoder — see module docstring.
     out["heldout/num_batches"] = float(n)
     return out
 
@@ -150,5 +164,7 @@ def metrics_table_row(metrics: dict[str, float]) -> dict[str, float]:
         "reward_mse": metrics.get("heldout/reward_mse", float("nan")),
         "k_step_rollout_k1": metrics.get("heldout/k_step_rollout_mse/k1", float("nan")),
         "k_step_rollout_k5": metrics.get("heldout/k_step_rollout_mse/k5", float("nan")),
-        "k_step_rollout_k15": metrics.get("heldout/k_step_rollout_mse/k15", float("nan")),
+        "k_step_rollout_k15": metrics.get(
+            "heldout/k_step_rollout_mse/k15", float("nan")
+        ),
     }

--- a/src/r2dreamer/launch/_helpers.py
+++ b/src/r2dreamer/launch/_helpers.py
@@ -10,7 +10,9 @@ curriculum; crafter forbids one) intentionally stays in the callers.
 from __future__ import annotations
 
 
-def resolve_curriculum_path(curriculum_path_arg: str | None, curriculum: str | None) -> str | None:
+def resolve_curriculum_path(
+    curriculum_path_arg: str | None, curriculum: str | None
+) -> str | None:
     """Resolve a curriculum JSON path from the CLI arg or a registry name.
 
     ``--curriculum_path`` (``curriculum_path_arg``) is the explicit escape hatch and
@@ -24,6 +26,8 @@ def resolve_curriculum_path(curriculum_path_arg: str | None, curriculum: str | N
         return curriculum_path_arg
     if curriculum is not None:
         if curriculum not in CURRICULA:
-            raise KeyError(f"Unknown curriculum {curriculum!r}. Available: {list(CURRICULA)}")
+            raise KeyError(
+                f"Unknown curriculum {curriculum!r}. Available: {list(CURRICULA)}"
+            )
         return str(CURRICULA[curriculum])
     return None

--- a/src/r2dreamer/launch/evaluate.py
+++ b/src/r2dreamer/launch/evaluate.py
@@ -40,12 +40,12 @@ def _extract_goal_positions(env):
             for vp in goal.view_points:
                 pos = vp.agent_state.position
                 goal_positions.append(
-                    pos.tolist() if hasattr(pos, "tolist") else list(pos))
+                    pos.tolist() if hasattr(pos, "tolist") else list(pos)
+                )
                 break
         else:
             pos = goal.position
-            goal_positions.append(
-                pos.tolist() if hasattr(pos, "tolist") else list(pos))
+            goal_positions.append(pos.tolist() if hasattr(pos, "tolist") else list(pos))
     return goal_positions
 
 
@@ -69,7 +69,9 @@ def _find_manifest_for_checkpoint(checkpoint: str | Path) -> Path | None:
     return None
 
 
-def _resolve_eval_settings(args, *, encoder: str, checkpoint: str | None, output_dir: str | None):
+def _resolve_eval_settings(
+    args, *, encoder: str, checkpoint: str | None, output_dir: str | None
+):
     # CLI --encoder overrides shim kwarg if user passed it explicitly.
     eff_encoder = args.encoder if args.encoder is not None else encoder
 
@@ -81,7 +83,9 @@ def _resolve_eval_settings(args, *, encoder: str, checkpoint: str | None, output
 
     eff_output_dir = args.output_dir if args.output_dir is not None else output_dir
     if eff_output_dir is None:
-        raise ValueError("output_dir must be set via evaluate(..., output_dir=...) or --output_dir")
+        raise ValueError(
+            "output_dir must be set via evaluate(..., output_dir=...) or --output_dir"
+        )
     return eff_encoder, eff_checkpoint, eff_output_dir
 
 
@@ -89,6 +93,7 @@ def _init_eval_wandb(args):
     if args.wandb_project is None or args.log_video_episodes <= 0:
         return None
     import wandb
+
     wandb.init(project=args.wandb_project, name=args.wandb_name)
     return wandb
 
@@ -103,7 +108,9 @@ def _make_eval_env(*, args, curriculum_path: str | None, eff_encoder: str):
     needs_hires = eff_encoder.startswith("vggt") or eff_encoder == "hybrid"
     default_resolution = 518 if needs_hires else 64
     render_resolution = (
-        args.render_resolution if args.render_resolution is not None else default_resolution
+        args.render_resolution
+        if args.render_resolution is not None
+        else default_resolution
     )
     hab_config = DreamerConfig(
         obs_shape=(3, render_resolution, render_resolution),
@@ -120,7 +127,9 @@ def _make_eval_env(*, args, curriculum_path: str | None, eff_encoder: str):
     return env_instance, needs_hires, render_resolution
 
 
-def _make_eval_encoder(eff_encoder: str, encoder_registry: dict, needs_hires: bool, render_resolution: int):
+def _make_eval_encoder(
+    eff_encoder: str, encoder_registry: dict, needs_hires: bool, render_resolution: int
+):
     encoder_cls = encoder_registry[eff_encoder]
     enc = encoder_cls(resolution=render_resolution) if needs_hires else encoder_cls()
     return enc, enc.make_adapter(), enc.spec()
@@ -138,17 +147,36 @@ def _load_arch_overrides_from_manifest(eff_checkpoint: str | None) -> dict:
         return {}
 
     arch_fields = (
-        "deter_size", "hidden_size", "stoch_classes", "stoch_discrete",
-        "blocks", "dyn_layers", "obs_layers", "img_layers",
-        "encoder_depth", "encoder_kernel", "encoder_mults",
-        "vggt_embed_dim", "vggt_mlp_layers", "mlp_vggt_hidden",
-        "vggt_token_transformer_layers", "vggt_token_transformer_heads",
-        "vggt_token_projection_dim", "vggt_token_transformer_mlp_ratio",
+        "deter_size",
+        "hidden_size",
+        "stoch_classes",
+        "stoch_discrete",
+        "blocks",
+        "dyn_layers",
+        "obs_layers",
+        "img_layers",
+        "encoder_depth",
+        "encoder_kernel",
+        "encoder_mults",
+        "vggt_embed_dim",
+        "vggt_mlp_layers",
+        "mlp_vggt_hidden",
+        "vggt_token_transformer_layers",
+        "vggt_token_transformer_heads",
+        "vggt_token_projection_dim",
+        "vggt_token_transformer_mlp_ratio",
         "vggt_token_transformer_dropout",
-        "vggt_keep_register_tokens", "vggt_token_count", "vggt_token_dim",
-        "mlp_vggt_layers", "mlp_units", "mlp_layers_reward",
-        "mlp_layers_cont", "mlp_layers_actor", "mlp_layers_critic",
-        "twohot_bins", "decoder",
+        "vggt_keep_register_tokens",
+        "vggt_token_count",
+        "vggt_token_dim",
+        "mlp_vggt_layers",
+        "mlp_units",
+        "mlp_layers_reward",
+        "mlp_layers_cont",
+        "mlp_layers_actor",
+        "mlp_layers_critic",
+        "twohot_bins",
+        "decoder",
     )
     overrides = {
         key: tuple(saved[key]) if key == "encoder_mults" else saved[key]
@@ -183,7 +211,10 @@ def _make_eval_agent(args, eff_checkpoint: str | None, agent_config_kwargs: dict
         print("Using random agent")
         return None
     agent = R2DreamerAgent.from_checkpoint(
-        eff_checkpoint, num_actions=4, seed=args.seed, **agent_config_kwargs,
+        eff_checkpoint,
+        num_actions=4,
+        seed=args.seed,
+        **agent_config_kwargs,
     )
     print(f"Loaded checkpoint from step {agent.checkpoint_step}")
     return agent
@@ -202,12 +233,20 @@ def _start_eval_episode(env_instance, adapter):
     trajectory = [start_pos]
     headings = [_get_agent_heading(env_instance)]
     return (
-        obs, agent_obs, start_pos, goal_positions, scene_id,
-        object_category, trajectory, headings,
+        obs,
+        agent_obs,
+        start_pos,
+        goal_positions,
+        scene_id,
+        object_category,
+        trajectory,
+        headings,
     )
 
 
-def _initial_eval_video_frames(env_instance, obs, trajectory, goal_positions, record_video: bool):
+def _initial_eval_video_frames(
+    env_instance, obs, trajectory, goal_positions, record_video: bool
+):
     if not record_video:
         return []
     topdown = render_topdown_frame(env_instance, trajectory, goal_positions)
@@ -237,8 +276,7 @@ def _make_eval_episode_result(
         "spl": float(obs.get("spl", 0.0)),
         "actions": actions_taken,
         "action_counts": {
-            name: actions_taken.count(idx)
-            for idx, name in _ACTIONS.items()
+            name: actions_taken.count(idx) for idx, name in _ACTIONS.items()
         },
         "start_position": start_pos,
         "goal_positions": goal_positions,
@@ -266,7 +304,8 @@ def _write_eval_episode_artifacts(
         _render_topdown(env_instance, trajectory, goal_positions, topdown_path)
     if record_video:
         log_episode_video(
-            wandb_module, f"eval/episode_video_{ep_idx}", video_frames, ep_idx)
+            wandb_module, f"eval/episode_video_{ep_idx}", video_frames, ep_idx
+        )
 
 
 def _run_eval_episode(
@@ -282,14 +321,24 @@ def _run_eval_episode(
     output_dir: str,
 ) -> tuple[dict, jax.Array]:
     (
-        obs, agent_obs, start_pos, goal_positions, scene_id,
-        object_category, trajectory, headings,
+        obs,
+        agent_obs,
+        start_pos,
+        goal_positions,
+        scene_id,
+        object_category,
+        trajectory,
+        headings,
     ) = _start_eval_episode(env_instance, adapter)
     actions_taken = []
     rewards = []
     record_video = wandb_module is not None and ep_idx < args.log_video_episodes
     video_frames = _initial_eval_video_frames(
-        env_instance, obs, trajectory, goal_positions, record_video,
+        env_instance,
+        obs,
+        trajectory,
+        goal_positions,
+        record_video,
     )
 
     for _step in range(500):
@@ -378,10 +427,15 @@ def evaluate(
     args = parser.parse_args(argv if argv is not None else sys.argv[1:])
 
     eff_encoder, eff_checkpoint, eff_output_dir = _resolve_eval_settings(
-        args, encoder=encoder, checkpoint=checkpoint, output_dir=output_dir,
+        args,
+        encoder=encoder,
+        checkpoint=checkpoint,
+        output_dir=output_dir,
     )
     if eff_encoder not in encoder_registry:
-        raise KeyError(f"Unknown encoder {eff_encoder!r}. Available: {list(encoder_registry)}")
+        raise KeyError(
+            f"Unknown encoder {eff_encoder!r}. Available: {list(encoder_registry)}"
+        )
 
     # --- Resolve curriculum path (shared with train via launch._helpers) ---
     curriculum_path = resolve_curriculum_path(args.curriculum_path, curriculum)
@@ -394,12 +448,17 @@ def evaluate(
     if env not in env_registry:
         raise KeyError(f"Unknown env {env!r}. Available: {list(env_registry)}")
     env_instance, needs_hires, render_resolution = _make_eval_env(
-        args=args, curriculum_path=curriculum_path, eff_encoder=eff_encoder,
+        args=args,
+        curriculum_path=curriculum_path,
+        eff_encoder=eff_encoder,
     )
 
     # --- Build encoder + adapter ---
     enc, adapter, encoder_spec = _make_eval_encoder(
-        eff_encoder, encoder_registry, needs_hires, render_resolution,
+        eff_encoder,
+        encoder_registry,
+        needs_hires,
+        render_resolution,
     )
 
     # --- Build agent ---
@@ -409,7 +468,9 @@ def evaluate(
     # (cnn / vggt / vggt_aggregator_mlp / vggt_wp_dense_cnn / hybrid) evaluates
     # correctly; the hybrid's (16404,) obs_shape and "hybrid" type flow through.
     agent_config_kwargs = _agent_config_kwargs(
-        encoder_spec, args=args, eff_checkpoint=eff_checkpoint,
+        encoder_spec,
+        args=args,
+        eff_checkpoint=eff_checkpoint,
     )
 
     config = R2DreamerConfig(num_actions=4, **agent_config_kwargs)

--- a/src/r2dreamer/launch/parity/__init__.py
+++ b/src/r2dreamer/launch/parity/__init__.py
@@ -1,4 +1,5 @@
 """Parity and benchmark sub-package for r2dreamer."""
+
 from src.r2dreamer.launch.parity.train_parity import run as train_parity_run
 from src.r2dreamer.launch.parity.benchmark import run as benchmark_run
 

--- a/src/r2dreamer/launch/parity/batch_utils.py
+++ b/src/r2dreamer/launch/parity/batch_utils.py
@@ -25,6 +25,7 @@ def _convert_batch(transitions, starts):
         is_first (B, T), is_last (B, T), is_terminal (B, T).
     """
     import jax.numpy as jnp
+
     B, T = len(starts), SEQ_LEN
     obs = np.zeros((B, T, *OBS_SHAPE_CHW), dtype=np.float32)
     actions = np.zeros((B, T, NUM_ACTIONS), dtype=np.float32)
@@ -42,9 +43,12 @@ def _convert_batch(transitions, starts):
             is_last[i, t] = float(tr["is_last"])
             is_terminal[i, t] = float(tr["is_terminal"])
     return {
-        "obs": jnp.array(obs), "actions": jnp.array(actions),
-        "rewards": jnp.array(rewards), "is_first": jnp.array(is_first),
-        "is_last": jnp.array(is_last), "is_terminal": jnp.array(is_terminal),
+        "obs": jnp.array(obs),
+        "actions": jnp.array(actions),
+        "rewards": jnp.array(rewards),
+        "is_first": jnp.array(is_first),
+        "is_last": jnp.array(is_last),
+        "is_terminal": jnp.array(is_terminal),
     }
 
 
@@ -57,6 +61,7 @@ def make_batch_torch(transitions, starts, device="cuda"):
     """
     import torch
     from tensordict import TensorDict
+
     B, T = len(starts), SEQ_LEN
     obs = np.zeros((B, T, *OBS_SHAPE_HWC), dtype=np.uint8)
     actions = np.zeros((B, T, NUM_ACTIONS), dtype=np.float32)
@@ -73,81 +78,191 @@ def make_batch_torch(transitions, starts, device="cuda"):
             is_first[i, t, 0] = float(tr["is_first"])
             is_last[i, t, 0] = float(tr["is_last"])
             is_terminal[i, t, 0] = float(tr["is_terminal"])
-    return TensorDict({
-        "image": torch.tensor(obs, device=device),
-        "action": torch.tensor(actions, device=device),
-        "reward": torch.tensor(rewards, device=device),
-        "is_first": torch.tensor(is_first, dtype=torch.bool, device=device),
-        "is_last": torch.tensor(is_last, dtype=torch.bool, device=device),
-        "is_terminal": torch.tensor(is_terminal, dtype=torch.bool, device=device),
-    }, batch_size=(B, T))
+    return TensorDict(
+        {
+            "image": torch.tensor(obs, device=device),
+            "action": torch.tensor(actions, device=device),
+            "reward": torch.tensor(rewards, device=device),
+            "is_first": torch.tensor(is_first, dtype=torch.bool, device=device),
+            "is_last": torch.tensor(is_last, dtype=torch.bool, device=device),
+            "is_terminal": torch.tensor(is_terminal, dtype=torch.bool, device=device),
+        },
+        batch_size=(B, T),
+    )
 
 
 def make_pytorch_config(device, rep_loss="r2dreamer"):
     """Return an OmegaConf config for the PyTorch r2dreamer / DreamerV3 agent."""
     from omegaconf import OmegaConf
-    return OmegaConf.create({
-        "act_entropy": 3e-4, "kl_free": 1.0, "imag_horizon": 15, "horizon": 333,
-        "lamb": 0.95, "compile": False, "log_grads": False, "device": device,
-        "rep_loss": rep_loss,
-        "lr": 4e-5, "agc": 0.3, "pmin": 1e-3, "eps": 1e-20,
-        "beta1": 0.9, "beta2": 0.999, "warmup": 1000,
-        "slow_target_update": 1, "slow_target_fraction": 0.02,
-        "loss_scales": {
-            "barlow": 0.05, "infonce": 1.0, "recon": 1.0, "rew": 1.0,
-            "con": 1.0, "dyn": 1.0, "rep": 0.1, "policy": 1.0,
-            "value": 1.0, "repval": 0.3, "swav": 1.0, "temp": 1.0, "norm": 1.0,
-        },
-        "r2dreamer": {"lambd": 5e-4},
-        "rssm": {
-            "stoch": 32, "deter": 2048, "hidden": 256, "discrete": 16,
-            "img_layers": 2, "obs_layers": 1, "dyn_layers": 1, "blocks": 8,
-            "act": "SiLU", "norm": True, "unimix_ratio": 0.01,
-            "initial": "learned", "device": device,
-        },
-        "encoder": {
-            "mlp_keys": "$^", "cnn_keys": "image",
-            "mlp": {"shape": None, "layers": 3, "units": 256, "act": "SiLU",
-                    "norm": True, "device": device, "outscale": None,
-                    "symlog_inputs": True, "name": "mlp_encoder"},
-            "cnn": {"act": "SiLU", "norm": True, "kernel_size": 5,
-                    "minres": 4, "depth": 16, "mults": [2, 3, 4, 4]},
-        },
-        "decoder": {
-            "mlp_keys": "$^", "cnn_keys": "image",
-            "mlp_dist": {"name": "symlog_mse"}, "cnn_dist": {"name": "mse"},
-            "mlp": {"shape": None, "layers": 3, "units": 256, "act": "SiLU",
-                    "norm": True, "dist": {"name": "identity"}, "device": device,
-                    "outscale": 1.0, "symlog_inputs": False, "name": "mlp_decoder"},
-            "cnn": {"depth": 16, "units": 256, "bspace": 8, "mults": [2, 3, 4, 4],
-                    "act": "SiLU", "norm": True, "kernel_size": 5, "minres": 4,
-                    "outscale": 1.0},
-        },
-        "reward": {"shape": [255], "layers": 1, "units": 256, "act": "SiLU",
-                   "norm": True, "dist": {"name": "symexp_twohot", "bin_num": 255},
-                   "outscale": 0.0, "device": device, "symlog_inputs": False, "name": "reward"},
-        "cont": {"shape": [1], "layers": 1, "units": 256, "act": "SiLU",
-                 "norm": True, "dist": {"name": "binary"},
-                 "outscale": 1.0, "device": device, "symlog_inputs": False, "name": "cont"},
-        "actor": {"shape": None, "layers": 3, "units": 256, "act": "SiLU",
-                  "norm": True, "device": device,
-                  "dist": {"cont": {"name": "bounded_normal", "min_std": 0.1, "max_std": 1.0},
-                           "disc": {"name": "onehot", "unimix_ratio": 0.01},
-                           "multi_disc": {"name": "multi_onehot", "unimix_ratio": 0.01}},
-                  "outscale": 0.01, "symlog_inputs": False, "name": "actor"},
-        "critic": {"shape": [255], "layers": 3, "units": 256, "act": "SiLU",
-                   "norm": True, "device": device,
-                   "dist": {"name": "symexp_twohot", "bin_num": 255},
-                   "outscale": 0.0, "symlog_inputs": False, "name": "value"},
-    })
+
+    return OmegaConf.create(
+        {
+            "act_entropy": 3e-4,
+            "kl_free": 1.0,
+            "imag_horizon": 15,
+            "horizon": 333,
+            "lamb": 0.95,
+            "compile": False,
+            "log_grads": False,
+            "device": device,
+            "rep_loss": rep_loss,
+            "lr": 4e-5,
+            "agc": 0.3,
+            "pmin": 1e-3,
+            "eps": 1e-20,
+            "beta1": 0.9,
+            "beta2": 0.999,
+            "warmup": 1000,
+            "slow_target_update": 1,
+            "slow_target_fraction": 0.02,
+            "loss_scales": {
+                "barlow": 0.05,
+                "infonce": 1.0,
+                "recon": 1.0,
+                "rew": 1.0,
+                "con": 1.0,
+                "dyn": 1.0,
+                "rep": 0.1,
+                "policy": 1.0,
+                "value": 1.0,
+                "repval": 0.3,
+                "swav": 1.0,
+                "temp": 1.0,
+                "norm": 1.0,
+            },
+            "r2dreamer": {"lambd": 5e-4},
+            "rssm": {
+                "stoch": 32,
+                "deter": 2048,
+                "hidden": 256,
+                "discrete": 16,
+                "img_layers": 2,
+                "obs_layers": 1,
+                "dyn_layers": 1,
+                "blocks": 8,
+                "act": "SiLU",
+                "norm": True,
+                "unimix_ratio": 0.01,
+                "initial": "learned",
+                "device": device,
+            },
+            "encoder": {
+                "mlp_keys": "$^",
+                "cnn_keys": "image",
+                "mlp": {
+                    "shape": None,
+                    "layers": 3,
+                    "units": 256,
+                    "act": "SiLU",
+                    "norm": True,
+                    "device": device,
+                    "outscale": None,
+                    "symlog_inputs": True,
+                    "name": "mlp_encoder",
+                },
+                "cnn": {
+                    "act": "SiLU",
+                    "norm": True,
+                    "kernel_size": 5,
+                    "minres": 4,
+                    "depth": 16,
+                    "mults": [2, 3, 4, 4],
+                },
+            },
+            "decoder": {
+                "mlp_keys": "$^",
+                "cnn_keys": "image",
+                "mlp_dist": {"name": "symlog_mse"},
+                "cnn_dist": {"name": "mse"},
+                "mlp": {
+                    "shape": None,
+                    "layers": 3,
+                    "units": 256,
+                    "act": "SiLU",
+                    "norm": True,
+                    "dist": {"name": "identity"},
+                    "device": device,
+                    "outscale": 1.0,
+                    "symlog_inputs": False,
+                    "name": "mlp_decoder",
+                },
+                "cnn": {
+                    "depth": 16,
+                    "units": 256,
+                    "bspace": 8,
+                    "mults": [2, 3, 4, 4],
+                    "act": "SiLU",
+                    "norm": True,
+                    "kernel_size": 5,
+                    "minres": 4,
+                    "outscale": 1.0,
+                },
+            },
+            "reward": {
+                "shape": [255],
+                "layers": 1,
+                "units": 256,
+                "act": "SiLU",
+                "norm": True,
+                "dist": {"name": "symexp_twohot", "bin_num": 255},
+                "outscale": 0.0,
+                "device": device,
+                "symlog_inputs": False,
+                "name": "reward",
+            },
+            "cont": {
+                "shape": [1],
+                "layers": 1,
+                "units": 256,
+                "act": "SiLU",
+                "norm": True,
+                "dist": {"name": "binary"},
+                "outscale": 1.0,
+                "device": device,
+                "symlog_inputs": False,
+                "name": "cont",
+            },
+            "actor": {
+                "shape": None,
+                "layers": 3,
+                "units": 256,
+                "act": "SiLU",
+                "norm": True,
+                "device": device,
+                "dist": {
+                    "cont": {"name": "bounded_normal", "min_std": 0.1, "max_std": 1.0},
+                    "disc": {"name": "onehot", "unimix_ratio": 0.01},
+                    "multi_disc": {"name": "multi_onehot", "unimix_ratio": 0.01},
+                },
+                "outscale": 0.01,
+                "symlog_inputs": False,
+                "name": "actor",
+            },
+            "critic": {
+                "shape": [255],
+                "layers": 3,
+                "units": 256,
+                "act": "SiLU",
+                "norm": True,
+                "device": device,
+                "dist": {"name": "symexp_twohot", "bin_num": 255},
+                "outscale": 0.0,
+                "symlog_inputs": False,
+                "name": "value",
+            },
+        }
+    )
 
 
 def make_crafter_spaces():
     """Return (obs_space, act_space) for the Crafter environment."""
     import gymnasium as gym
-    obs_space = gym.spaces.Dict({
-        "image": gym.spaces.Box(0, 255, OBS_SHAPE_HWC, dtype=np.uint8),
-    })
+
+    obs_space = gym.spaces.Dict(
+        {
+            "image": gym.spaces.Box(0, 255, OBS_SHAPE_HWC, dtype=np.uint8),
+        }
+    )
     act_space = gym.spaces.Box(low=0, high=1, shape=(NUM_ACTIONS,), dtype=np.float32)
     act_space.discrete = True
     return obs_space, act_space
@@ -156,21 +271,24 @@ def make_crafter_spaces():
 def collect_crafter_data(num_steps, seed=42):
     """Collect random-policy transitions from CrafterEnv."""
     from src.environments.crafter import CrafterEnv
+
     env = CrafterEnv(size=(64, 64), seed=seed)
     transitions = []
     obs = env.reset()
     for _ in range(num_steps):
         action = np.random.randint(0, NUM_ACTIONS)
         next_obs = env.step(action)
-        transitions.append({
-            "image_chw": obs["image"].copy(),
-            "image_hwc": obs["image"].transpose(1, 2, 0).copy(),
-            "action": action,
-            "reward": next_obs["reward"],
-            "is_first": obs["is_first"],
-            "is_last": next_obs["done"],
-            "is_terminal": next_obs["done"],
-        })
+        transitions.append(
+            {
+                "image_chw": obs["image"].copy(),
+                "image_hwc": obs["image"].transpose(1, 2, 0).copy(),
+                "action": action,
+                "reward": next_obs["reward"],
+                "is_first": obs["is_first"],
+                "is_last": next_obs["done"],
+                "is_terminal": next_obs["done"],
+            }
+        )
         obs = env.reset() if next_obs["done"] else next_obs
     env.close()
     return transitions

--- a/src/r2dreamer/launch/parity/benchmark.py
+++ b/src/r2dreamer/launch/parity/benchmark.py
@@ -16,14 +16,23 @@ import time
 
 import numpy as np
 
+from src.r2dreamer.launch.parity.batch_utils import (
+    SEED,
+    WARMUP_STEPS,
+    BATCH_SIZE,
+    SEQ_LEN,
+    OBS_SHAPE_CHW,
+    NUM_ACTIONS,
+    collect_crafter_data,
+    precompute_batch_starts,
+    _convert_batch,
+    make_batch_torch,
+    make_pytorch_config,
+    make_crafter_spaces,
+)
+
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
 EXT = os.path.join(ROOT, "external", "r2dreamer")
-
-from src.r2dreamer.launch.parity.batch_utils import (
-    SEED, WARMUP_STEPS, BATCH_SIZE, SEQ_LEN, OBS_SHAPE_CHW, NUM_ACTIONS,
-    collect_crafter_data, precompute_batch_starts,
-    _convert_batch, make_batch_torch, make_pytorch_config, make_crafter_spaces,
-)
 
 NUM_COLLECT = 10_000
 EVAL_MAX_STEPS = 500
@@ -32,6 +41,7 @@ EVAL_MAX_STEPS = 500
 def _train_step_pytorch(agent, data, initial):
     import torch
     from torch.amp import autocast
+
     torch.compiler.cudagraph_mark_step_begin()
     p_data = agent.preprocess(data)
     agent._update_slow_target()
@@ -51,6 +61,7 @@ def _train_step_pytorch(agent, data, initial):
 def _eval_jax_agent(agent, num_episodes, max_steps, rng_key):
     import jax
     from src.environments.crafter import CrafterEnv
+
     env = CrafterEnv(size=(64, 64), seed=123)
     rewards, lengths = [], []
     for _ in range(num_episodes):
@@ -73,6 +84,7 @@ def _eval_jax_agent(agent, num_episodes, max_steps, rng_key):
 def _eval_pytorch_agent(agent, num_episodes, max_steps, device):
     import torch
     from src.environments.crafter import CrafterEnv
+
     agent.eval()
     env = CrafterEnv(size=(64, 64), seed=123)
     rewards, lengths = [], []
@@ -85,10 +97,19 @@ def _eval_pytorch_agent(agent, num_episodes, max_steps, device):
         for step in range(max_steps):
             with torch.no_grad():
                 image_hwc = obs_dict["image"].transpose(1, 2, 0)
-                image_t = torch.tensor(image_hwc[None], dtype=torch.float32, device=device) / 255.0
-                is_first = torch.tensor([obs_dict["is_first"]], dtype=torch.bool, device=device)
-                embed = agent._frozen_encoder({"image": image_t.unsqueeze(1)}).squeeze(1)
-                stoch, deter, _ = agent._frozen_rssm.obs_step(stoch, deter, prev_action, embed, is_first)
+                image_t = (
+                    torch.tensor(image_hwc[None], dtype=torch.float32, device=device)
+                    / 255.0
+                )
+                is_first = torch.tensor(
+                    [obs_dict["is_first"]], dtype=torch.bool, device=device
+                )
+                embed = agent._frozen_encoder({"image": image_t.unsqueeze(1)}).squeeze(
+                    1
+                )
+                stoch, deter, _ = agent._frozen_rssm.obs_step(
+                    stoch, deter, prev_action, embed, is_first
+                )
                 feat = agent._frozen_rssm.get_feat(stoch, deter)
                 action = agent._frozen_actor(feat).mode
                 prev_action = action
@@ -111,9 +132,13 @@ def _run_variant_jax(transitions, all_starts, train_steps):
     from src.r2dreamer.agent import R2DreamerAgent
     from src.r2dreamer.world_model.encoders import ConvEncoder
 
-    cfg = R2DreamerConfig(obs_shape=OBS_SHAPE_CHW, num_actions=NUM_ACTIONS,
-                          batch_size=BATCH_SIZE, seq_len=SEQ_LEN,
-                          encoder_module_cls=ConvEncoder)
+    cfg = R2DreamerConfig(
+        obs_shape=OBS_SHAPE_CHW,
+        num_actions=NUM_ACTIONS,
+        batch_size=BATCH_SIZE,
+        seq_len=SEQ_LEN,
+        encoder_module_cls=ConvEncoder,
+    )
     rng = jax.random.PRNGKey(SEED)
     rng, init_key = jax.random.split(rng)
     agent = R2DreamerAgent(cfg, init_key)
@@ -137,8 +162,10 @@ def _run_variant_jax(transitions, all_starts, train_steps):
         step_times.append(t1 - t0)
         metrics_history.append(metrics)
         if (i + 1) % 500 == 0:
-            print(f"  [JAX] step {i+1}/{train_steps} | loss={metrics.get('total_loss',0):.2f} | "
-                  f"dyn={metrics.get('loss/dyn',0):.2f} | {(t1-t0)*1000:.1f} ms")
+            print(
+                f"  [JAX] step {i + 1}/{train_steps} | loss={metrics.get('total_loss', 0):.2f} | "
+                f"dyn={metrics.get('loss/dyn', 0):.2f} | {(t1 - t0) * 1000:.1f} ms"
+            )
 
     peak_mem = jax.devices()[0].memory_stats()["peak_bytes_in_use"] / 1e9
     times = np.array(step_times)
@@ -151,13 +178,16 @@ def _run_variant_jax(transitions, all_starts, train_steps):
         "steps_per_sec": float(train_steps / sum(step_times)),
         "peak_gpu_gb": float(peak_mem),
         "total_time_s": float(sum(step_times)),
-        "metrics_history": [{k: float(v) for k, v in m.items()} for m in metrics_history],
+        "metrics_history": [
+            {k: float(v) for k, v in m.items()} for m in metrics_history
+        ],
         "agent": agent,
     }
 
 
 def _run_variant_pytorch(transitions, all_starts, train_steps, rep_loss, device):
     import torch
+
     sys.path.insert(0, EXT)
     from dreamer import Dreamer
 
@@ -169,7 +199,9 @@ def _run_variant_pytorch(transitions, all_starts, train_steps, rep_loss, device)
 
     for i in range(WARMUP_STEPS):
         data = make_batch_torch(transitions, all_starts[i], device)
-        stoch0 = torch.zeros(BATCH_SIZE, cfg.rssm.stoch, cfg.rssm.discrete, device=device)
+        stoch0 = torch.zeros(
+            BATCH_SIZE, cfg.rssm.stoch, cfg.rssm.discrete, device=device
+        )
         deter0 = torch.zeros(BATCH_SIZE, cfg.rssm.deter, device=device)
         _ = _train_step_pytorch(agent, data, (stoch0, deter0))
 
@@ -180,7 +212,9 @@ def _run_variant_pytorch(transitions, all_starts, train_steps, rep_loss, device)
     step_times = []
     for i in range(train_steps):
         data = make_batch_torch(transitions, all_starts[WARMUP_STEPS + i], device)
-        stoch0 = torch.zeros(BATCH_SIZE, cfg.rssm.stoch, cfg.rssm.discrete, device=device)
+        stoch0 = torch.zeros(
+            BATCH_SIZE, cfg.rssm.stoch, cfg.rssm.discrete, device=device
+        )
         deter0 = torch.zeros(BATCH_SIZE, cfg.rssm.deter, device=device)
         torch.cuda.synchronize()
         t0 = time.perf_counter()
@@ -188,13 +222,19 @@ def _run_variant_pytorch(transitions, all_starts, train_steps, rep_loss, device)
         torch.cuda.synchronize()
         t1 = time.perf_counter()
         step_times.append(t1 - t0)
-        metrics_history.append({k: float(v) if isinstance(v, torch.Tensor) else float(v)
-                                for k, v in mets.items()})
+        metrics_history.append(
+            {
+                k: float(v) if isinstance(v, torch.Tensor) else float(v)
+                for k, v in mets.items()
+            }
+        )
         if (i + 1) % 500 == 0:
             loss = float(mets.get("opt/loss", 0))
             dyn = float(mets.get("loss/dyn", 0))
-            print(f"  [{label}] step {i+1}/{train_steps} | loss={loss:.2f} | "
-                  f"dyn={dyn:.2f} | {(t1-t0)*1000:.1f} ms")
+            print(
+                f"  [{label}] step {i + 1}/{train_steps} | loss={loss:.2f} | "
+                f"dyn={dyn:.2f} | {(t1 - t0) * 1000:.1f} ms"
+            )
 
     peak_mem = torch.cuda.max_memory_allocated() / 1e9
 
@@ -225,22 +265,29 @@ def run(*, train_steps=4_000, eval_episodes=10, output_path=None, argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--train-steps", type=int, default=train_steps)
     parser.add_argument("--eval-episodes", type=int, default=eval_episodes)
-    parser.add_argument("--skip-pytorch", action="store_true", help="Only run JAX variant")
+    parser.add_argument(
+        "--skip-pytorch", action="store_true", help="Only run JAX variant"
+    )
     args = parser.parse_args(argv)
 
     import torch
     import jax
+
     torch.set_float32_matmul_precision("high")
     device = "cuda" if torch.cuda.is_available() else "cpu"
 
     print(f"PyTorch {torch.__version__}, JAX {jax.__version__}")
     if torch.cuda.is_available():
         print(f"GPU: {torch.cuda.get_device_name(0)}")
-    print(f"Config: train_steps={args.train_steps}, eval_episodes={args.eval_episodes}, seed={SEED}\n")
+    print(
+        f"Config: train_steps={args.train_steps}, eval_episodes={args.eval_episodes}, seed={SEED}\n"
+    )
 
     print("Collecting Crafter data...")
     transitions = collect_crafter_data(NUM_COLLECT, seed=SEED)
-    all_starts = precompute_batch_starts(WARMUP_STEPS + args.train_steps, transitions, SEED)
+    all_starts = precompute_batch_starts(
+        WARMUP_STEPS + args.train_steps, transitions, SEED
+    )
     print(f"Collected {len(transitions)} transitions, {len(all_starts)} batch starts\n")
 
     results = {}
@@ -249,27 +296,39 @@ def run(*, train_steps=4_000, eval_episodes=10, output_path=None, argv=None):
     jax_result = _run_variant_jax(transitions, all_starts, args.train_steps)
     agent_jax = jax_result.pop("agent")
     results["R2-Dreamer (JAX)"] = jax_result
-    print(f"  Done: {jax_result['mean_step_ms']:.1f} ms/step, {jax_result['peak_gpu_gb']:.2f} GB\n")
+    print(
+        f"  Done: {jax_result['mean_step_ms']:.1f} ms/step, {jax_result['peak_gpu_gb']:.2f} GB\n"
+    )
 
     agent_r2_pt = None
     agent_dv3_pt = None
 
     if not args.skip_pytorch:
         print("=== R2-Dreamer (PyTorch) ===")
-        r2_result = _run_variant_pytorch(transitions, all_starts, args.train_steps, "r2dreamer", device)
+        r2_result = _run_variant_pytorch(
+            transitions, all_starts, args.train_steps, "r2dreamer", device
+        )
         agent_r2_pt = r2_result.pop("agent")
         results["R2-Dreamer (PyTorch)"] = r2_result
-        print(f"  Done: {r2_result['mean_step_ms']:.1f} ms/step, {r2_result['peak_gpu_gb']:.2f} GB\n")
+        print(
+            f"  Done: {r2_result['mean_step_ms']:.1f} ms/step, {r2_result['peak_gpu_gb']:.2f} GB\n"
+        )
 
         print("=== DreamerV3 (PyTorch) ===")
-        dv3_result = _run_variant_pytorch(transitions, all_starts, args.train_steps, "dreamer", device)
+        dv3_result = _run_variant_pytorch(
+            transitions, all_starts, args.train_steps, "dreamer", device
+        )
         agent_dv3_pt = dv3_result.pop("agent")
         results["DreamerV3 (PyTorch)"] = dv3_result
-        print(f"  Done: {dv3_result['mean_step_ms']:.1f} ms/step, {dv3_result['peak_gpu_gb']:.2f} GB\n")
+        print(
+            f"  Done: {dv3_result['mean_step_ms']:.1f} ms/step, {dv3_result['peak_gpu_gb']:.2f} GB\n"
+        )
 
     print("=== Policy Evaluation ===")
     rng_eval = jax.random.PRNGKey(123)
-    jax_rewards, jax_lengths = _eval_jax_agent(agent_jax, args.eval_episodes, EVAL_MAX_STEPS, rng_eval)
+    jax_rewards, jax_lengths = _eval_jax_agent(
+        agent_jax, args.eval_episodes, EVAL_MAX_STEPS, rng_eval
+    )
     results["R2-Dreamer (JAX)"]["eval_rewards"] = jax_rewards
     results["R2-Dreamer (JAX)"]["eval_lengths"] = jax_lengths
     print(f"  JAX:    reward={np.mean(jax_rewards):.2f} +/- {np.std(jax_rewards):.2f}")
@@ -278,15 +337,23 @@ def run(*, train_steps=4_000, eval_episodes=10, output_path=None, argv=None):
     gc.collect()
 
     if not args.skip_pytorch:
-        r2_rewards, r2_lengths = _eval_pytorch_agent(agent_r2_pt, args.eval_episodes, EVAL_MAX_STEPS, device)
+        r2_rewards, r2_lengths = _eval_pytorch_agent(
+            agent_r2_pt, args.eval_episodes, EVAL_MAX_STEPS, device
+        )
         results["R2-Dreamer (PyTorch)"]["eval_rewards"] = r2_rewards
         results["R2-Dreamer (PyTorch)"]["eval_lengths"] = r2_lengths
-        print(f"  R2-PT:  reward={np.mean(r2_rewards):.2f} +/- {np.std(r2_rewards):.2f}")
+        print(
+            f"  R2-PT:  reward={np.mean(r2_rewards):.2f} +/- {np.std(r2_rewards):.2f}"
+        )
 
-        dv3_rewards, dv3_lengths = _eval_pytorch_agent(agent_dv3_pt, args.eval_episodes, EVAL_MAX_STEPS, device)
+        dv3_rewards, dv3_lengths = _eval_pytorch_agent(
+            agent_dv3_pt, args.eval_episodes, EVAL_MAX_STEPS, device
+        )
         results["DreamerV3 (PyTorch)"]["eval_rewards"] = dv3_rewards
         results["DreamerV3 (PyTorch)"]["eval_lengths"] = dv3_lengths
-        print(f"  DV3-PT: reward={np.mean(dv3_rewards):.2f} +/- {np.std(dv3_rewards):.2f}")
+        print(
+            f"  DV3-PT: reward={np.mean(dv3_rewards):.2f} +/- {np.std(dv3_rewards):.2f}"
+        )
 
         del agent_r2_pt, agent_dv3_pt
         torch.cuda.empty_cache()
@@ -299,10 +366,14 @@ def run(*, train_steps=4_000, eval_episodes=10, output_path=None, argv=None):
         json.dump(results, f, indent=2)
     print(f"\nResults saved to {outpath}")
 
-    print(f"\n{'Variant':<25} {'Params':>10} {'ms/step':>10} {'GPU (GB)':>10} {'Reward':>10}")
+    print(
+        f"\n{'Variant':<25} {'Params':>10} {'ms/step':>10} {'GPU (GB)':>10} {'Reward':>10}"
+    )
     print("-" * 70)
     for name, r in results.items():
         rew = np.mean(r.get("eval_rewards", [0]))
-        print(f"{name:<25} {r['params']:>10,} {r['mean_step_ms']:>8.1f}ms {r['peak_gpu_gb']:>8.2f}GB {rew:>8.2f}")
+        print(
+            f"{name:<25} {r['params']:>10,} {r['mean_step_ms']:>8.1f}ms {r['peak_gpu_gb']:>8.2f}GB {rew:>8.2f}"
+        )
 
     return results

--- a/src/r2dreamer/launch/parity/train_parity.py
+++ b/src/r2dreamer/launch/parity/train_parity.py
@@ -13,15 +13,23 @@ import os
 import sys
 import time
 
+from src.r2dreamer.launch.parity.batch_utils import (
+    SEED,
+    WARMUP_STEPS,
+    BATCH_SIZE,
+    SEQ_LEN,
+    OBS_SHAPE_CHW,
+    NUM_ACTIONS,
+    collect_crafter_data,
+    precompute_batch_starts,
+    _convert_batch,
+    make_batch_torch,
+    make_pytorch_config,
+    make_crafter_spaces,
+)
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
 EXT = os.path.join(ROOT, "external", "r2dreamer")
-
-from src.r2dreamer.launch.parity.batch_utils import (
-    SEED, WARMUP_STEPS, BATCH_SIZE, SEQ_LEN, OBS_SHAPE_CHW,
-    NUM_ACTIONS, collect_crafter_data, precompute_batch_starts,
-    _convert_batch, make_batch_torch, make_pytorch_config, make_crafter_spaces,
-)
 
 LOG_EVERY = 100
 NUM_COLLECT = 20_000
@@ -30,6 +38,7 @@ NUM_COLLECT = 20_000
 def _train_step_pytorch(agent, data, initial):
     import torch
     from torch.amp import autocast
+
     torch.compiler.cudagraph_mark_step_begin()
     p_data = agent.preprocess(data)
     agent._update_slow_target()
@@ -51,8 +60,10 @@ def _run_jax(transitions, all_starts, train_steps, outpath):
     from src.r2dreamer.world_model.encoders import ConvEncoder
 
     cfg = R2DreamerConfig(
-        obs_shape=OBS_SHAPE_CHW, num_actions=NUM_ACTIONS,
-        batch_size=BATCH_SIZE, seq_len=SEQ_LEN,
+        obs_shape=OBS_SHAPE_CHW,
+        num_actions=NUM_ACTIONS,
+        batch_size=BATCH_SIZE,
+        seq_len=SEQ_LEN,
         encoder_module_cls=ConvEncoder,
     )
     rng = jax.random.PRNGKey(SEED)
@@ -84,11 +95,13 @@ def _run_jax(transitions, all_starts, train_steps, outpath):
             elapsed = time.perf_counter() - t_start
             sps = (i + 1) / elapsed
             eta = (train_steps - i - 1) / sps / 3600
-            print(f"  [JAX] step {i+1}/{train_steps} | loss={metrics.get('total_loss',0):.2f} | "
-                  f"dyn={metrics.get('loss/dyn',0):.2f} | {sps:.1f} sps | ETA {eta:.1f}h")
+            print(
+                f"  [JAX] step {i + 1}/{train_steps} | loss={metrics.get('total_loss', 0):.2f} | "
+                f"dyn={metrics.get('loss/dyn', 0):.2f} | {sps:.1f} sps | ETA {eta:.1f}h"
+            )
 
     elapsed = time.perf_counter() - t_start
-    print(f"  [JAX] Done in {elapsed/60:.1f} min ({train_steps/elapsed:.1f} sps)")
+    print(f"  [JAX] Done in {elapsed / 60:.1f} min ({train_steps / elapsed:.1f} sps)")
 
     with open(outpath, "w") as f:
         json.dump(rows, f)
@@ -99,6 +112,7 @@ def _run_jax(transitions, all_starts, train_steps, outpath):
 
 def _run_pytorch(transitions, all_starts, train_steps, outpath, device):
     import torch
+
     sys.path.insert(0, EXT)
     from dreamer import Dreamer
 
@@ -108,7 +122,9 @@ def _run_pytorch(transitions, all_starts, train_steps, outpath, device):
 
     for i in range(WARMUP_STEPS):
         data = make_batch_torch(transitions, all_starts[i], device)
-        stoch0 = torch.zeros(BATCH_SIZE, cfg.rssm.stoch, cfg.rssm.discrete, device=device)
+        stoch0 = torch.zeros(
+            BATCH_SIZE, cfg.rssm.stoch, cfg.rssm.discrete, device=device
+        )
         deter0 = torch.zeros(BATCH_SIZE, cfg.rssm.deter, device=device)
         _ = _train_step_pytorch(agent, data, (stoch0, deter0))
 
@@ -119,7 +135,9 @@ def _run_pytorch(transitions, all_starts, train_steps, outpath, device):
     t_start = time.perf_counter()
     for i in range(train_steps):
         data = make_batch_torch(transitions, all_starts[WARMUP_STEPS + i], device)
-        stoch0 = torch.zeros(BATCH_SIZE, cfg.rssm.stoch, cfg.rssm.discrete, device=device)
+        stoch0 = torch.zeros(
+            BATCH_SIZE, cfg.rssm.stoch, cfg.rssm.discrete, device=device
+        )
         deter0 = torch.zeros(BATCH_SIZE, cfg.rssm.deter, device=device)
         torch.cuda.synchronize()
         t0 = time.perf_counter()
@@ -129,8 +147,12 @@ def _run_pytorch(transitions, all_starts, train_steps, outpath, device):
 
         if (i + 1) % LOG_EVERY == 0:
             row = {"step": i + 1, "step_ms": (t1 - t0) * 1000}
-            row.update({k: float(v) if isinstance(v, torch.Tensor) else float(v)
-                        for k, v in mets.items()})
+            row.update(
+                {
+                    k: float(v) if isinstance(v, torch.Tensor) else float(v)
+                    for k, v in mets.items()
+                }
+            )
             rows.append(row)
 
         if (i + 1) % 1000 == 0:
@@ -139,11 +161,13 @@ def _run_pytorch(transitions, all_starts, train_steps, outpath, device):
             eta = (train_steps - i - 1) / sps / 3600
             loss = float(mets.get("opt/loss", 0))
             dyn = float(mets.get("loss/dyn", 0))
-            print(f"  [PT]  step {i+1}/{train_steps} | loss={loss:.2f} | "
-                  f"dyn={dyn:.2f} | {sps:.1f} sps | ETA {eta:.1f}h")
+            print(
+                f"  [PT]  step {i + 1}/{train_steps} | loss={loss:.2f} | "
+                f"dyn={dyn:.2f} | {sps:.1f} sps | ETA {eta:.1f}h"
+            )
 
     elapsed = time.perf_counter() - t_start
-    print(f"  [PT]  Done in {elapsed/60:.1f} min ({train_steps/elapsed:.1f} sps)")
+    print(f"  [PT]  Done in {elapsed / 60:.1f} min ({train_steps / elapsed:.1f} sps)")
 
     with open(outpath, "w") as f:
         json.dump(rows, f)
@@ -173,6 +197,7 @@ def run(*, train_steps=100_000, output_path=None, argv=None):
 
     import torch
     import jax
+
     torch.set_float32_matmul_precision("high")
     device = "cuda" if torch.cuda.is_available() else "cpu"
 

--- a/src/r2dreamer/launch/parser.py
+++ b/src/r2dreamer/launch/parser.py
@@ -12,140 +12,295 @@ def _add_basic_train_args(p: argparse.ArgumentParser) -> None:
     p.add_argument("--checkpoint_every", type=int, default=50_000)
     p.add_argument("--wandb_project", type=str, default="3d-vla-objectnav")
     p.add_argument("--wandb_name", type=str, default=None)
-    p.add_argument("--wandb_tags", type=str, default=None,
-                   help="Comma-separated tags (appended to shim defaults)")
+    p.add_argument(
+        "--wandb_tags",
+        type=str,
+        default=None,
+        help="Comma-separated tags (appended to shim defaults)",
+    )
     # escape hatch: override the shim-hardcoded curriculum path
-    p.add_argument("--curriculum_path", type=str, default=None,
-                   help="Override shim curriculum path (escape hatch)")
+    p.add_argument(
+        "--curriculum_path",
+        type=str,
+        default=None,
+        help="Override shim curriculum path (escape hatch)",
+    )
     p.add_argument("--curriculum_mode", type=str, default="train")
-    p.add_argument("--render_resolution", type=int, default=518,
-                   help="Render resolution for VGGT encoder")
-    p.add_argument("--mlp_layers", type=int, default=None,
-                   help="Depth of the VGGT MLP encoders (wp_cp + aggregator): number "
-                        "of hidden Dense->RMSNorm->SiLU blocks before the linear readout. "
-                        "None keeps the config default (1). The experiment runs pass 3 to "
-                        "match R2Dreamer's native encoder.mlp.layers (3D-52). Only valid "
-                        "for VGGT MLP encoders; CNN/dense-WP conv encoders require the "
-                        "default value (1).")
+    p.add_argument(
+        "--render_resolution",
+        type=int,
+        default=518,
+        help="Render resolution for VGGT encoder",
+    )
+    p.add_argument(
+        "--mlp_layers",
+        type=int,
+        default=None,
+        help="Depth of the VGGT MLP encoders (wp_cp + aggregator): number "
+        "of hidden Dense->RMSNorm->SiLU blocks before the linear readout. "
+        "None keeps the config default (1). The experiment runs pass 3 to "
+        "match R2Dreamer's native encoder.mlp.layers (3D-52). Only valid "
+        "for VGGT MLP encoders; CNN/dense-WP conv encoders require the "
+        "default value (1).",
+    )
 
 
 def _add_val_train_args(p: argparse.ArgumentParser) -> None:
     # Val-Episode-Loop (3D-36). 0 disables. Default off keeps production runs
     # scalars-only unless validation is explicitly requested.
-    p.add_argument("--val_every", type=int, default=0,
-                   help="Run a deterministic val-episode loop every N steps (0 disables)")
-    p.add_argument("--val_episodes", type=int, default=50,
-                   help="Episodes per val-loop trigger")
-    p.add_argument("--val_video_episodes", type=int, default=0,
-                   help="Number of val episodes to record as W&B videos per trigger")
-    p.add_argument("--val_max_episode_steps", type=int, default=500,
-                   help="Per-episode step cap inside the val loop")
+    p.add_argument(
+        "--val_every",
+        type=int,
+        default=0,
+        help="Run a deterministic val-episode loop every N steps (0 disables)",
+    )
+    p.add_argument(
+        "--val_episodes", type=int, default=50, help="Episodes per val-loop trigger"
+    )
+    p.add_argument(
+        "--val_video_episodes",
+        type=int,
+        default=0,
+        help="Number of val episodes to record as W&B videos per trigger",
+    )
+    p.add_argument(
+        "--val_max_episode_steps",
+        type=int,
+        default=500,
+        help="Per-episode step cap inside the val loop",
+    )
 
 
 def _add_resume_video_train_args(p: argparse.ArgumentParser) -> None:
     p.add_argument("--resume_from", type=str, default=None)
-    p.add_argument("--wandb_id", type=str, default=None,
-                   help="W&B run-id to reattach to (resume='must')")
-    p.add_argument("--video_log_every", type=int, default=0,
-                   help="Log one Habitat episode video every N train steps")
-    p.add_argument("--video_log_episodes", type=int, default=0,
-                   help="Number of Habitat train episodes to record per interval")
-    p.add_argument("--act_entropy", type=float, default=3e-2,
-                   help="Actor entropy coefficient. 3e-2 is the Habitat 4-action ObjectNav "
-                        "baseline; the DreamerV3 paper default 3e-4 (tuned for 17-action Crafter) "
-                        "collapses the policy here.")
+    p.add_argument(
+        "--wandb_id",
+        type=str,
+        default=None,
+        help="W&B run-id to reattach to (resume='must')",
+    )
+    p.add_argument(
+        "--video_log_every",
+        type=int,
+        default=0,
+        help="Log one Habitat episode video every N train steps",
+    )
+    p.add_argument(
+        "--video_log_episodes",
+        type=int,
+        default=0,
+        help="Number of Habitat train episodes to record per interval",
+    )
+    p.add_argument(
+        "--act_entropy",
+        type=float,
+        default=3e-2,
+        help="Actor entropy coefficient. 3e-2 is the Habitat 4-action ObjectNav "
+        "baseline; the DreamerV3 paper default 3e-4 (tuned for 17-action Crafter) "
+        "collapses the policy here.",
+    )
 
 
 def _add_overfit_train_args(p: argparse.ArgumentParser) -> None:
     # --- Diagnostic / overfit-one-batch knobs (Karpathy step 3) ---
-    p.add_argument("--overfit_one_batch", action="store_true",
-                   help="After prefill, freeze a single sampled batch and call "
-                        "train_step on it for --overfit_steps iterations. Disables "
-                        "env rollouts, validation and checkpointing.")
-    p.add_argument("--overfit_steps", type=int, default=1000,
-                   help="Number of gradient steps to run on the frozen batch "
-                        "when --overfit_one_batch is set.")
-    p.add_argument("--overfit_batch_size", type=int, default=1,
-                   help="B for the frozen overfit batch (default 1).")
-    p.add_argument("--overfit_seq_len", type=int, default=8,
-                   help="T for the frozen overfit batch (default 8).")
-    p.add_argument("--overfit_min_loss_drop", type=float, default=0.20,
-                   help="Fail --overfit_one_batch unless total_loss drops by this "
-                        "fraction over the frozen-batch run (default 0.20).")
+    p.add_argument(
+        "--overfit_one_batch",
+        action="store_true",
+        help="After prefill, freeze a single sampled batch and call "
+        "train_step on it for --overfit_steps iterations. Disables "
+        "env rollouts, validation and checkpointing.",
+    )
+    p.add_argument(
+        "--overfit_steps",
+        type=int,
+        default=1000,
+        help="Number of gradient steps to run on the frozen batch "
+        "when --overfit_one_batch is set.",
+    )
+    p.add_argument(
+        "--overfit_batch_size",
+        type=int,
+        default=1,
+        help="B for the frozen overfit batch (default 1).",
+    )
+    p.add_argument(
+        "--overfit_seq_len",
+        type=int,
+        default=8,
+        help="T for the frozen overfit batch (default 8).",
+    )
+    p.add_argument(
+        "--overfit_min_loss_drop",
+        type=float,
+        default=0.20,
+        help="Fail --overfit_one_batch unless total_loss drops by this "
+        "fraction over the frozen-batch run (default 0.20).",
+    )
 
 
 def _add_loss_override_train_args(p: argparse.ArgumentParser) -> None:
     # Loss-scale overrides (Protocol C). None => keep config default.
-    p.add_argument("--actor_loss_weight", type=float, default=None,
-                   help="Override cfg.scale_policy. Set 0 to disable actor loss.")
-    p.add_argument("--value_loss_weight", type=float, default=None,
-                   help="Override cfg.scale_value. Set 0 to disable critic loss.")
-    p.add_argument("--repval_loss_weight", type=float, default=None,
-                   help="Override cfg.scale_repval. Set 0 to disable replay value loss.")
+    p.add_argument(
+        "--actor_loss_weight",
+        type=float,
+        default=None,
+        help="Override cfg.scale_policy. Set 0 to disable actor loss.",
+    )
+    p.add_argument(
+        "--value_loss_weight",
+        type=float,
+        default=None,
+        help="Override cfg.scale_value. Set 0 to disable critic loss.",
+    )
+    p.add_argument(
+        "--repval_loss_weight",
+        type=float,
+        default=None,
+        help="Override cfg.scale_repval. Set 0 to disable replay value loss.",
+    )
     # Protocol D toggle
-    p.add_argument("--barlow_grad_to_encoder", action="store_true",
-                   help="Let Barlow Twins gradient reach the encoder (removes the "
-                        "stop_gradient at agent._loss_fn). Default off matches "
-                        "PyTorch reference.")
+    p.add_argument(
+        "--barlow_grad_to_encoder",
+        action="store_true",
+        help="Let Barlow Twins gradient reach the encoder (removes the "
+        "stop_gradient at agent._loss_fn). Default off matches "
+        "PyTorch reference.",
+    )
     # Small-batch knobs for the overfit run
-    p.add_argument("--batch_size", type=int, default=None,
-                   help="Override cfg.batch_size (production default 16).")
-    p.add_argument("--seq_len", type=int, default=None,
-                   help="Override cfg.seq_len (production default 64).")
-    p.add_argument("--lr", type=float, default=None,
-                   help="Override cfg.lr (production default 4e-5).")
-    p.add_argument("--train_ratio", type=int, default=None,
-                   help="Override cfg.train_ratio (production default 512). Lower "
-                        "values bound train_step count for short smoke runs.")
-    p.add_argument("--buffer_capacity", "--buffer-capacity", type=int, default=None,
-                   help="Override cfg.buffer_capacity for replay-capacity ablations.")
+    p.add_argument(
+        "--batch_size",
+        type=int,
+        default=None,
+        help="Override cfg.batch_size (production default 16).",
+    )
+    p.add_argument(
+        "--seq_len",
+        type=int,
+        default=None,
+        help="Override cfg.seq_len (production default 64).",
+    )
+    p.add_argument(
+        "--lr",
+        type=float,
+        default=None,
+        help="Override cfg.lr (production default 4e-5).",
+    )
+    p.add_argument(
+        "--train_ratio",
+        type=int,
+        default=None,
+        help="Override cfg.train_ratio (production default 512). Lower "
+        "values bound train_step count for short smoke runs.",
+    )
+    p.add_argument(
+        "--buffer_capacity",
+        "--buffer-capacity",
+        type=int,
+        default=None,
+        help="Override cfg.buffer_capacity for replay-capacity ablations.",
+    )
 
 
 def _add_latent_decoder_train_args(p: argparse.ArgumentParser) -> None:
     # --- Latent-size ablation (3D-50) ---
-    p.add_argument("--latent_preset", choices=["small", "default", "large"],
-                   default="default",
-                   help="Latent-size ablation preset (3D-50). Explicit "
-                        "--deter_size/--stoch_classes/--stoch_discrete win over it.")
-    p.add_argument("--deter_size", type=int, default=None,
-                   help="Override cfg.deter_size (explicit; wins over --latent_preset).")
-    p.add_argument("--stoch_classes", type=int, default=None,
-                   help="Override cfg.stoch_classes (explicit; wins over --latent_preset).")
-    p.add_argument("--stoch_discrete", type=int, default=None,
-                   help="Override cfg.stoch_discrete (explicit; wins over --latent_preset).")
+    p.add_argument(
+        "--latent_preset",
+        choices=["small", "default", "large"],
+        default="default",
+        help="Latent-size ablation preset (3D-50). Explicit "
+        "--deter_size/--stoch_classes/--stoch_discrete win over it.",
+    )
+    p.add_argument(
+        "--deter_size",
+        type=int,
+        default=None,
+        help="Override cfg.deter_size (explicit; wins over --latent_preset).",
+    )
+    p.add_argument(
+        "--stoch_classes",
+        type=int,
+        default=None,
+        help="Override cfg.stoch_classes (explicit; wins over --latent_preset).",
+    )
+    p.add_argument(
+        "--stoch_discrete",
+        type=int,
+        default=None,
+        help="Override cfg.stoch_discrete (explicit; wins over --latent_preset).",
+    )
     # --- Debug decoder probe (3D-51) ---
-    p.add_argument("--decoder", action="store_true",
-                   help="Train a stop-gradient ConvDecoder probe for reconstruction logging (3D-51).")
-    p.add_argument("--scale_decoder", type=float, default=None,
-                   help="Override cfg.scale_decoder (decoder-only reconstruction weight).")
+    p.add_argument(
+        "--decoder",
+        action="store_true",
+        help="Train a stop-gradient ConvDecoder probe for reconstruction logging (3D-51).",
+    )
+    p.add_argument(
+        "--scale_decoder",
+        type=float,
+        default=None,
+        help="Override cfg.scale_decoder (decoder-only reconstruction weight).",
+    )
     # --- Hybrid VGGT-branch MLP knobs ---
-    p.add_argument("--mlp_vggt_hidden", type=int, default=None,
-                   help="Override cfg.mlp_vggt_hidden (hybrid WP/CP MLP width).")
-    p.add_argument("--mlp_vggt_layers", type=int, default=None,
-                   help="Override cfg.mlp_vggt_layers (hybrid WP/CP MLP depth).")
+    p.add_argument(
+        "--mlp_vggt_hidden",
+        type=int,
+        default=None,
+        help="Override cfg.mlp_vggt_hidden (hybrid WP/CP MLP width).",
+    )
+    p.add_argument(
+        "--mlp_vggt_layers",
+        type=int,
+        default=None,
+        help="Override cfg.mlp_vggt_layers (hybrid WP/CP MLP depth).",
+    )
 
 
 def _add_token_transformer_train_args(p: argparse.ArgumentParser) -> None:
-    p.add_argument("--vggt_token_transformer_layers", type=int, default=None,
-                   help="Override cfg.vggt_token_transformer_layers for "
-                        "vggt_agg_token_transformer.")
-    p.add_argument("--vggt_token_transformer_heads", type=int, default=None,
-                   help="Override cfg.vggt_token_transformer_heads for "
-                        "vggt_agg_token_transformer.")
-    p.add_argument("--vggt_token_projection_dim", type=int, default=None,
-                   help="Override cfg.vggt_token_projection_dim before token attention.")
-    p.add_argument("--vggt_token_transformer_mlp_ratio", type=int, default=None,
-                   help="Override cfg.vggt_token_transformer_mlp_ratio.")
-    p.add_argument("--vggt_token_transformer_dropout", type=float, default=None,
-                   help="Override cfg.vggt_token_transformer_dropout. Default 0.0.")
-    p.add_argument("--vggt_drop_register_tokens", action="store_true",
-                   help="Drop the 4 VGGT register tokens in the token Transformer "
-                        "ablation. Default keeps registers for 3D-75.")
-    p.add_argument("--compute_dtype",
-                   choices=["float32", "bfloat16", "bf16", "float16", "fp16"],
-                   default=None,
-                   help="Override cfg.compute_dtype for large encoder activations. "
-                        "Use bfloat16 for full-token memory ablations.")
+    p.add_argument(
+        "--vggt_token_transformer_layers",
+        type=int,
+        default=None,
+        help="Override cfg.vggt_token_transformer_layers for "
+        "vggt_agg_token_transformer.",
+    )
+    p.add_argument(
+        "--vggt_token_transformer_heads",
+        type=int,
+        default=None,
+        help="Override cfg.vggt_token_transformer_heads for "
+        "vggt_agg_token_transformer.",
+    )
+    p.add_argument(
+        "--vggt_token_projection_dim",
+        type=int,
+        default=None,
+        help="Override cfg.vggt_token_projection_dim before token attention.",
+    )
+    p.add_argument(
+        "--vggt_token_transformer_mlp_ratio",
+        type=int,
+        default=None,
+        help="Override cfg.vggt_token_transformer_mlp_ratio.",
+    )
+    p.add_argument(
+        "--vggt_token_transformer_dropout",
+        type=float,
+        default=None,
+        help="Override cfg.vggt_token_transformer_dropout. Default 0.0.",
+    )
+    p.add_argument(
+        "--vggt_drop_register_tokens",
+        action="store_true",
+        help="Drop the 4 VGGT register tokens in the token Transformer "
+        "ablation. Default keeps registers for 3D-75.",
+    )
+    p.add_argument(
+        "--compute_dtype",
+        choices=["float32", "bfloat16", "bf16", "float16", "fp16"],
+        default=None,
+        help="Override cfg.compute_dtype for large encoder activations. "
+        "Use bfloat16 for full-token memory ablations.",
+    )
 
 
 def _build_parser_train() -> argparse.ArgumentParser:
@@ -165,31 +320,58 @@ def _build_parser_eval() -> argparse.ArgumentParser:
     """Build CLI parser for evaluate()."""
     p = argparse.ArgumentParser(add_help=True)
     p.add_argument("--checkpoint", type=str, default=None)
-    p.add_argument("--encoder", type=str, default=None,
-                   choices=[
-                       "cnn", "vggt", "vggt_aggregator_mlp",
-                       "vggt_agg_token_transformer", "vggt_wp_dense_cnn",
-                       "vggt_wp_cp_64", "hybrid", "vggt_house_context",
-                       "vggt_house_full_tokens_nogate",
-                   ])
-    p.add_argument("--random", action="store_true",
-                   help="Use random agent instead of a checkpoint")
+    p.add_argument(
+        "--encoder",
+        type=str,
+        default=None,
+        choices=[
+            "cnn",
+            "vggt",
+            "vggt_aggregator_mlp",
+            "vggt_agg_token_transformer",
+            "vggt_wp_dense_cnn",
+            "vggt_wp_cp_64",
+            "hybrid",
+            "vggt_house_context",
+            "vggt_house_full_tokens_nogate",
+        ],
+    )
+    p.add_argument(
+        "--random", action="store_true", help="Use random agent instead of a checkpoint"
+    )
     p.add_argument("--episodes", type=int, default=10)
-    p.add_argument("--output_dir", type=str, default=None,
-                   help="Directory to write results JSON")
+    p.add_argument(
+        "--output_dir", type=str, default=None, help="Directory to write results JSON"
+    )
     p.add_argument("--seed", type=int, default=42)
     # escape hatch: override shim-hardcoded curriculum
-    p.add_argument("--curriculum_path", type=str, default=None,
-                   help="Override shim curriculum path (escape hatch)")
-    p.add_argument("--render_resolution", type=int, default=None,
-                   help="Render resolution (default: 518 for vggt, 64 for cnn)")
+    p.add_argument(
+        "--curriculum_path",
+        type=str,
+        default=None,
+        help="Override shim curriculum path (escape hatch)",
+    )
+    p.add_argument(
+        "--render_resolution",
+        type=int,
+        default=None,
+        help="Render resolution (default: 518 for vggt, 64 for cnn)",
+    )
     p.add_argument("--split", type=str, default="val")
     p.add_argument("--save_frames", action="store_true")
     p.add_argument("--semantic", action="store_true")
     p.add_argument("--render_topdown", action="store_true")
-    p.add_argument("--log_video_episodes", type=int, default=0,
-                   help="Number of eval episodes to log as W&B videos")
-    p.add_argument("--wandb_project", type=str, default=None,
-                   help="W&B project for eval video logging")
+    p.add_argument(
+        "--log_video_episodes",
+        type=int,
+        default=0,
+        help="Number of eval episodes to log as W&B videos",
+    )
+    p.add_argument(
+        "--wandb_project",
+        type=str,
+        default=None,
+        help="W&B project for eval video logging",
+    )
     p.add_argument("--wandb_name", type=str, default=None)
     return p

--- a/src/r2dreamer/launch/registries.py
+++ b/src/r2dreamer/launch/registries.py
@@ -21,6 +21,7 @@ from src.r2dreamer.launch.habitat_setup import make_habitat_env
 def make_crafter_env(*, seed: int = 0, **kwargs):
     """Thin wrapper so crafter follows the same factory signature as habitat."""
     from src.environments.crafter import CrafterEnv
+
     return CrafterEnv(size=(64, 64), seed=seed)
 
 

--- a/src/r2dreamer/launch/train.py
+++ b/src/r2dreamer/launch/train.py
@@ -11,7 +11,11 @@ if TYPE_CHECKING:
 
 
 def _resolve_curriculum_inputs(
-    *, env: str, args: Any, curriculum: str | None, env_registry: dict[str, Any],
+    *,
+    env: str,
+    args: Any,
+    curriculum: str | None,
+    env_registry: dict[str, Any],
 ) -> str | None:
     from src.r2dreamer.launch._helpers import resolve_curriculum_path
 
@@ -31,7 +35,9 @@ def _resolve_curriculum_inputs(
 
 def _make_encoder_bundle(encoder: str, args: Any, encoder_registry: dict[str, Any]):
     if encoder not in encoder_registry:
-        raise KeyError(f"Unknown encoder {encoder!r}. Available: {list(encoder_registry)}")
+        raise KeyError(
+            f"Unknown encoder {encoder!r}. Available: {list(encoder_registry)}"
+        )
     enc = encoder_registry[encoder].from_train_args(args)
     return enc, enc.make_adapter(), enc.spec()
 
@@ -46,7 +52,9 @@ def _effective_run_metadata(
     # CLI value (non-None) wins over shim kwarg.
     eff_output_dir = args.output_dir if args.output_dir is not None else output_dir
     if eff_output_dir is None:
-        raise ValueError("output_dir must be set via train(..., output_dir=...) or --output_dir")
+        raise ValueError(
+            "output_dir must be set via train(..., output_dir=...) or --output_dir"
+        )
 
     eff_wandb_name = args.wandb_name if args.wandb_name is not None else wandb_name
     eff_wandb_tags: list[str] = list(wandb_tags) if wandb_tags is not None else []
@@ -86,7 +94,9 @@ def _make_env_instances(
     return env_fn(seed=args.seed), None, 17
 
 
-def _agent_overrides_from_args(args: Any, encoder_spec: Any, latent_presets: dict[str, dict]):
+def _agent_overrides_from_args(
+    args: Any, encoder_spec: Any, latent_presets: dict[str, dict]
+):
     agent_overrides = dict(encoder_spec.agent_overrides)
     # Diagnostic CLI overrides (None => keep config default / encoder override).
     for attr, override in (
@@ -113,10 +123,16 @@ def _agent_overrides_from_args(args: Any, encoder_spec: Any, latent_presets: dic
     preset = getattr(args, "latent_preset", "default")
     agent_overrides.update(latent_presets.get(preset, {}))
     for name in (
-        "deter_size", "stoch_classes", "stoch_discrete",
-        "mlp_vggt_hidden", "mlp_vggt_layers", "scale_decoder",
-        "vggt_token_transformer_layers", "vggt_token_transformer_heads",
-        "vggt_token_projection_dim", "vggt_token_transformer_mlp_ratio",
+        "deter_size",
+        "stoch_classes",
+        "stoch_discrete",
+        "mlp_vggt_hidden",
+        "mlp_vggt_layers",
+        "scale_decoder",
+        "vggt_token_transformer_layers",
+        "vggt_token_transformer_heads",
+        "vggt_token_projection_dim",
+        "vggt_token_transformer_mlp_ratio",
         "vggt_token_transformer_dropout",
     ):
         value = getattr(args, name, None)
@@ -137,8 +153,13 @@ def _agent_overrides_from_args(args: Any, encoder_spec: Any, latent_presets: dic
 
 
 def _make_agent_config(
-    *, args: Any, encoder_spec: Any, num_actions: int, output_dir: str,
-    agent_overrides: dict[str, Any], config_cls: type,
+    *,
+    args: Any,
+    encoder_spec: Any,
+    num_actions: int,
+    output_dir: str,
+    agent_overrides: dict[str, Any],
+    config_cls: type,
 ):
     from src.r2dreamer.observation_preparation import (
         encoder_module_kwargs_from_config,
@@ -170,8 +191,12 @@ def _make_agent_config(
 
 
 def _make_trainer_config(
-    *, args: Any, output_dir: str, wandb_name: str | None,
-    wandb_tags: list[str], trainer_config_cls: type,
+    *,
+    args: Any,
+    output_dir: str,
+    wandb_name: str | None,
+    wandb_tags: list[str],
+    trainer_config_cls: type,
 ):
     return trainer_config_cls(
         output_dir=output_dir,
@@ -277,11 +302,17 @@ def train(
     args = parser.parse_args(argv if argv is not None else sys.argv[1:])
 
     curriculum_path = _resolve_curriculum_inputs(
-        env=env, args=args, curriculum=curriculum, env_registry=env_registry,
+        env=env,
+        args=args,
+        curriculum=curriculum,
+        env_registry=env_registry,
     )
     enc, adapter, encoder_spec = _make_encoder_bundle(encoder, args, encoder_registry)
     eff_output_dir, eff_wandb_name, eff_wandb_tags = _effective_run_metadata(
-        args=args, output_dir=output_dir, wandb_name=wandb_name, wandb_tags=wandb_tags,
+        args=args,
+        output_dir=output_dir,
+        wandb_name=wandb_name,
+        wandb_tags=wandb_tags,
     )
     env_instance, val_env_instance, num_actions = _make_env_instances(
         env=env,

--- a/src/r2dreamer/manifest.py
+++ b/src/r2dreamer/manifest.py
@@ -23,7 +23,10 @@ MANIFEST_NAME = "MANIFEST.json"
 def _git(*args: str) -> str:
     """Run a git command and return stdout stripped. Lets git failures propagate."""
     return subprocess.run(
-        ("git", *args), check=True, capture_output=True, text=True,
+        ("git", *args),
+        check=True,
+        capture_output=True,
+        text=True,
     ).stdout.strip()
 
 
@@ -34,6 +37,7 @@ def _wandb_id() -> str | None:
         return env
     try:
         import wandb  # noqa: WPS433 — optional dep
+
         run = getattr(wandb, "run", None)
         return run.id if run is not None else None
     except Exception:

--- a/src/r2dreamer/obs_batch.py
+++ b/src/r2dreamer/obs_batch.py
@@ -139,7 +139,9 @@ def encoder_obs_from_batch(batch: dict[str, Any], cfg: ObsBatchConfig) -> Encode
         world_points = jnp.asarray(obs[WORLD_POINTS_KEY], dtype=compute_dtype).reshape(
             B * T, *world_points_shape
         )
-        camera_pose = jnp.asarray(obs[CAMERA_POSE_KEY], dtype=compute_dtype).reshape(B * T, *camera_pose_shape)
+        camera_pose = jnp.asarray(obs[CAMERA_POSE_KEY], dtype=compute_dtype).reshape(
+            B * T, *camera_pose_shape
+        )
         return {WORLD_POINTS_KEY: world_points, CAMERA_POSE_KEY: camera_pose}
     elif cfg.encoder_type in ("vggt", "vggt_wp_cp_64") and isinstance(obs, Mapping):
         obs = pack_world_points_camera_pose_obs(obs, dtype=compute_dtype)
@@ -152,7 +154,9 @@ def encoder_obs_from_batch(batch: dict[str, Any], cfg: ObsBatchConfig) -> Encode
     return obs.reshape(B * T, *_flat_obs_shape(cfg))
 
 
-def encoder_obs_from_agent_obs(obs_dict: Mapping[str, Any], cfg: ObsBatchConfig) -> EncoderObs:
+def encoder_obs_from_agent_obs(
+    obs_dict: Mapping[str, Any], cfg: ObsBatchConfig
+) -> EncoderObs:
     """Return one-step encoder input for acting."""
     compute_dtype = compute_jnp_dtype(cfg.compute_dtype)
     if cfg.encoder_type == "hybrid":
@@ -172,8 +176,12 @@ def encoder_obs_from_agent_obs(obs_dict: Mapping[str, Any], cfg: ObsBatchConfig)
         return obs
     elif cfg.encoder_type == "vggt_wp64_cnn_cp_mlp":
         return {
-            WORLD_POINTS_KEY: jnp.asarray(obs_dict[WORLD_POINTS_KEY], dtype=compute_dtype)[None],
-            CAMERA_POSE_KEY: jnp.asarray(obs_dict[CAMERA_POSE_KEY], dtype=compute_dtype)[None],
+            WORLD_POINTS_KEY: jnp.asarray(
+                obs_dict[WORLD_POINTS_KEY], dtype=compute_dtype
+            )[None],
+            CAMERA_POSE_KEY: jnp.asarray(
+                obs_dict[CAMERA_POSE_KEY], dtype=compute_dtype
+            )[None],
         }
     elif cfg.encoder_type == "vggt_wp_dense_cnn" and WORLD_POINTS_KEY in obs_dict:
         obs = jnp.asarray(obs_dict[WORLD_POINTS_KEY], dtype=compute_dtype)
@@ -196,14 +204,20 @@ def decoder_rgb_target(batch: dict[str, Any], cfg: ObsBatchConfig) -> jnp.ndarra
     """Return decoder RGB targets as ``(B*T, 3, 64, 64)`` in ``[0, 1]``."""
     obs = batch["obs"]
     B, T = obs_leading_shape(obs)
-    if cfg.encoder_type in ("hybrid", "vggt_house_context", "vggt_house_full_tokens_nogate"):
+    if cfg.encoder_type in (
+        "hybrid",
+        "vggt_house_context",
+        "vggt_house_full_tokens_nogate",
+    ):
         if isinstance(obs, Mapping):
             image = normalize_image_obs(obs[HYBRID_IMAGE_KEY])
             return image.reshape(B * T, 3, 64, 64)
         obs_shape = _flat_obs_shape(cfg)
         rgb_dim = obs_shape[0] - cfg.vggt_feature_dim
-        return jnp.asarray(obs, dtype=jnp.float32).reshape(B * T, -1)[
-            :, :rgb_dim
-        ].reshape(B * T, 3, 64, 64)
+        return (
+            jnp.asarray(obs, dtype=jnp.float32)
+            .reshape(B * T, -1)[:, :rgb_dim]
+            .reshape(B * T, 3, 64, 64)
+        )
     image = normalize_image_obs(obs)
     return image.reshape(B * T, 3, 64, 64)

--- a/src/r2dreamer/observation_preparation/contracts.py
+++ b/src/r2dreamer/observation_preparation/contracts.py
@@ -44,7 +44,8 @@ def _tuple_value(config: Any, name: str) -> tuple[int, ...]:
 
 
 def encoder_module_kwargs_from_config(
-    config: Any, encoder_module_cls: type,
+    config: Any,
+    encoder_module_cls: type,
 ) -> dict[str, Any]:
     """Resolve Encoder Module constructor kwargs from an effective config."""
     class_name = encoder_module_cls.__name__
@@ -55,10 +56,12 @@ def encoder_module_kwargs_from_config(
             "mults": _tuple_value(config, "encoder_mults"),
         }
         if getattr(config, "encoder_type", None) == "vggt_wp_dense_cnn":
-            kwargs.update({
-                "input_kind": "world_points",
-                "embed_dim": int(config.vggt_embed_dim),
-            })
+            kwargs.update(
+                {
+                    "input_kind": "world_points",
+                    "embed_dim": int(config.vggt_embed_dim),
+                }
+            )
         return kwargs
     if class_name == "WP64CNNCPMLPEncoder":
         return {
@@ -173,16 +176,19 @@ class ObservationFormContract:
 
     @classmethod
     def from_snapshot(
-        cls, snapshot: Mapping[str, Any],
+        cls,
+        snapshot: Mapping[str, Any],
     ) -> "ObservationFormContract":
         kind = snapshot["kind"]
         if kind == "single":
             return cls(ObservationField.from_snapshot(snapshot["field"]))
         if kind == "structured":
-            return cls({
-                key: ObservationField.from_snapshot(field_snapshot)
-                for key, field_snapshot in snapshot["fields"].items()
-            })
+            return cls(
+                {
+                    key: ObservationField.from_snapshot(field_snapshot)
+                    for key, field_snapshot in snapshot["fields"].items()
+                }
+            )
         raise ValueError(f"unknown observation form snapshot kind {kind!r}")
 
 
@@ -215,7 +221,9 @@ class EncoderInputContract:
             "agent_observation": self.agent_observation.to_snapshot(),
             "encoder_input": self.encoder_input.to_snapshot(),
             "decoder_target": (
-                None if self.decoder_target is None else self.decoder_target.to_snapshot()
+                None
+                if self.decoder_target is None
+                else self.decoder_target.to_snapshot()
             ),
             "agent_overrides": dict(self.agent_overrides),
             "encoder_module_kwargs": dict(self.encoder_module_kwargs),
@@ -224,7 +232,8 @@ class EncoderInputContract:
 
     @classmethod
     def from_snapshot(
-        cls, snapshot: Mapping[str, Any],
+        cls,
+        snapshot: Mapping[str, Any],
     ) -> "EncoderInputContract":
         if int(snapshot.get("version", 1)) != 1:
             raise ValueError(

--- a/src/r2dreamer/observation_preparation/vggt.py
+++ b/src/r2dreamer/observation_preparation/vggt.py
@@ -22,7 +22,9 @@ from src.r2dreamer.observation_preparation.contracts import (
 from src.r2dreamer.world_model import encoders as wm_encoders
 
 
-VGGTFeatureKind = Literal["wp_cp", "wp64_cp", "aggregator", "wp_dense", "agg_raw", "agg_tokens"]
+VGGTFeatureKind = Literal[
+    "wp_cp", "wp64_cp", "aggregator", "wp_dense", "agg_raw", "agg_tokens"
+]
 HeadEncoderInputKind = Literal["flat_wp_cp", "structured_wp_cp", "world_points"]
 
 VGGT_IMAGE_SIZE = 518
@@ -92,7 +94,9 @@ def world_points_side_for_head_readout(extractor: Any, spec: HeadReadoutSpec) ->
     return int(getattr(extractor, "wp_pool_size", VGGT_DEFAULT_WP_POOL_SIZE))
 
 
-def contract_world_points_hwc_shape(contract: EncoderInputContract) -> tuple[int, int, int]:
+def contract_world_points_hwc_shape(
+    contract: EncoderInputContract,
+) -> tuple[int, int, int]:
     """Resolve the extractor-facing HWC point-map shape from a structured contract."""
     shape_by_field = contract.replay_observation.buffer_shape()
     if not isinstance(shape_by_field, dict):
@@ -102,10 +106,14 @@ def contract_world_points_hwc_shape(contract: EncoderInputContract) -> tuple[int
         raise ValueError(f"expected CHW world-points contract shape, got {chw_shape}")
     channels, height, width = chw_shape
     if height != width:
-        raise ValueError(f"expected square world-points contract shape, got {chw_shape}")
+        raise ValueError(
+            f"expected square world-points contract shape, got {chw_shape}"
+        )
     expected_hwc_shape = world_points_hwc_shape(height)
     if channels != expected_hwc_shape[-1]:
-        raise ValueError(f"expected {expected_hwc_shape[-1]} world-point channels, got {channels}")
+        raise ValueError(
+            f"expected {expected_hwc_shape[-1]} world-point channels, got {channels}"
+        )
     return expected_hwc_shape
 
 
@@ -136,7 +144,9 @@ HYBRID_FEATURE_DIM = hybrid_feature_dim()
 def _env_observation(env_render_resolution: int) -> ObservationFormContract:
     return ObservationFormContract(
         {
-            "image": ObservationField((3, env_render_resolution, env_render_resolution), "uint8"),
+            "image": ObservationField(
+                (3, env_render_resolution, env_render_resolution), "uint8"
+            ),
             "is_first": ObservationField((), "bool"),
         }
     )
@@ -158,8 +168,12 @@ def _wp_cp_fields(
     camera_pose_dtype: str,
 ) -> dict[str, ObservationField]:
     return {
-        WORLD_POINTS_KEY: ObservationField(world_points_shape, world_points_dtype, normalize_on_sample=False),
-        CAMERA_POSE_KEY: ObservationField((VGGT_CAMERA_POSE_DIM,), camera_pose_dtype, normalize_on_sample=False),
+        WORLD_POINTS_KEY: ObservationField(
+            world_points_shape, world_points_dtype, normalize_on_sample=False
+        ),
+        CAMERA_POSE_KEY: ObservationField(
+            (VGGT_CAMERA_POSE_DIM,), camera_pose_dtype, normalize_on_sample=False
+        ),
     }
 
 
@@ -236,7 +250,9 @@ def _default_encoder_type(feature_kind: VGGTFeatureKind, wp_pool_size: int) -> s
     raise ValueError(f"unknown VGGT feature_kind {feature_kind!r}")
 
 
-def _default_module_cls(encoder_type: str, feature_kind: VGGTFeatureKind) -> type[nn.Module]:
+def _default_module_cls(
+    encoder_type: str, feature_kind: VGGTFeatureKind
+) -> type[nn.Module]:
     if encoder_type == "hybrid":
         return wm_encoders.HybridEncoder
     if spec := head_readout_spec(feature_kind):
@@ -246,13 +262,21 @@ def _default_module_cls(encoder_type: str, feature_kind: VGGTFeatureKind) -> typ
     return wm_encoders.VGGTEncoder
 
 
-def _vggt_shape_dtype(extractor: Any, feature_kind: VGGTFeatureKind) -> tuple[tuple[int, ...], str]:
+def _vggt_shape_dtype(
+    extractor: Any, feature_kind: VGGTFeatureKind
+) -> tuple[tuple[int, ...], str]:
     if feature_kind == "aggregator":
-        return (aggregator_pooled_dim(tuple(extractor.aggregator_feature_shape)),), "float32"
+        return (
+            aggregator_pooled_dim(tuple(extractor.aggregator_feature_shape)),
+        ), "float32"
     if feature_kind == "agg_raw":
-        return (aggregator_raw_dim(tuple(extractor.aggregator_feature_shape)),), "float16"
+        return (
+            aggregator_raw_dim(tuple(extractor.aggregator_feature_shape)),
+        ), "float16"
     if feature_kind == "agg_tokens":
-        return (aggregator_token_dim(tuple(extractor.aggregator_feature_shape)),), "float16"
+        return (
+            aggregator_token_dim(tuple(extractor.aggregator_feature_shape)),
+        ), "float16"
     raise ValueError(f"unknown non-head VGGT feature_kind {feature_kind!r}")
 
 
@@ -268,7 +292,9 @@ def build_vggt_contract(
 ) -> EncoderInputContract:
     """Build the Encoder Input Contract for one VGGT readout variant."""
     wp_pool_size = int(getattr(extractor, "wp_pool_size", VGGT_DEFAULT_WP_POOL_SIZE))
-    resolved_encoder_type = encoder_type or _default_encoder_type(feature_kind, wp_pool_size)
+    resolved_encoder_type = encoder_type or _default_encoder_type(
+        feature_kind, wp_pool_size
+    )
     if spec := head_readout_spec(feature_kind):
         image_size = int(getattr(extractor, "image_size", VGGT_IMAGE_SIZE))
         wp_side = world_points_side_for_head_readout(extractor, spec)
@@ -285,7 +311,9 @@ def build_vggt_contract(
         )
         encoder_input_by_kind = {
             "flat_wp_cp": ObservationFormContract(
-                ObservationField((wp_cp_dim(wp_pool_size),), "float32", normalize_on_sample=False)
+                ObservationField(
+                    (wp_cp_dim(wp_pool_size),), "float32", normalize_on_sample=False
+                )
             ),
             "structured_wp_cp": ObservationFormContract(agent_fields),
             "world_points": ObservationFormContract(
@@ -303,10 +331,13 @@ def build_vggt_contract(
             observation_preparation_type=resolved_encoder_type,
             encoder_type=resolved_encoder_type,
             env_render_resolution=render_resolution,
-            encoder_module_cls=encoder_module_cls or _default_module_cls(resolved_encoder_type, feature_kind),
+            encoder_module_cls=encoder_module_cls
+            or _default_module_cls(resolved_encoder_type, feature_kind),
             env_observation=_env_observation(render_resolution),
             replay_observation=ObservationFormContract(replay_fields),
-            agent_observation=ObservationFormContract({**agent_fields, "is_first": ObservationField((), "bool")}),
+            agent_observation=ObservationFormContract(
+                {**agent_fields, "is_first": ObservationField((), "bool")}
+            ),
             encoder_input=encoder_input,
             decoder_target=None,
             agent_overrides=resolved_overrides,
@@ -328,7 +359,8 @@ def build_vggt_contract(
         observation_preparation_type=resolved_encoder_type,
         encoder_type=resolved_encoder_type,
         env_render_resolution=render_resolution,
-        encoder_module_cls=encoder_module_cls or _default_module_cls(resolved_encoder_type, feature_kind),
+        encoder_module_cls=encoder_module_cls
+        or _default_module_cls(resolved_encoder_type, feature_kind),
         env_observation=_env_observation(render_resolution),
         replay_observation=ObservationFormContract(replay_field),
         agent_observation=_agent_features_observation(shape),
@@ -355,12 +387,20 @@ def build_hybrid_contract(
     )
 
     replay_fields = {
-        HYBRID_IMAGE_KEY: ObservationField(HYBRID_IMAGE_SHAPE, "uint8", normalize_on_sample=False),
-        HYBRID_WP_CP_KEY: ObservationField(wp_cp_shape, "float32", normalize_on_sample=False),
+        HYBRID_IMAGE_KEY: ObservationField(
+            HYBRID_IMAGE_SHAPE, "uint8", normalize_on_sample=False
+        ),
+        HYBRID_WP_CP_KEY: ObservationField(
+            wp_cp_shape, "float32", normalize_on_sample=False
+        ),
     }
     agent_fields = {
-        HYBRID_IMAGE_KEY: ObservationField(HYBRID_IMAGE_SHAPE, "uint8", normalize_on_sample=False),
-        HYBRID_WP_CP_KEY: ObservationField(wp_cp_shape, "float32", normalize_on_sample=False),
+        HYBRID_IMAGE_KEY: ObservationField(
+            HYBRID_IMAGE_SHAPE, "uint8", normalize_on_sample=False
+        ),
+        HYBRID_WP_CP_KEY: ObservationField(
+            wp_cp_shape, "float32", normalize_on_sample=False
+        ),
         "is_first": ObservationField((), "bool"),
     }
 
@@ -372,8 +412,16 @@ def build_hybrid_contract(
         env_observation=_env_observation(render_resolution),
         replay_observation=ObservationFormContract(replay_fields),
         agent_observation=ObservationFormContract(agent_fields),
-        encoder_input=ObservationFormContract(ObservationField((hybrid_feature_dim(wp_pool_size),), "float32")),
-        decoder_target=ObservationFormContract(ObservationField(HYBRID_IMAGE_SHAPE, "float32")),
-        agent_overrides=dict(agent_overrides if agent_overrides is not None else _DEFAULT_AGENT_OVERRIDES["hybrid"]),
+        encoder_input=ObservationFormContract(
+            ObservationField((hybrid_feature_dim(wp_pool_size),), "float32")
+        ),
+        decoder_target=ObservationFormContract(
+            ObservationField(HYBRID_IMAGE_SHAPE, "float32")
+        ),
+        agent_overrides=dict(
+            agent_overrides
+            if agent_overrides is not None
+            else _DEFAULT_AGENT_OVERRIDES["hybrid"]
+        ),
         design_notes=design_notes,
     )

--- a/src/r2dreamer/observation_preparation/vggt_readouts.py
+++ b/src/r2dreamer/observation_preparation/vggt_readouts.py
@@ -63,7 +63,9 @@ def _structured_world_points_camera_pose(
     }
 
 
-def _checked_feature(out: dict, key: str, expected_shape: tuple[int, ...]) -> jnp.ndarray:
+def _checked_feature(
+    out: dict, key: str, expected_shape: tuple[int, ...]
+) -> jnp.ndarray:
     """Return a float32 VGGT readout after validating its contract shape."""
     features = out[key]
     if tuple(features.shape) != expected_shape:

--- a/src/r2dreamer/representation/barlow.py
+++ b/src/r2dreamer/representation/barlow.py
@@ -15,6 +15,7 @@ import flax.linen as nn
 
 class Projector(nn.Module):
     """Single linear projection without bias (maps feat_size -> embed_dim)."""
+
     out_dim: int
 
     @nn.compact

--- a/src/r2dreamer/representation/loss.py
+++ b/src/r2dreamer/representation/loss.py
@@ -4,8 +4,9 @@ from .barlow import barlow_loss
 from .repvalue import repval_loss
 
 
-def representation_loss(*, forward, batch, params, modules, cfg, twohot,
-                        slow_critic_params, imag_ret, B, T):
+def representation_loss(
+    *, forward, batch, params, modules, cfg, twohot, slow_critic_params, imag_ret, B, T
+):
     """Combined Barlow + repval. Both consume the shared forward dict.
 
     Returns:
@@ -14,13 +15,24 @@ def representation_loss(*, forward, batch, params, modules, cfg, twohot,
     """
     losses = {}
     losses["barlow"] = barlow_loss(
-        feat=forward["feat"], embed=forward["embed"],
-        params=params, modules=modules, cfg=cfg, B=B, T=T,
+        feat=forward["feat"],
+        embed=forward["embed"],
+        params=params,
+        modules=modules,
+        cfg=cfg,
+        B=B,
+        T=T,
     )
     losses["repval"] = repval_loss(
-        feat=forward["feat"], batch=batch,
-        params=params, modules=modules, cfg=cfg, twohot=twohot,
-        slow_critic_params=slow_critic_params, imag_ret=imag_ret,
-        B=B, T=T,
+        feat=forward["feat"],
+        batch=batch,
+        params=params,
+        modules=modules,
+        cfg=cfg,
+        twohot=twohot,
+        slow_critic_params=slow_critic_params,
+        imag_ret=imag_ret,
+        B=B,
+        T=T,
     )
     return losses, {}

--- a/src/r2dreamer/representation/repvalue.py
+++ b/src/r2dreamer/representation/repvalue.py
@@ -12,8 +12,9 @@ import jax.numpy as jnp
 from ..behavior.imagination import _lambda_return
 
 
-def repval_loss(*, feat, batch, params, modules, cfg, twohot,
-                slow_critic_params, imag_ret, B, T):
+def repval_loss(
+    *, feat, batch, params, modules, cfg, twohot, slow_critic_params, imag_ret, B, T
+):
     """Replay value loss with world-model gradients.
 
     Args:
@@ -31,7 +32,7 @@ def repval_loss(*, feat, batch, params, modules, cfg, twohot,
     Returns:
         scalar repval loss.
     """
-    replay_last = batch["is_last"]   # (B, T)
+    replay_last = batch["is_last"]  # (B, T)
     replay_term = batch["is_terminal"]  # (B, T)
     replay_reward = batch["rewards"]  # (B, T)
 
@@ -41,28 +42,40 @@ def repval_loss(*, feat, batch, params, modules, cfg, twohot,
     feat_flat = feat.reshape(B * T, -1)
 
     # Frozen critic for the lambda-return target
-    replay_val_logits = modules["critic"].apply(
-        jax.lax.stop_gradient(params["critic"]), feat_flat
-    ).reshape(B, T, cfg.twohot_bins)
+    replay_val_logits = (
+        modules["critic"]
+        .apply(jax.lax.stop_gradient(params["critic"]), feat_flat)
+        .reshape(B, T, cfg.twohot_bins)
+    )
     replay_value = twohot.pred(replay_val_logits)  # (B, T, 1)
 
-    replay_slow_logits = modules["critic"].apply(
-        slow_critic_params, feat_flat
-    ).reshape(B, T, cfg.twohot_bins)
+    replay_slow_logits = (
+        modules["critic"]
+        .apply(slow_critic_params, feat_flat)
+        .reshape(B, T, cfg.twohot_bins)
+    )
     replay_slow_value = twohot.pred(replay_slow_logits)  # (B, T, 1)
 
     disc = 1.0 - 1.0 / cfg.horizon
     replay_ret = _lambda_return(
-        replay_last[..., None], replay_term[..., None],
-        replay_reward[..., None], replay_value, boot, disc, cfg.lamb,
+        replay_last[..., None],
+        replay_term[..., None],
+        replay_reward[..., None],
+        replay_value,
+        boot,
+        disc,
+        cfg.lamb,
     )  # (B, T-1, 1)
     ret_padded = jnp.concatenate(
-        [replay_ret, jnp.zeros_like(replay_ret[:, -1:])], axis=1)
+        [replay_ret, jnp.zeros_like(replay_ret[:, -1:])], axis=1
+    )
 
     # Critic on replay features WITH gradients to the world model
-    repval_logits = modules["critic"].apply(
-        params["critic"], feat_flat
-    ).reshape(B, T, cfg.twohot_bins)
+    repval_logits = (
+        modules["critic"]
+        .apply(params["critic"], feat_flat)
+        .reshape(B, T, cfg.twohot_bins)
+    )
 
     repval_weight = 1.0 - replay_last  # (B, T)
     loss_tar = twohot.loss(

--- a/src/r2dreamer/trainer.py
+++ b/src/r2dreamer/trainer.py
@@ -20,7 +20,11 @@ import jax.numpy as jnp
 import numpy as np
 
 from src.buffer.replay_buffer import BufferConfig, ReplayBuffer
-from src.shared.video_utils import compose_frame, log_episode_video, render_topdown_frame
+from src.shared.video_utils import (
+    compose_frame,
+    log_episode_video,
+    render_topdown_frame,
+)
 from src.r2dreamer.adapters import ObsAdapter  # noqa: F401 — re-exported for callers
 from src.r2dreamer.checkpointing import (
     config_snapshot,
@@ -34,6 +38,7 @@ from src.r2dreamer.manifest import write_manifest_end, write_manifest_start
 # ---------------------------------------------------------------------------
 # Protocols
 # ---------------------------------------------------------------------------
+
 
 class Env(Protocol):
     def reset(self) -> dict: ...
@@ -71,8 +76,8 @@ class R2DreamerAgentLike(Protocol):
 # convert_batch
 # ---------------------------------------------------------------------------
 
-def convert_batch(batch: dict[str, Any],
-                  num_actions: int) -> dict[str, Any]:
+
+def convert_batch(batch: dict[str, Any], num_actions: int) -> dict[str, Any]:
     """Convert replay buffer output to agent training format.
 
     - actions: int32 (B,T) -> one_hot float32 (B,T,A)
@@ -93,9 +98,11 @@ def convert_batch(batch: dict[str, Any],
 # TrainerConfig
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class TrainerConfig:
     """Controls the training loop (separate from R2DreamerConfig model arch)."""
+
     output_dir: str = "output/runs/r2dreamer"
     total_steps: int = 10_000_000
     prefill_steps: int = 5000
@@ -162,12 +169,16 @@ def habitat_defaults(env: Any, *, track_collision_rate: bool = False) -> dict[st
     leave it False so the dashboard isn't doubly-noisy.
     """
     from src.shared.wandb_utils import EpisodeTracker
+
     tracker = EpisodeTracker(window=100, track_collision_rate=track_collision_rate)
     action_names = {0: "stop", 1: "forward", 2: "left", 3: "right"}
 
     def episode_metrics_fn(
-        env: Any, last_obs: dict, episode_reward: float,
-        episode_steps: int, action_counts: np.ndarray,
+        env: Any,
+        last_obs: dict,
+        episode_reward: float,
+        episode_steps: int,
+        action_counts: np.ndarray,
     ) -> dict[str, Any]:
         success = last_obs.get("success", 0.0)
         spl = last_obs.get("spl", 0.0)
@@ -181,9 +192,14 @@ def habitat_defaults(env: Any, *, track_collision_rate: bool = False) -> dict[st
         path_ratio = path_length / shortest_path if shortest_path > 0 else 0.0
 
         tracked = tracker.record(
-            reward=episode_reward, success=success, spl=spl,
-            category=category, scene_id=scene_raw,
-            softspl=softspl, dtg=dtg, collision_rate=collision_rate,
+            reward=episode_reward,
+            success=success,
+            spl=spl,
+            category=category,
+            scene_id=scene_raw,
+            softspl=softspl,
+            dtg=dtg,
+            collision_rate=collision_rate,
         )
 
         action_pcts = action_counts / max(episode_steps, 1)
@@ -194,8 +210,10 @@ def habitat_defaults(env: Any, *, track_collision_rate: bool = False) -> dict[st
             "episode/shortest_path": shortest_path,
             "episode/path_ratio": path_ratio,
             "episode_reset": 1,
-            **{f"action/{action_names[i]}_pct": float(action_pcts[i])
-               for i in range(len(action_counts))},
+            **{
+                f"action/{action_names[i]}_pct": float(action_pcts[i])
+                for i in range(len(action_counts))
+            },
         }
 
     return {
@@ -207,6 +225,7 @@ def habitat_defaults(env: Any, *, track_collision_rate: bool = False) -> dict[st
 # ---------------------------------------------------------------------------
 # Trainer
 # ---------------------------------------------------------------------------
+
 
 class Trainer:
     """Training loop: prefill -> train (train-ratio) -> log -> checkpoint.
@@ -248,7 +267,9 @@ class Trainer:
         # Build buffer from the Observation Preparation contract when present;
         # legacy adapters keep using their adapter attributes during migration.
         replay_contract = getattr(
-            getattr(self.obs_adapter, "contract", None), "replay_observation", None,
+            getattr(self.obs_adapter, "contract", None),
+            "replay_observation",
+            None,
         )
         if replay_contract is not None:
             obs_shape = replay_contract.buffer_shape()
@@ -258,12 +279,14 @@ class Trainer:
             obs_shape = self.obs_adapter.buffer_shape
             obs_dtype = self.obs_adapter.buffer_dtype
             normalize_obs = self.obs_adapter.normalize_on_sample
-        self.buffer = ReplayBuffer(BufferConfig(
-            capacity=agent_config.buffer_capacity,
-            obs_shape=obs_shape,
-            obs_dtype=obs_dtype,
-            normalize_obs=normalize_obs,
-        ))
+        self.buffer = ReplayBuffer(
+            BufferConfig(
+                capacity=agent_config.buffer_capacity,
+                obs_shape=obs_shape,
+                obs_dtype=obs_dtype,
+                normalize_obs=normalize_obs,
+            )
+        )
 
         # Resume from checkpoint (overwrite freshly-initialised agent state).
         self._resume_step = 0
@@ -289,6 +312,7 @@ class Trainer:
         self._wandb = None
         if trainer_config.wandb_project is not None:
             import wandb
+
             self._wandb = wandb
             init_kwargs: dict[str, Any] = dict(
                 project=trainer_config.wandb_project,
@@ -328,7 +352,9 @@ class Trainer:
                     # Skip random prefill — the trained policy collects on-policy
                     # transitions in _train_loop until buffer >= batch_steps.
                     # env.reset() / extractor.reset() fire at _train_loop entry.
-                    print(f"Resume mode: skipping prefill, jumping to step {self._resume_step}")
+                    print(
+                        f"Resume mode: skipping prefill, jumping to step {self._resume_step}"
+                    )
                 else:
                     self._prefill(rng_key, writer, f)
                 if tcfg.overfit_one_batch:
@@ -384,8 +410,13 @@ class Trainer:
             next_buffer_obs, _ = self._prepare_observation(self.obs_adapter, next_obs)
 
             success = next_obs.get("success", 0.0) > 0
-            self.buffer.add(buffer_obs, action, next_obs["reward"],
-                            next_obs["done"], terminal=success)
+            self.buffer.add(
+                buffer_obs,
+                action,
+                next_obs["reward"],
+                next_obs["done"],
+                terminal=success,
+            )
 
             if next_obs["done"]:
                 obs = self.env.reset()
@@ -400,7 +431,9 @@ class Trainer:
     # Train loop
     # ------------------------------------------------------------------
 
-    def _reset_train_episode(self) -> tuple[dict, np.ndarray | dict[str, np.ndarray], dict]:
+    def _reset_train_episode(
+        self,
+    ) -> tuple[dict, np.ndarray | dict[str, np.ndarray], dict]:
         obs = self.env.reset()
         if self.obs_adapter.on_episode_reset:
             self.obs_adapter.on_episode_reset()
@@ -411,7 +444,10 @@ class Trainer:
         return 0.0, 0, np.zeros(self.acfg.num_actions, dtype=int)
 
     def _start_train_video_if_due(
-        self, step: int, next_video_step: int, obs: dict,
+        self,
+        step: int,
+        next_video_step: int,
+        obs: dict,
     ) -> dict[str, Any] | None:
         if self._should_record_video(step, next_video_step):
             return self._start_video_recording(self.env, obs)
@@ -426,7 +462,10 @@ class Trainer:
     ) -> None:
         success = next_obs.get("success", 0.0) > 0
         self.buffer.add(
-            buffer_obs, action, next_obs["reward"], next_obs["done"],
+            buffer_obs,
+            action,
+            next_obs["reward"],
+            next_obs["done"],
             terminal=success,
         )
 
@@ -453,7 +492,13 @@ class Trainer:
         int,
     ]:
         self._on_episode_end(
-            last_obs, episode_reward, episode_steps, action_counts, step, writer, f,
+            last_obs,
+            episode_reward,
+            episode_steps,
+            action_counts,
+            step,
+            writer,
+            f,
         )
         if video_recording is not None:
             log_episode_video(
@@ -470,8 +515,14 @@ class Trainer:
         if self._should_record_video(step + 1, video_next_step):
             video_recording = self._start_video_recording(self.env, obs)
         return (
-            obs, buffer_obs, agent_obs, episode_reward, episode_steps,
-            action_counts, video_recording, video_next_step,
+            obs,
+            buffer_obs,
+            agent_obs,
+            episode_reward,
+            episode_steps,
+            action_counts,
+            video_recording,
+            video_next_step,
         )
 
     def _train_loop(self, rng_key: jnp.ndarray, writer: Any, f: Any) -> jnp.ndarray:
@@ -489,7 +540,9 @@ class Trainer:
         metrics: dict[str, Any] = {}
         video_next_step = start_step
         video_recording = self._start_train_video_if_due(
-            start_step, video_next_step, obs,
+            start_step,
+            video_next_step,
+            obs,
         )
 
         for step in range(start_step, tcfg.total_steps):
@@ -497,11 +550,14 @@ class Trainer:
             action = self.agent.act(agent_obs, act_key)
             next_obs = self.env.step(action)
             next_buffer_obs, next_agent_obs = self._prepare_observation(
-                self.obs_adapter, next_obs,
+                self.obs_adapter,
+                next_obs,
             )
 
             self._record_train_transition(
-                buffer_obs=buffer_obs, action=action, next_obs=next_obs,
+                buffer_obs=buffer_obs,
+                action=action,
+                next_obs=next_obs,
             )
             action_counts[action] += 1
             episode_reward += next_obs["reward"]
@@ -511,8 +567,14 @@ class Trainer:
 
             if next_obs["done"]:
                 (
-                    obs, buffer_obs, agent_obs, episode_reward, episode_steps,
-                    action_counts, video_recording, video_next_step,
+                    obs,
+                    buffer_obs,
+                    agent_obs,
+                    episode_reward,
+                    episode_steps,
+                    action_counts,
+                    video_recording,
+                    video_next_step,
                 ) = self._finish_train_episode(
                     last_obs=next_obs,
                     episode_reward=episode_reward,
@@ -546,9 +608,11 @@ class Trainer:
                         self._maybe_log_recon(batch, step)
 
             # --- Val-Episode-Loop (3D-36): deterministic held-out rollouts ---
-            if (self.val_env is not None
-                    and tcfg.val_every > 0
-                    and (step + 1) % tcfg.val_every == 0):
+            if (
+                self.val_env is not None
+                and tcfg.val_every > 0
+                and (step + 1) % tcfg.val_every == 0
+            ):
                 rng_key, val_key = jax.random.split(rng_key)
                 self._run_val_loop(val_key, step, writer, f)
 
@@ -590,13 +654,14 @@ class Trainer:
         self._append_video_frame(env, recording, obs)
         return recording
 
-    def _append_video_frame(self, env: Env, recording: dict[str, Any], obs: dict) -> None:
+    def _append_video_frame(
+        self, env: Env, recording: dict[str, Any], obs: dict
+    ) -> None:
         if "image" not in obs:
             return
         if recording["frames"]:
             recording["trajectory"].append(self._agent_position(env))
-        topdown = render_topdown_frame(
-            env, recording["trajectory"], recording["goals"])
+        topdown = render_topdown_frame(env, recording["trajectory"], recording["goals"])
         recording["frames"].append(compose_frame(obs["image"], topdown))
 
     # ------------------------------------------------------------------
@@ -648,11 +713,13 @@ class Trainer:
 
         loss_drop = (first_loss - last_loss) / max(abs(first_loss), 1e-12)
         writer.writerow([tcfg.overfit_steps - 1, "verify/overfit_loss_drop", loss_drop])
-        writer.writerow([
-            tcfg.overfit_steps - 1,
-            "verify/overfit_pass",
-            float(loss_drop >= tcfg.overfit_min_loss_drop),
-        ])
+        writer.writerow(
+            [
+                tcfg.overfit_steps - 1,
+                "verify/overfit_pass",
+                float(loss_drop >= tcfg.overfit_min_loss_drop),
+            ]
+        )
         f.flush()
         print(
             f"Overfit verify: first_loss={first_loss:.6g} "
@@ -673,12 +740,22 @@ class Trainer:
     # ------------------------------------------------------------------
 
     def _on_episode_end(
-        self, last_obs: dict, episode_reward: float, episode_steps: int,
-        action_counts: np.ndarray, step: int, writer: Any, f: Any,
+        self,
+        last_obs: dict,
+        episode_reward: float,
+        episode_steps: int,
+        action_counts: np.ndarray,
+        step: int,
+        writer: Any,
+        f: Any,
     ) -> dict[str, Any]:
         if self.episode_metrics_fn is not None:
             ep_metrics = self.episode_metrics_fn(
-                self.env, last_obs, episode_reward, episode_steps, action_counts,
+                self.env,
+                last_obs,
+                episode_reward,
+                episode_steps,
+                action_counts,
             )
         else:
             ep_metrics = {"episode/reward": episode_reward}
@@ -700,7 +777,11 @@ class Trainer:
         return ep_metrics
 
     def _log_train_metrics(
-        self, metrics: dict, step: int, writer: Any, f: Any,
+        self,
+        metrics: dict,
+        step: int,
+        writer: Any,
+        f: Any,
     ) -> None:
         now = time.time()
         elapsed = now - self._t0
@@ -799,22 +880,32 @@ class Trainer:
             agent_obs = next_agent_obs
 
         val_metrics = self.val_episode_metrics_fn(
-            self.val_env, obs, episode_reward, episode_steps, action_counts,
+            self.val_env,
+            obs,
+            episode_reward,
+            episode_steps,
+            action_counts,
         )
         if recording is not None:
             log_episode_video(
-                self._wandb, "val/episode_video", recording["frames"], step,
+                self._wandb,
+                "val/episode_video",
+                recording["frames"],
+                step,
             )
         return val_metrics, rng_key
 
     def _prefix_val_metrics(self, metrics: dict[str, Any]) -> dict[str, Any]:
         return {
-            f"val/{k}" if not k.startswith("val/") else k: v
-            for k, v in metrics.items()
+            f"val/{k}" if not k.startswith("val/") else k: v for k, v in metrics.items()
         }
 
     def _log_val_metrics(
-        self, val_logged: dict[str, Any], step: int, writer: Any, f: Any,
+        self,
+        val_logged: dict[str, Any],
+        step: int,
+        writer: Any,
+        f: Any,
     ) -> None:
         for k, v in val_logged.items():
             writer.writerow([step, k, v])
@@ -823,7 +914,10 @@ class Trainer:
             self._wandb.log(val_logged, step=step)
 
     def _print_val_summary(
-        self, val_logged: dict[str, Any], step: int, elapsed: float,
+        self,
+        val_logged: dict[str, Any],
+        step: int,
+        elapsed: float,
     ) -> None:
         sr = val_logged.get("val/metrics/sr", 0.0)
         spl = val_logged.get("val/metrics/spl", 0.0)
@@ -840,7 +934,11 @@ class Trainer:
         )
 
     def _run_val_loop(
-        self, rng_key: jnp.ndarray, step: int, writer: Any, f: Any,
+        self,
+        rng_key: jnp.ndarray,
+        step: int,
+        writer: Any,
+        f: Any,
     ) -> None:
         """Deterministic Val-Episode-Loop (3D-36) + video recording (3D-41).
 
@@ -850,8 +948,11 @@ class Trainer:
         because the eval episode order is pinned by the curriculum JSON).
         """
         tcfg = self.tcfg
-        if (self.val_env is None or self.val_obs_adapter is None
-                or self.val_episode_metrics_fn is None):
+        if (
+            self.val_env is None
+            or self.val_obs_adapter is None
+            or self.val_episode_metrics_fn is None
+        ):
             return
 
         last_val_metrics: dict[str, Any] = {}
@@ -860,11 +961,12 @@ class Trainer:
 
         for ep_idx in range(tcfg.val_episodes):
             record_video = (
-                videos_recorded < tcfg.val_video_episodes
-                and self._wandb is not None
+                videos_recorded < tcfg.val_video_episodes and self._wandb is not None
             )
             last_val_metrics, rng_key = self._run_single_val_episode(
-                rng_key=rng_key, record_video=record_video, step=step,
+                rng_key=rng_key,
+                record_video=record_video,
+                step=step,
             )
             if record_video:
                 videos_recorded += 1

--- a/src/r2dreamer/world_model/__init__.py
+++ b/src/r2dreamer/world_model/__init__.py
@@ -14,9 +14,20 @@ from .heads import R2MLP, R2TwoHotDist, onehot_mode_st
 from .loss import world_model_loss, kl_loss
 
 __all__ = [
-    "RMSNorm", "BlockLinear", "Deter", "R2RSSM",
-    "ConvEncoder", "VGGTEncoder", "VGGTAggregatorMLPEncoder", "WP64CNNCPMLPEncoder",
-    "HybridEncoder", "RGBFullTokenTransformerEncoder", "ConvDecoder",
-    "R2MLP", "R2TwoHotDist", "onehot_mode_st",
-    "world_model_loss", "kl_loss",
+    "RMSNorm",
+    "BlockLinear",
+    "Deter",
+    "R2RSSM",
+    "ConvEncoder",
+    "VGGTEncoder",
+    "VGGTAggregatorMLPEncoder",
+    "WP64CNNCPMLPEncoder",
+    "HybridEncoder",
+    "RGBFullTokenTransformerEncoder",
+    "ConvDecoder",
+    "R2MLP",
+    "R2TwoHotDist",
+    "onehot_mode_st",
+    "world_model_loss",
+    "kl_loss",
 ]

--- a/src/r2dreamer/world_model/encoders.py
+++ b/src/r2dreamer/world_model/encoders.py
@@ -18,19 +18,19 @@ from .rssm import RMSNorm
 # fields (see HybridObsAdapter); src.r2dreamer.obs_batch packs them into this
 # flat tensor right before the Flax encoder boundary.
 HYBRID_RGB_DIM = 3 * 64 * 64  # 12288 — the CNN branch's 64x64 RGB, flattened
-HYBRID_VGGT_DIM = 4116        # WP/CP width: world_points 37*37*3 + camera_pose 9
+HYBRID_VGGT_DIM = 4116  # WP/CP width: world_points 37*37*3 + camera_pose 9
 
 # Aggregator readouts (3D-50 follow-up). Defined here (small ints) rather than
 # imported from adapters.vggt_adapter so importing the world-model encoders stays
 # free of the heavy VGGT extractor dependency; tests/test_agg_raw_dims.py asserts
 # these agree with the adapter's constants and the live extractor shape.
-AGG_RAW_TOKENS = 1370                  # cam(1) + patches(1369); 4 register tokens dropped
-AGG_RAW_DIM = AGG_RAW_TOKENS * 1024    # 1,402,880 — raw flattened aggregator
-AGG_TOKEN_TOKENS = 1374                # cam(1) + registers(4) + patches(1369)
+AGG_RAW_TOKENS = 1370  # cam(1) + patches(1369); 4 register tokens dropped
+AGG_RAW_DIM = AGG_RAW_TOKENS * 1024  # 1,402,880 — raw flattened aggregator
+AGG_TOKEN_TOKENS = 1374  # cam(1) + registers(4) + patches(1369)
 AGG_TOKEN_DIM = AGG_TOKEN_TOKENS * 1024  # 1,406,976 — full flattened aggregator
 FULL_TOKEN_DIM = AGG_TOKEN_TOKENS * 2048  # 2,813,952 — frame + global streams
 HOUSE_CONTEXT_DIM = 1024
-AGG_POOLED_DIM = 3 * 1024              # 3,072 — pooled [cam | mean | max]
+AGG_POOLED_DIM = 3 * 1024  # 3,072 — pooled [cam | mean | max]
 AGG_REGISTER_TOKENS = 4
 
 
@@ -54,6 +54,7 @@ class ConvEncoder(nn.Module):
     optional for historical RGB compatibility; set it for world-point variants
     to project the flattened conv map to a fixed embedding width.
     """
+
     depth: int = 16
     kernel_size: int = 5
     mults: tuple = (2, 3, 4, 4)
@@ -73,8 +74,12 @@ class ConvEncoder(nn.Module):
         x = jnp.transpose(x, (0, 2, 3, 1))  # NCHW -> NHWC
         for i, mult in enumerate(self.mults):
             ch = self.depth * mult
-            x = nn.Conv(ch, (self.kernel_size, self.kernel_size),
-                        padding="SAME", name=f"conv{i}")(x)
+            x = nn.Conv(
+                ch,
+                (self.kernel_size, self.kernel_size),
+                padding="SAME",
+                name=f"conv{i}",
+            )(x)
             x = nn.max_pool(x, (2, 2), strides=(2, 2))
             x = RMSNorm(name=f"norm{i}")(x)
             x = nn.silu(x)
@@ -117,6 +122,7 @@ class VGGTEncoder(nn.Module):
     R2Dreamer's native ``encoder.mlp.layers``. ``num_layers=0`` reproduces the
     historical single-``Dense`` linear projection exactly.
     """
+
     embed_dim: int = 1024
     hidden: int = 1024
     num_layers: int = 1
@@ -130,6 +136,7 @@ class VGGTEncoder(nn.Module):
 
 class WP64CNNCPMLPEncoder(nn.Module):
     """CNN over 64x64 VGGT world points plus MLP over camera pose (3D-89)."""
+
     embed_dim: int = 1024
     conv_depth: int = 16
     conv_kernel: int = 5
@@ -168,6 +175,7 @@ class VGGTAggregatorMLPEncoder(nn.Module):
     ``num_layers`` hidden ``Dense->RMSNorm->SiLU`` blocks + a linear readout
     (default depth 1; the experiment run uses 3 — see 3D-52).
     """
+
     embed_dim: int = 1024
     pool_dim: int = 1024
     hidden: int = 1024
@@ -198,6 +206,7 @@ class VGGTAggRawMLPEncoder(nn.Module):
     the dense matmuls run in the agent's working precision. No per-slice RMSNorm
     (unlike the pooled readout): raw tokens have no cam/mean/max slice structure.
     """
+
     embed_dim: int = 1024
     hidden: int = 1024
     num_layers: int = 3
@@ -275,12 +284,16 @@ class VGGTAggTokenTransformerEncoder(nn.Module):
                 f"projection_dim={self.projection_dim} must be divisible by heads={self.heads}"
             )
 
-        tokens = obs.astype(jnp.float32).reshape(obs.shape[0], self.num_tokens, self.token_dim)
+        tokens = obs.astype(jnp.float32).reshape(
+            obs.shape[0], self.num_tokens, self.token_dim
+        )
         if self.keep_register_tokens:
             x = tokens
             patch_start = 1 + AGG_REGISTER_TOKENS
         else:
-            x = jnp.concatenate([tokens[:, :1], tokens[:, 1 + AGG_REGISTER_TOKENS:]], axis=1)
+            x = jnp.concatenate(
+                [tokens[:, :1], tokens[:, 1 + AGG_REGISTER_TOKENS :]], axis=1
+            )
             patch_start = 1
 
         x = nn.Dense(self.projection_dim, name="token_proj")(x)
@@ -460,9 +473,6 @@ class RGBFullTokenTransformerEncoder(nn.Module):
         return self._branches(obs)
 
 
-
-
-
 class HybridEncoder(nn.Module):
     """Hybrid encoder feeding the latent BOTH modalities at once (3D-50/51/52).
 
@@ -486,6 +496,7 @@ class HybridEncoder(nn.Module):
     that ``__call__`` and the diagnostic ``branches`` method share identical
     parameters.
     """
+
     cnn_depth: int = 16
     cnn_kernel: int = 5
     cnn_mults: tuple = (2, 3, 4, 4)
@@ -544,6 +555,7 @@ class HybridAggPooledModule(nn.Module):
     metrics work unchanged (the VGGT branch still projects to ``vggt_embed_dim``
     and the module exposes a ``gate`` param via ``setup``).
     """
+
     cnn_depth: int = 16
     cnn_kernel: int = 5
     cnn_mults: tuple = (2, 3, 4, 4)
@@ -573,7 +585,11 @@ class HybridAggPooledModule(nn.Module):
                 f"expected (B, {self.rgb_dim + self.vggt_dim}) hybrid-agg-pooled "
                 f"features, got {obs.shape}"
             )
-        rgb = obs[..., : self.rgb_dim].astype(jnp.float32).reshape(obs.shape[0], 3, 64, 64)
+        rgb = (
+            obs[..., : self.rgb_dim]
+            .astype(jnp.float32)
+            .reshape(obs.shape[0], 3, 64, 64)
+        )
         agg = obs[..., self.rgb_dim :]
         cnn_e = self.cnn(rgb)
         vggt_e = self.gate * self.vggt_mlp(agg)
@@ -597,6 +613,7 @@ class HybridAggRawModule(nn.Module):
     upcast to float32 before the CNN; the raw slice is upcast inside the MLP. The
     expensive ~1.44B-param layer-1 lives in this branch.
     """
+
     cnn_depth: int = 16
     cnn_kernel: int = 5
     cnn_mults: tuple = (2, 3, 4, 4)
@@ -611,7 +628,9 @@ class HybridAggRawModule(nn.Module):
             depth=self.cnn_depth, kernel_size=self.cnn_kernel, mults=self.cnn_mults
         )
         self.vggt_mlp = VGGTAggRawMLPEncoder(
-            embed_dim=self.vggt_embed_dim, hidden=self.mlp_hidden, num_layers=self.mlp_layers
+            embed_dim=self.vggt_embed_dim,
+            hidden=self.mlp_hidden,
+            num_layers=self.mlp_layers,
         )
         self.gate = self.param("gate", nn.initializers.zeros, ())
 
@@ -621,7 +640,11 @@ class HybridAggRawModule(nn.Module):
                 f"expected (B, {self.rgb_dim + self.vggt_dim}) hybrid-agg-raw "
                 f"features, got {obs.shape}"
             )
-        rgb = obs[..., : self.rgb_dim].astype(jnp.float32).reshape(obs.shape[0], 3, 64, 64)
+        rgb = (
+            obs[..., : self.rgb_dim]
+            .astype(jnp.float32)
+            .reshape(obs.shape[0], 3, 64, 64)
+        )
         raw = obs[..., self.rgb_dim :]
         cnn_e = self.cnn(rgb)
         vggt_e = self.gate * self.vggt_mlp(raw)
@@ -646,6 +669,7 @@ class ConvDecoder(nn.Module):
     decoder-free by default; when enabled, the loss detaches ``feat`` so this
     stays a visualisation probe rather than an agent objective.
     """
+
     depth: int = 16
     kernel_size: int = 5
     mults: tuple = (2, 3, 4, 4)
@@ -661,12 +685,19 @@ class ConvDecoder(nn.Module):
         for i, mult in enumerate(reversed(self.mults)):
             ch = self.depth * mult
             x = nn.ConvTranspose(
-                ch, (self.kernel_size, self.kernel_size), strides=(2, 2),
-                padding="SAME", name=f"deconv{i}",
+                ch,
+                (self.kernel_size, self.kernel_size),
+                strides=(2, 2),
+                padding="SAME",
+                name=f"deconv{i}",
             )(x)
             x = RMSNorm(name=f"norm{i}")(x)
             x = nn.silu(x)
-        x = nn.Conv(self.out_channels, (self.kernel_size, self.kernel_size),
-                    padding="SAME", name="out")(x)
+        x = nn.Conv(
+            self.out_channels,
+            (self.kernel_size, self.kernel_size),
+            padding="SAME",
+            name="out",
+        )(x)
         x = nn.sigmoid(x)
         return jnp.transpose(x, (0, 3, 1, 2))  # NHWC -> NCHW, matches RGB layout

--- a/src/r2dreamer/world_model/heads.py
+++ b/src/r2dreamer/world_model/heads.py
@@ -55,7 +55,9 @@ class R2TwoHotDist:
         """Two-hot encode a scalar target in real space. target: (...)."""
         # Find below/above indices (matching PyTorch's logic)
         below = jnp.sum((self.bins <= target[..., None]).astype(jnp.int32), axis=-1) - 1
-        above = self.num_bins - jnp.sum((self.bins > target[..., None]).astype(jnp.int32), axis=-1)
+        above = self.num_bins - jnp.sum(
+            (self.bins > target[..., None]).astype(jnp.int32), axis=-1
+        )
         below = jnp.clip(below, 0, self.num_bins - 1)
         above = jnp.clip(above, 0, self.num_bins - 1)
         equal = below == above
@@ -64,8 +66,9 @@ class R2TwoHotDist:
         total = dist_to_below + dist_to_above
         weight_below = dist_to_above / total
         weight_above = dist_to_below / total
-        return (weight_below[..., None] * jax.nn.one_hot(below, self.num_bins) +
-                weight_above[..., None] * jax.nn.one_hot(above, self.num_bins))
+        return weight_below[..., None] * jax.nn.one_hot(
+            below, self.num_bins
+        ) + weight_above[..., None] * jax.nn.one_hot(above, self.num_bins)
 
     def loss(self, logits: jnp.ndarray, target: jnp.ndarray) -> jnp.ndarray:
         """Cross-entropy loss. logits: (..., bins), target: (...) in real space."""
@@ -83,18 +86,19 @@ class R2TwoHotDist:
         if n % 2 == 1:
             m = (n - 1) // 2
             p1 = probs[..., :m]
-            p2 = probs[..., m:m + 1]
-            p3 = probs[..., m + 1:]
+            p2 = probs[..., m : m + 1]
+            p3 = probs[..., m + 1 :]
             b1 = self.bins[:m]
-            b2 = self.bins[m:m + 1]
-            b3 = self.bins[m + 1:]
-            wavg = (jnp.sum(p2 * b2, axis=-1, keepdims=True) +
-                    jnp.sum(p1[..., ::-1] * b1[::-1] + p3 * b3, axis=-1, keepdims=True))
+            b2 = self.bins[m : m + 1]
+            b3 = self.bins[m + 1 :]
+            wavg = jnp.sum(p2 * b2, axis=-1, keepdims=True) + jnp.sum(
+                p1[..., ::-1] * b1[::-1] + p3 * b3, axis=-1, keepdims=True
+            )
         else:
-            p1 = probs[..., :n // 2]
-            p2 = probs[..., n // 2:]
-            b1 = self.bins[:n // 2]
-            b2 = self.bins[n // 2:]
+            p1 = probs[..., : n // 2]
+            p2 = probs[..., n // 2 :]
+            b1 = self.bins[: n // 2]
+            b2 = self.bins[n // 2 :]
             wavg = jnp.sum(p1[..., ::-1] * b1[::-1] + p2 * b2, axis=-1, keepdims=True)
         return wavg  # (..., 1) — real space, no unsquash needed
 
@@ -123,6 +127,7 @@ def onehot_mode_st(logits: jnp.ndarray, unimix_ratio: float = 0.0) -> jnp.ndarra
 
 class R2MLP(nn.Module):
     """MLP with RMSNorm, matching PyTorch R2-Dreamer's MLP + MLPHead."""
+
     hidden: int = 256
     layers: int = 2
     out_dim: int = 1
@@ -138,6 +143,7 @@ class R2MLP(nn.Module):
             out_init = nn.initializers.zeros
         elif self.outscale != 1.0:
             base_init = nn.initializers.lecun_normal()
+
             def out_init(key, shape, dtype=jnp.float32):
                 return base_init(key, shape, dtype) * self.outscale
         else:

--- a/src/r2dreamer/world_model/loss.py
+++ b/src/r2dreamer/world_model/loss.py
@@ -70,12 +70,17 @@ def world_model_loss(*, forward, params, batch, modules, cfg, twohot):
 
     # ---- KL losses ----
     post_logits_flat = forward["post_logits"].reshape(
-        B * T, cfg.stoch_classes, cfg.stoch_discrete)
+        B * T, cfg.stoch_classes, cfg.stoch_discrete
+    )
     prior_logits_flat = forward["prior_logits"].reshape(
-        B * T, cfg.stoch_classes, cfg.stoch_discrete)
+        B * T, cfg.stoch_classes, cfg.stoch_discrete
+    )
     dyn_loss, rep_loss = kl_loss(
-        post_logits_flat, prior_logits_flat,
-        cfg.stoch_classes, cfg.stoch_discrete, cfg.kl_free,
+        post_logits_flat,
+        prior_logits_flat,
+        cfg.stoch_classes,
+        cfg.stoch_discrete,
+        cfg.kl_free,
     )
     losses["dyn"] = jnp.mean(dyn_loss)
     losses["rep"] = jnp.mean(rep_loss)
@@ -99,7 +104,9 @@ def world_model_loss(*, forward, params, batch, modules, cfg, twohot):
     # the auxiliary opt loss that keeps the probe itself learning.
     if cfg.decoder:
         decoder_feat = jax.lax.stop_gradient(feat_flat)
-        recon = modules["decoder"].apply(params["decoder"], decoder_feat)  # (BT,3,64,64)
+        recon = modules["decoder"].apply(
+            params["decoder"], decoder_feat
+        )  # (BT,3,64,64)
         rgb_target = decoder_rgb_target(batch, cfg)
         losses["decoder"] = jnp.mean((recon - rgb_target) ** 2)
         metrics["decoder/recon_mse"] = losses["decoder"]
@@ -108,8 +115,10 @@ def world_model_loss(*, forward, params, batch, modules, cfg, twohot):
     prior_probs = jax.nn.softmax(prior_logits_flat, axis=-1)
     post_probs = jax.nn.softmax(post_logits_flat, axis=-1)
     metrics["latent/prior_entropy"] = -jnp.mean(
-        jnp.sum(prior_probs * jnp.log(prior_probs + 1e-8), axis=-1))
+        jnp.sum(prior_probs * jnp.log(prior_probs + 1e-8), axis=-1)
+    )
     metrics["latent/posterior_entropy"] = -jnp.mean(
-        jnp.sum(post_probs * jnp.log(post_probs + 1e-8), axis=-1))
+        jnp.sum(post_probs * jnp.log(post_probs + 1e-8), axis=-1)
+    )
 
     return losses, metrics

--- a/src/r2dreamer/world_model/rssm.py
+++ b/src/r2dreamer/world_model/rssm.py
@@ -15,12 +15,13 @@ import flax.linen as nn
 
 class RMSNorm(nn.Module):
     """Root Mean Square Layer Normalization."""
+
     eps: float = 1e-4
 
     @nn.compact
     def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
         scale = self.param("scale", nn.initializers.ones, (x.shape[-1],))
-        rms = jnp.sqrt(jnp.mean(x ** 2, axis=-1, keepdims=True) + self.eps)
+        rms = jnp.sqrt(jnp.mean(x**2, axis=-1, keepdims=True) + self.eps)
         return (x / rms) * scale
 
 
@@ -29,6 +30,7 @@ class BlockLinear(nn.Module):
     Weight layout: (out_per_block, in_per_block, blocks).
     Matches r2dreamer's einsum: "...gi,oig->...go".
     """
+
     out_features: int
     blocks: int = 8
 
@@ -54,6 +56,7 @@ class BlockLinear(nn.Module):
 
 class Deter(nn.Module):
     """Block-GRU deterministic state transition."""
+
     deter_size: int = 2048
     stoch_size: int = 512
     act_dim: int = 17
@@ -71,7 +74,9 @@ class Deter(nn.Module):
         # Three input projections
         x0 = nn.silu(RMSNorm(name="in_norm0")(nn.Dense(self.hidden, name="in0")(deter)))
         x1 = nn.silu(RMSNorm(name="in_norm1")(nn.Dense(self.hidden, name="in1")(stoch)))
-        x2 = nn.silu(RMSNorm(name="in_norm2")(nn.Dense(self.hidden, name="in2")(action)))
+        x2 = nn.silu(
+            RMSNorm(name="in_norm2")(nn.Dense(self.hidden, name="in2")(action))
+        )
 
         # Concatenate: (B, 3*hidden)
         x = jnp.concatenate([x0, x1, x2], axis=-1)
@@ -80,7 +85,9 @@ class Deter(nn.Module):
         x = jnp.broadcast_to(x[:, None, :], (x.shape[0], self.blocks, x.shape[-1]))
 
         # Per-block deter slice: (B, blocks, deter_size//blocks)
-        deter_blocked = deter.reshape(deter.shape[0], self.blocks, self.deter_size // self.blocks)
+        deter_blocked = deter.reshape(
+            deter.shape[0], self.blocks, self.deter_size // self.blocks
+        )
 
         # Combine: (B, blocks, deter/blocks + 3*hidden) -> flatten
         x = jnp.concatenate([deter_blocked, x], axis=-1)
@@ -88,8 +95,11 @@ class Deter(nn.Module):
 
         # Hidden layers
         for i in range(self.dyn_layers):
-            x = nn.silu(RMSNorm(name=f"hid_norm{i}")(
-                BlockLinear(self.deter_size, self.blocks, name=f"hid{i}")(x)))
+            x = nn.silu(
+                RMSNorm(name=f"hid_norm{i}")(
+                    BlockLinear(self.deter_size, self.blocks, name=f"hid{i}")(x)
+                )
+            )
 
         # GRU gates: (B, 3*deter_size)
         gates = BlockLinear(3 * self.deter_size, self.blocks, name="gru")(x)
@@ -112,6 +122,7 @@ class R2RSSM(nn.Module):
     in the external interface. Internally, stoch is flattened to (B, S*K)
     before feeding into Deter.
     """
+
     deter_size: int = 2048
     stoch_classes: int = 32
     stoch_discrete: int = 16
@@ -142,14 +153,22 @@ class R2RSSM(nn.Module):
         )
 
         # Posterior head (obs_net): obs_layers Dense+RMSNorm+SiLU then Dense→logits
-        self.obs_fcs = [nn.Dense(self.hidden, name=f"obs_fc{i}") for i in range(self.obs_layers)]
+        self.obs_fcs = [
+            nn.Dense(self.hidden, name=f"obs_fc{i}") for i in range(self.obs_layers)
+        ]
         self.obs_norms = [RMSNorm(name=f"obs_norm{i}") for i in range(self.obs_layers)]
-        self.obs_out = nn.Dense(self.stoch_classes * self.stoch_discrete, name="obs_out")
+        self.obs_out = nn.Dense(
+            self.stoch_classes * self.stoch_discrete, name="obs_out"
+        )
 
         # Prior head (img_net): img_layers Dense+RMSNorm+SiLU then Dense→logits
-        self.img_fcs = [nn.Dense(self.hidden, name=f"img_fc{i}") for i in range(self.img_layers)]
+        self.img_fcs = [
+            nn.Dense(self.hidden, name=f"img_fc{i}") for i in range(self.img_layers)
+        ]
         self.img_norms = [RMSNorm(name=f"img_norm{i}") for i in range(self.img_layers)]
-        self.img_out = nn.Dense(self.stoch_classes * self.stoch_discrete, name="img_out")
+        self.img_out = nn.Dense(
+            self.stoch_classes * self.stoch_discrete, name="img_out"
+        )
 
     def __call__(self, stoch, deter, action, embed):
         """Single posterior step: Deter transition then posterior head.
@@ -241,7 +260,11 @@ class R2RSSM(nn.Module):
             deters.append(deter)
             logits.append(logit)
 
-        return jnp.stack(stochs, axis=1), jnp.stack(deters, axis=1), jnp.stack(logits, axis=1)
+        return (
+            jnp.stack(stochs, axis=1),
+            jnp.stack(deters, axis=1),
+            jnp.stack(logits, axis=1),
+        )
 
     def get_feat(self, stoch, deter):
         """Flatten stoch and concat with deter to form the feature vector.
@@ -253,7 +276,9 @@ class R2RSSM(nn.Module):
         Returns:
             feat: (..., stoch_size + deter_size)
         """
-        flat = stoch.reshape(*stoch.shape[:-2], self.stoch_classes * self.stoch_discrete)
+        flat = stoch.reshape(
+            *stoch.shape[:-2], self.stoch_classes * self.stoch_discrete
+        )
         return jnp.concatenate([flat, deter], axis=-1)
 
     def initial_state(self, batch_size):
@@ -276,9 +301,11 @@ class R2RSSM(nn.Module):
             logits = jnp.log(probs + 1e-8)
         # Gumbel-Softmax: stochastic forward, soft gradient backward
         rng = self.make_rng("sample")
-        gumbel_noise = -jnp.log(-jnp.log(
-            jax.random.uniform(rng, logits.shape, minval=1e-20)
-        ) + 1e-20)
+        gumbel_noise = -jnp.log(
+            -jnp.log(jax.random.uniform(rng, logits.shape, minval=1e-20)) + 1e-20
+        )
         soft = jax.nn.softmax(logits + gumbel_noise, axis=-1)
-        hard = jax.nn.one_hot(jnp.argmax(logits + gumbel_noise, axis=-1), self.stoch_discrete)
+        hard = jax.nn.one_hot(
+            jnp.argmax(logits + gumbel_noise, axis=-1), self.stoch_discrete
+        )
         return hard + soft - jax.lax.stop_gradient(soft)

--- a/src/shared/optim.py
+++ b/src/shared/optim.py
@@ -38,7 +38,8 @@ def laprop(lr=4e-4, b1=0.9, b2=0.999, eps=1e-15, warmup=0):
 
         # Second moment
         exp_avg_sq = jax.tree.map(
-            lambda v, g: b2 * v + (1 - b2) * g ** 2, state.exp_avg_sq, updates)
+            lambda v, g: b2 * v + (1 - b2) * g**2, state.exp_avg_sq, updates
+        )
 
         # LR tracking for bias correction
         exp_avg_lr1 = state.exp_avg_lr1 * b1 + (1 - b1) * effective_lr
@@ -50,14 +51,16 @@ def laprop(lr=4e-4, b1=0.9, b2=0.999, eps=1e-15, warmup=0):
 
         # Normalize gradient: g / (sqrt(v/bc2) + eps)
         denom = jax.tree.map(
-            lambda v: jnp.sqrt(v / jnp.maximum(exp_avg_lr2, 1e-30)) + eps,
-            exp_avg_sq)
+            lambda v: jnp.sqrt(v / jnp.maximum(exp_avg_lr2, 1e-30)) + eps, exp_avg_sq
+        )
         normalized = jax.tree.map(lambda g, d: g / d, updates, denom)
 
         # First moment of normalized gradient (scaled by effective_lr)
         exp_avg = jax.tree.map(
             lambda m, ng: b1 * m + (1 - b1) * effective_lr * ng,
-            state.exp_avg, normalized)
+            state.exp_avg,
+            normalized,
+        )
 
         # Final update: -step_size * exp_avg
         final = jax.tree.map(lambda m: -step_size * m, exp_avg)
@@ -69,9 +72,10 @@ def laprop(lr=4e-4, b1=0.9, b2=0.999, eps=1e-15, warmup=0):
 
 def agc(grads, params, clip=0.3, pmin=1e-3):
     def clip_fn(g, p):
-        p_norm = jnp.maximum(jnp.sqrt(jnp.sum(p ** 2)), pmin)
-        g_norm = jnp.sqrt(jnp.sum(g ** 2))
+        p_norm = jnp.maximum(jnp.sqrt(jnp.sum(p**2)), pmin)
+        g_norm = jnp.sqrt(jnp.sum(g**2))
         max_norm = clip * p_norm
         scale = max_norm / jnp.maximum(g_norm, 1e-8)
         return jnp.where(g_norm > max_norm, g * scale, g)
+
     return jax.tree.map(clip_fn, grads, params)

--- a/src/shared/profiling/step_timer.py
+++ b/src/shared/profiling/step_timer.py
@@ -50,8 +50,7 @@ class StepTimer:
         total = sum(self.sums.values())
         components_ms = {p: 1000.0 * self.sums[p] / active for p in self.PHASES}
         components_pct = {
-            p: (100.0 * self.sums[p] / total) if total > 0 else 0.0
-            for p in self.PHASES
+            p: (100.0 * self.sums[p] / total) if total > 0 else 0.0 for p in self.PHASES
         }
         return {
             "warmup_steps": self.warmup,

--- a/src/shared/profiling/timing.py
+++ b/src/shared/profiling/timing.py
@@ -68,7 +68,9 @@ def summarize_phase_times(
     return {phase: summarize_values_ms(values) for phase, values in phase_times.items()}
 
 
-def measure_ms(fn: Callable[[], Any], n: int = 20, warmup: int = 3) -> tuple[float, float]:
+def measure_ms(
+    fn: Callable[[], Any], n: int = 20, warmup: int = 3
+) -> tuple[float, float]:
     """Run ``fn`` after warmup and return ``(mean_ms, std_ms)``."""
     if n < 1:
         raise ValueError("n must be >= 1")

--- a/src/shared/video_utils.py
+++ b/src/shared/video_utils.py
@@ -61,7 +61,9 @@ def compose_frame(rgb: np.ndarray, topdown: np.ndarray) -> np.ndarray:
             return panel
         pad_top = (height - panel.shape[0]) // 2
         pad_bottom = height - panel.shape[0] - pad_top
-        return np.pad(panel, ((pad_top, pad_bottom), (0, 0), (0, 0)), constant_values=255)
+        return np.pad(
+            panel, ((pad_top, pad_bottom), (0, 0), (0, 0)), constant_values=255
+        )
 
     return np.concatenate([pad(left), pad(right)], axis=1).astype(np.uint8)
 
@@ -73,6 +75,7 @@ def render_topdown_frame(
 ) -> np.ndarray:
     """Render a top-down Habitat map frame as ``(H, W, 3) uint8``."""
     import matplotlib
+
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
 
@@ -80,6 +83,7 @@ def render_topdown_frame(
         nav = env.sample_navmesh(resolution=0.1)
     else:
         from src.environments.habitat import sample_navmesh
+
         nav = sample_navmesh(env._env, resolution=0.1)
     fig, ax = plt.subplots(1, 1, figsize=(2.56, 2.56), dpi=100)
 
@@ -106,8 +110,9 @@ def render_topdown_frame(
     return frame.astype(np.uint8)
 
 
-def log_episode_video(wandb_module: Any, key: str, frames: list[np.ndarray],
-                      step: int, fps: int = 10) -> Any | None:
+def log_episode_video(
+    wandb_module: Any, key: str, frames: list[np.ndarray], step: int, fps: int = 10
+) -> Any | None:
     """Log frames to W&B as an MP4 video, capped to ``MAX_VIDEO_FRAMES``."""
     if wandb_module is None or not frames:
         return None

--- a/src/shared/wandb_utils.py
+++ b/src/shared/wandb_utils.py
@@ -124,5 +124,7 @@ class EpisodeTracker:
             )
         for cat, per in self._per_cat.items():
             for k, dq in per.items():
-                metrics[f"goal/{cat}/{self._OUTPUT_RENAME.get(k, k)}"] = float(np.mean(dq))
+                metrics[f"goal/{cat}/{self._OUTPUT_RENAME.get(k, k)}"] = float(
+                    np.mean(dq)
+                )
         return metrics

--- a/src/vggt/benchmark.py
+++ b/src/vggt/benchmark.py
@@ -59,12 +59,14 @@ def benchmark_variant(
                     output_shape = tuple(v.shape)
                     break
 
-        results.append({
-            "n_frames": n_frames,
-            "latency_ms": latency_ms,
-            "peak_mem_mb": peak_mem,
-            "output_shape": str(output_shape),
-        })
+        results.append(
+            {
+                "n_frames": n_frames,
+                "latency_ms": latency_ms,
+                "peak_mem_mb": peak_mem,
+                "output_shape": str(output_shape),
+            }
+        )
 
     return results
 
@@ -83,11 +85,13 @@ def build_comparison_table(
     rows = []
     for variant_name, seq_results in all_results.items():
         for r in seq_results:
-            rows.append({
-                "variant": variant_name,
-                "n_frames": r["n_frames"],
-                "latency_ms": r["latency_ms"],
-                "peak_mem_mb": r["peak_mem_mb"],
-                "output_shape": r["output_shape"],
-            })
+            rows.append(
+                {
+                    "variant": variant_name,
+                    "n_frames": r["n_frames"],
+                    "latency_ms": r["latency_ms"],
+                    "peak_mem_mb": r["peak_mem_mb"],
+                    "output_shape": r["output_shape"],
+                }
+            )
     return pd.DataFrame(rows)

--- a/src/vggt/feature_extractor.py
+++ b/src/vggt/feature_extractor.py
@@ -10,7 +10,9 @@ import torch.nn.functional as F
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
 # Ensure InfiniteVGGT source is importable.
-_IVGGT_SRC = str(Path(__file__).resolve().parent.parent.parent / "external" / "InfiniteVGGT" / "src")
+_IVGGT_SRC = str(
+    Path(__file__).resolve().parent.parent.parent / "external" / "InfiniteVGGT" / "src"
+)
 if _IVGGT_SRC not in sys.path:
     sys.path.insert(0, _IVGGT_SRC)
 
@@ -77,14 +79,12 @@ class VGGTFeatureExtractor:
 
         # Prefer Flash SDP kernels when available (PyTorch 2.0+).
         if prefer_flash_sdp and self.device.type == "cuda":
-            self._flash_sdp_ctx_factory = (
-                lambda: sdpa_kernel(
-                    [
-                        SDPBackend.FLASH_ATTENTION,
-                        SDPBackend.EFFICIENT_ATTENTION,
-                        SDPBackend.MATH,
-                    ]
-                )
+            self._flash_sdp_ctx_factory = lambda: sdpa_kernel(
+                [
+                    SDPBackend.FLASH_ATTENTION,
+                    SDPBackend.EFFICIENT_ATTENTION,
+                    SDPBackend.MATH,
+                ]
             )
         else:
             self._flash_sdp_ctx_factory = lambda: nullcontext()
@@ -114,9 +114,7 @@ class VGGTFeatureExtractor:
             self.model.camera_head = torch.compile(
                 self.model.camera_head, dynamic=True, **mode_kwargs
             )
-            self.model.point_head = torch.compile(
-                self.model.point_head, **mode_kwargs
-            )
+            self.model.point_head = torch.compile(self.model.point_head, **mode_kwargs)
 
         # Aggregator depth drives the per-layer KV-cache list length.
         self._agg_depth: int = self.model.aggregator.depth
@@ -203,8 +201,8 @@ class VGGTFeatureExtractor:
                         past_key_values_camera=self._past_key_values_camera,
                         use_cache=True,
                     )
-                pose_enc = pose_enc[-1]           # last iteration
-                camera_pose = pose_enc[:, 0, :]   # (B, 9)
+                pose_enc = pose_enc[-1]  # last iteration
+                camera_pose = pose_enc[:, 0, :]  # (B, 9)
 
                 # Prune camera-head KV cache to a fixed window if requested.
                 if self._max_camera_tokens is not None:
@@ -219,7 +217,9 @@ class VGGTFeatureExtractor:
 
                 # Point head (DPT upsampled).
                 pts3d, _ = self.model.point_head(
-                    aggregated_tokens, images=images, patch_start_idx=patch_start_idx,
+                    aggregated_tokens,
+                    images=images,
+                    patch_start_idx=patch_start_idx,
                 )
                 pts3d = pts3d[:, 0]  # (B, H, W, 3)  — remove sequence dim
 
@@ -231,7 +231,9 @@ class VGGTFeatureExtractor:
         # pts3d is (1, H, W, 3) with H=W=518.  Pool to 37×37.
         # adaptive_avg_pool2d works on (N, C, H, W) so permute channels.
         pts_chw = pts3d.permute(0, 3, 1, 2).float()  # (1, 3, H, W)
-        pts_down = F.adaptive_avg_pool2d(pts_chw, (_PATCH_GRID, _PATCH_GRID))  # (1, 3, 37, 37)
+        pts_down = F.adaptive_avg_pool2d(
+            pts_chw, (_PATCH_GRID, _PATCH_GRID)
+        )  # (1, 3, 37, 37)
         world_points = pts_down.permute(0, 2, 3, 1).squeeze(0)  # (37, 37, 3)
 
         # --- to numpy --------------------------------------------------------
@@ -260,6 +262,6 @@ class VGGTFeatureExtractor:
         # print(f"[BP#1] NaN={np.isnan(world_points_np).any()} Inf={np.isinf(world_points_np).any()}", flush=True)
         # print(f"[BP#1] camera_pose: shape={camera_pose_np.shape} values={camera_pose_np}", flush=True)
         return {
-            "world_points": world_points_np,   # (37, 37, 3) float32
-            "camera_pose": camera_pose_np,     # (9,)        float32
+            "world_points": world_points_np,  # (37, 37, 3) float32
+            "camera_pose": camera_pose_np,  # (9,)        float32
         }

--- a/src/vggt/jax/aggregator.py
+++ b/src/vggt/jax/aggregator.py
@@ -123,9 +123,9 @@ class _TokenLayout:
         return tokens
 
     def to_global(self, frame_tokens: jnp.ndarray) -> jnp.ndarray:
-        return frame_tokens.reshape(
-            self.B, self.S, self.P, self.embed_dim
-        ).reshape(self.B, self.S * self.P, self.embed_dim)
+        return frame_tokens.reshape(self.B, self.S, self.P, self.embed_dim).reshape(
+            self.B, self.S * self.P, self.embed_dim
+        )
 
     def split_layers(self, tokens: jnp.ndarray) -> jnp.ndarray:
         return tokens.reshape(self.B, self.S, self.P, self.embed_dim)
@@ -239,9 +239,9 @@ def _prepare_attention_geometry(
     positions_bs_p = _make_position_grid(
         layout.B, layout.S, grid, grid, patch_start_idx
     )
-    positions_b_sp = positions_bs_p.reshape(
-        layout.B, layout.S, layout.P, 2
-    ).reshape(layout.B, layout.S * layout.P, 2)
+    positions_b_sp = positions_bs_p.reshape(layout.B, layout.S, layout.P, 2).reshape(
+        layout.B, layout.S * layout.P, 2
+    )
     head_dim = layout.embed_dim // num_heads
     cos_t, sin_t = compute_1d_rope_tables(
         dim=head_dim // 2,
@@ -249,8 +249,10 @@ def _prepare_attention_geometry(
         frequency=rope_freq,
         dtype=dtype,
     )
-    global_mask = None if use_cache else _make_causal_global_mask(
-        layout.S, layout.P, dtype=jnp.float32
+    global_mask = (
+        None
+        if use_cache
+        else _make_causal_global_mask(layout.S, layout.P, dtype=jnp.float32)
     )
     return positions_bs_p, positions_b_sp, (cos_t, sin_t), global_mask
 
@@ -366,7 +368,7 @@ class Aggregator(nn.Module):
             mlp_ratio=4.0,
             num_register_tokens=self.num_register_tokens,
             init_values=1.0,  # DINOv2 default
-            norm_eps=1e-6,     # DINOv2 override
+            norm_eps=1e-6,  # DINOv2 override
             name="patch_embed",
         )(x)
 

--- a/src/vggt/jax/attention.py
+++ b/src/vggt/jax/attention.py
@@ -141,8 +141,12 @@ def _padded_evict(
     v_pad_out = jnp.zeros_like(v_pad)
     k_pad_out = jax.lax.dynamic_update_slice_in_dim(k_pad_out, anchor_k, 0, axis=2)
     v_pad_out = jax.lax.dynamic_update_slice_in_dim(v_pad_out, anchor_v, 0, axis=2)
-    k_pad_out = jax.lax.dynamic_update_slice_in_dim(k_pad_out, kept_cand_k, n_anchor, axis=2)
-    v_pad_out = jax.lax.dynamic_update_slice_in_dim(v_pad_out, kept_cand_v, n_anchor, axis=2)
+    k_pad_out = jax.lax.dynamic_update_slice_in_dim(
+        k_pad_out, kept_cand_k, n_anchor, axis=2
+    )
+    v_pad_out = jax.lax.dynamic_update_slice_in_dim(
+        v_pad_out, kept_cand_v, n_anchor, axis=2
+    )
     new_valid_len = jnp.asarray(n_anchor + n_keep, dtype=jnp.int32)
     return k_pad_out, v_pad_out, new_valid_len, evict_score
 
@@ -197,9 +201,7 @@ class Attention(nn.Module):
             k = apply_rope_2d(k, positions, cos_table, sin_table)
 
         is_padded_cache = (
-            past_kv is not None
-            and isinstance(past_kv, tuple)
-            and len(past_kv) == 3
+            past_kv is not None and isinstance(past_kv, tuple) and len(past_kv) == 3
         )
 
         if use_cache and is_padded_cache:
@@ -249,7 +251,9 @@ class Attention(nn.Module):
         """Padded-cache path: dynamic_update_slice writes + SDPA with bool mask."""
         past_k_pad, past_v_pad, valid_len = past_kv
         _, _, MAX, Dh = past_k_pad.shape
-        cache_dtype = past_k_pad.dtype  # honour whatever dtype the cache was allocated in
+        cache_dtype = (
+            past_k_pad.dtype
+        )  # honour whatever dtype the cache was allocated in
 
         # 1. Append new K/V at offset valid_len (must match cache dtype).
         k_pad = jax.lax.dynamic_update_slice_in_dim(
@@ -279,7 +283,9 @@ class Attention(nn.Module):
                 _no_evict,
                 operand=(k_pad, v_pad, new_valid_len),
             )
-            did_evict = new_valid_len <= cache_budget  # after clamp: True iff eviction ran
+            did_evict = (
+                new_valid_len <= cache_budget
+            )  # after clamp: True iff eviction ran
             # Note: the cleaner check is "new_valid_len_before > cache_budget".
             # Recompute that:
             # Actually we want did_evict = (valid_len + N > cache_budget).
@@ -291,11 +297,13 @@ class Attention(nn.Module):
         # so cuDNN flash attention can lower to its kernel.  Replace the
         # explicit -inf bias with a bool mask (True = valid slot).
         q_tnhd = jnp.transpose(q.astype(cache_dtype), (0, 2, 1, 3))  # (B, N, H, Dh)
-        k_tnhd = jnp.transpose(k_pad, (0, 2, 1, 3))  # (B, MAX, H, Dh) — already cache_dtype
+        k_tnhd = jnp.transpose(
+            k_pad, (0, 2, 1, 3)
+        )  # (B, MAX, H, Dh) — already cache_dtype
         v_tnhd = jnp.transpose(v_pad, (0, 2, 1, 3))
 
         head_dim_f = float(q.shape[-1])
-        scale = 1.0 / head_dim_f ** 0.5
+        scale = 1.0 / head_dim_f**0.5
 
         # cuDNN flash attention with key_value_seq_lengths: tells cuDNN how
         # many K/V slots are valid without materialising a (B,H,N,MAX) bias.
@@ -305,18 +313,25 @@ class Attention(nn.Module):
         # cuDNN flash supports only fp16/bf16/fp8. Fall back to XLA for fp32.
         if q_tnhd.dtype in (jnp.bfloat16, jnp.float16):
             out_tnhd = jax.nn.dot_product_attention(
-                q_tnhd, k_tnhd, v_tnhd,
-                scale=scale, is_causal=False,
+                q_tnhd,
+                k_tnhd,
+                v_tnhd,
+                scale=scale,
+                is_causal=False,
                 key_value_seq_lengths=kv_len,
-                implementation='cudnn',
+                implementation="cudnn",
             )
         else:
             pos = jnp.arange(MAX, dtype=jnp.int32)
             mask_xla = (pos < new_valid_len).reshape(1, 1, 1, MAX)
             out_tnhd = jax.nn.dot_product_attention(
-                q_tnhd, k_tnhd, v_tnhd,
-                scale=scale, is_causal=False,
-                mask=mask_xla, implementation='xla',
+                q_tnhd,
+                k_tnhd,
+                v_tnhd,
+                scale=scale,
+                is_causal=False,
+                mask=mask_xla,
+                implementation="xla",
             )
         # out_tnhd is already (B, N, H, Dh) from jax.nn.dot_product_attention;
         # the legacy path's transpose is for its (B, H, N, Dh) einsum output —

--- a/src/vggt/jax/backbone.py
+++ b/src/vggt/jax/backbone.py
@@ -169,4 +169,4 @@ class DinoV2Backbone(nn.Module):
 
         # Return patch tokens only: drop cls (index 0) and register tokens.
         # This mirrors the reference's `x_norm_patchtokens` slice.
-        return x[:, 1 + self.num_register_tokens:]
+        return x[:, 1 + self.num_register_tokens :]

--- a/src/vggt/jax/benchmark_streaming.py
+++ b/src/vggt/jax/benchmark_streaming.py
@@ -40,7 +40,9 @@ WARMUP_FRAMES = 3
 
 
 def bench_pytorch(
-    n_frames: int, compile: bool = False, compile_mode: str | None = None,
+    n_frames: int,
+    compile: bool = False,
+    compile_mode: str | None = None,
 ) -> dict:
     """Benchmark the PyTorch extractor over ``n_frames`` with fresh cache."""
     import torch
@@ -48,7 +50,9 @@ def bench_pytorch(
     from src.vggt.feature_extractor import VGGTFeatureExtractor
 
     ext = VGGTFeatureExtractor(
-        device="cuda", compile=compile, compile_mode=compile_mode,
+        device="cuda",
+        compile=compile,
+        compile_mode=compile_mode,
     )
 
     # Warmup.
@@ -108,7 +112,9 @@ def bench_jax(
     from src.vggt.jax import JAXVGGTFeatureExtractor
 
     jax_dtype = jnp.bfloat16 if dtype == "bf16" else jnp.float32
-    ext = JAXVGGTFeatureExtractor(device="cuda", dtype=jax_dtype, budgets_static=budgets_static)
+    ext = JAXVGGTFeatureExtractor(
+        device="cuda", dtype=jax_dtype, budgets_static=budgets_static
+    )
 
     ext.reset()
     for i in range(WARMUP_FRAMES):
@@ -171,7 +177,9 @@ def run(
             print(f"[{backend}] n_frames={n} ...", flush=True)
             if backend == "pytorch":
                 row = bench_pytorch(
-                    n, compile=pt_compile, compile_mode=pt_compile_mode,
+                    n,
+                    compile=pt_compile,
+                    compile_mode=pt_compile_mode,
                 )
             elif backend == "jax":
                 row = bench_jax(

--- a/src/vggt/jax/feature_extractor.py
+++ b/src/vggt/jax/feature_extractor.py
@@ -95,6 +95,7 @@ def load_params_on_device(device: jax.Device) -> ExtractorParams:
 
 def compile_point_head_apply(point_head: Any) -> Any:
     """JIT the point-head apply with static ``patch_start_idx``."""
+
     def _point_head_fn(
         params: ParamTree,
         out_list: list[jnp.ndarray],
@@ -108,6 +109,7 @@ def compile_point_head_apply(point_head: Any) -> Any:
 
 def compile_aggregator_apply(aggregator: Any) -> Any:
     """JIT one streaming aggregator step with static cache-control arguments."""
+
     def _agg_fn(
         params: ParamTree,
         images: jnp.ndarray,
@@ -134,6 +136,7 @@ def compile_aggregator_apply(aggregator: Any) -> Any:
 
 def compile_camera_head_apply(camera_head: Any) -> Any:
     """JIT the camera head against padded cache entries with stable shapes."""
+
     def _cam_fn(
         params: ParamTree,
         out_list: list[jnp.ndarray],
@@ -158,7 +161,9 @@ def _pool_dense_world_points(pts_nhwc: jnp.ndarray, out_size: int) -> jnp.ndarra
     """
     n_batch, height, width, channels = pts_nhwc.shape
     if (height, width) != (_IMG_SIZE, _IMG_SIZE):
-        raise ValueError(f"expected ({_IMG_SIZE}, {_IMG_SIZE}), got ({height}, {width})")
+        raise ValueError(
+            f"expected ({_IMG_SIZE}, {_IMG_SIZE}), got ({height}, {width})"
+        )
     if out_size <= 0 or out_size > _IMG_SIZE:
         raise ValueError(f"out_size must be in [1, {_IMG_SIZE}], got {out_size}")
     if _IMG_SIZE % out_size == 0:
@@ -284,7 +289,7 @@ class JAXVGGTFeatureExtractor:
     def aggregator_feature_shape(self) -> tuple[int, int, int]:
         """Shape of one frame's all-token pre-head global aggregator features."""
         return (
-            1 + self._aggregator.num_register_tokens + self.patch_grid ** 2,
+            1 + self._aggregator.num_register_tokens + self.patch_grid**2,
             self._aggregator.embed_dim,
         )
 
@@ -334,17 +339,21 @@ class JAXVGGTFeatureExtractor:
 
     def _warmup(self) -> None:
         """Pre-compile both cache states so the first real call is fast."""
-        dummy = jnp.zeros(
-            (1, 1, 3, _IMG_SIZE, _IMG_SIZE), dtype=self._dtype
-        )
+        dummy = jnp.zeros((1, 1, 3, _IMG_SIZE, _IMG_SIZE), dtype=self._dtype)
 
         # Frame 0: padded cache with valid_len=0 on every block.
         past0 = [self._new_padded_cache_entry() for _ in range(self._agg_depth)]
         last0 = jnp.zeros((self._agg_depth,), dtype=jnp.float32)
         bud0 = self._compute_static_budgets(np.zeros(self._agg_depth, dtype=np.float32))
         out0 = self._aggregator_apply(
-            self._agg_params, dummy, past0, True, self._total_budget,
-            last0, True, bud0,
+            self._agg_params,
+            dummy,
+            past0,
+            True,
+            self._total_budget,
+            last0,
+            True,
+            bud0,
         )
         out0[0][-1].block_until_ready()
 
@@ -352,19 +361,21 @@ class JAXVGGTFeatureExtractor:
         _, _, past1, last1 = out0
         # Keep same budget (same last_scores pre-eviction) so shapes match.
         out1 = self._aggregator_apply(
-            self._agg_params, dummy, past1, False, self._total_budget,
-            last1, True, bud0,
+            self._agg_params,
+            dummy,
+            past1,
+            False,
+            self._total_budget,
+            last1,
+            True,
+            bud0,
         )
         out1[0][-1].block_until_ready()
 
         # Camera-head warmup: single graph covers all frames since the padded
         # cache keeps shapes stable regardless of valid_len.
-        past_cam0 = [
-            self._new_padded_camera_entry() for _ in range(self._cam_depth)
-        ]
-        pose_list_w, _ = self._camera_head_apply(
-            self._cam_params, out0[0], past_cam0
-        )
+        past_cam0 = [self._new_padded_camera_entry() for _ in range(self._cam_depth)]
+        pose_list_w, _ = self._camera_head_apply(self._cam_params, out0[0], past_cam0)
         pose_list_w[-1].block_until_ready()
 
     # ------------------------------------------------------------------
@@ -545,7 +556,7 @@ class JAXVGGTFeatureExtractor:
         # by Variant 1 before camera/point heads transform it into WP+CP. Keep
         # all VGGT-DP / VGGT-World tokens: camera + register + spatial patches.
         final_tokens = self._aggregator_full_tokens(out_list)
-        return final_tokens[..., final_tokens.shape[-1] // 2:]
+        return final_tokens[..., final_tokens.shape[-1] // 2 :]
 
     def _run_optional_heads(
         self,
@@ -666,7 +677,9 @@ class JAXVGGTFeatureExtractor:
             forward_start=forward_start,
         )
         aggregator_full_tokens = self._aggregator_full_tokens(out_list)
-        aggregator_features = aggregator_full_tokens[..., aggregator_full_tokens.shape[-1] // 2:]
+        aggregator_features = aggregator_full_tokens[
+            ..., aggregator_full_tokens.shape[-1] // 2 :
+        ]
         self._frame_idx += 1
         return self._build_extract_output(
             aggregator_full_tokens=aggregator_full_tokens,

--- a/src/vggt/jax/heads/dpt_head.py
+++ b/src/vggt/jax/heads/dpt_head.py
@@ -46,7 +46,7 @@ def _make_sincos_pos_embed(
     # scaling by ratio=0.1 and subsequent convs dominate any precision loss.
     omega = jnp.arange(embed_dim // 2, dtype=jnp.float32)
     omega = omega / (embed_dim / 2.0)
-    omega = 1.0 / (omega_0 ** omega)
+    omega = 1.0 / (omega_0**omega)
     pos = pos.reshape(-1)
     out = jnp.einsum("m,d->md", pos, omega)
     return jnp.concatenate([jnp.sin(out), jnp.cos(out)], axis=-1)
@@ -65,16 +65,14 @@ def _position_grid_to_embed(
     return emb.reshape(H, W, embed_dim)
 
 
-def _create_uv_grid(
-    width: int, height: int, aspect_ratio: float
-) -> jnp.ndarray:
+def _create_uv_grid(width: int, height: int, aspect_ratio: float) -> jnp.ndarray:
     """Port of ``heads.utils.create_uv_grid``.
 
     Reference uses ``torch.meshgrid(x_coords, y_coords, indexing='xy')`` which
     yields shape ``(height, width, 2)`` tensors (xy indexing swaps to row-y
     col-x). Matches that.
     """
-    diag = (aspect_ratio ** 2 + 1.0) ** 0.5
+    diag = (aspect_ratio**2 + 1.0) ** 0.5
     span_x = aspect_ratio / diag
     span_y = 1.0 / diag
     left_x = -span_x * (width - 1) / width
@@ -205,7 +203,9 @@ class _ResidualConvUnit(nn.Module):
 
     def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
         # NCHW throughout; Flax convs are NHWC so we transpose in / out.
-        x_relu = jax.nn.relu(x)  # also the "x" that skip-add uses (in-place side effect)
+        x_relu = jax.nn.relu(
+            x
+        )  # also the "x" that skip-add uses (in-place side effect)
         h = jnp.transpose(x_relu, (0, 2, 3, 1))
         h = self.conv1(h)
         h = jnp.transpose(h, (0, 3, 1, 2))
@@ -277,20 +277,32 @@ class _Scratch(nn.Module):
     def setup(self):
         # layer{i}_rn: Conv3x3 stride=1 padding=1, bias=False
         self.layer1_rn = nn.Conv(
-            self.features, kernel_size=(3, 3), strides=(1, 1),
-            padding="SAME", use_bias=False,
+            self.features,
+            kernel_size=(3, 3),
+            strides=(1, 1),
+            padding="SAME",
+            use_bias=False,
         )
         self.layer2_rn = nn.Conv(
-            self.features, kernel_size=(3, 3), strides=(1, 1),
-            padding="SAME", use_bias=False,
+            self.features,
+            kernel_size=(3, 3),
+            strides=(1, 1),
+            padding="SAME",
+            use_bias=False,
         )
         self.layer3_rn = nn.Conv(
-            self.features, kernel_size=(3, 3), strides=(1, 1),
-            padding="SAME", use_bias=False,
+            self.features,
+            kernel_size=(3, 3),
+            strides=(1, 1),
+            padding="SAME",
+            use_bias=False,
         )
         self.layer4_rn = nn.Conv(
-            self.features, kernel_size=(3, 3), strides=(1, 1),
-            padding="SAME", use_bias=False,
+            self.features,
+            kernel_size=(3, 3),
+            strides=(1, 1),
+            padding="SAME",
+            use_bias=False,
         )
         # refinenet4 has has_residual=False (only the running branch, no skip).
         self.refinenet4 = _FeatureFusionBlock(
@@ -307,18 +319,27 @@ class _Scratch(nn.Module):
         )
         # output_conv1: Conv3x3 features -> features//2  (256 -> 128)
         self.output_conv1 = nn.Conv(
-            self.features // 2, kernel_size=(3, 3), strides=(1, 1),
-            padding="SAME", use_bias=True,
+            self.features // 2,
+            kernel_size=(3, 3),
+            strides=(1, 1),
+            padding="SAME",
+            use_bias=True,
         )
         # output_conv2 is a Sequential(Conv3x3 128->32, ReLU, Conv1x1 32->out_dim=4).
         # We store as two separate submodules named output_conv2_0 / output_conv2_2.
         self.output_conv2_0 = nn.Conv(
-            32, kernel_size=(3, 3), strides=(1, 1),
-            padding="SAME", use_bias=True,
+            32,
+            kernel_size=(3, 3),
+            strides=(1, 1),
+            padding="SAME",
+            use_bias=True,
         )
         self.output_conv2_2 = nn.Conv(
-            4, kernel_size=(1, 1), strides=(1, 1),
-            padding="VALID", use_bias=True,
+            4,
+            kernel_size=(1, 1),
+            strides=(1, 1),
+            padding="VALID",
+            use_bias=True,
         )
 
     def _nchw_conv(self, conv: nn.Conv, x: jnp.ndarray) -> jnp.ndarray:
@@ -327,9 +348,7 @@ class _Scratch(nn.Module):
         x = conv(x)
         return jnp.transpose(x, (0, 3, 1, 2))
 
-    def fuse(
-        self, features: list[jnp.ndarray]
-    ) -> jnp.ndarray:
+    def fuse(self, features: list[jnp.ndarray]) -> jnp.ndarray:
         layer_1, layer_2, layer_3, layer_4 = features
 
         l1 = self._nchw_conv(self.layer1_rn, layer_1)
@@ -378,35 +397,56 @@ class DPTHead(nn.Module):
 
         # projects: 1x1 Conv per scale
         self.projects_0 = nn.Conv(
-            self.out_channels[0], kernel_size=(1, 1), strides=(1, 1),
-            padding="VALID", use_bias=True,
+            self.out_channels[0],
+            kernel_size=(1, 1),
+            strides=(1, 1),
+            padding="VALID",
+            use_bias=True,
         )
         self.projects_1 = nn.Conv(
-            self.out_channels[1], kernel_size=(1, 1), strides=(1, 1),
-            padding="VALID", use_bias=True,
+            self.out_channels[1],
+            kernel_size=(1, 1),
+            strides=(1, 1),
+            padding="VALID",
+            use_bias=True,
         )
         self.projects_2 = nn.Conv(
-            self.out_channels[2], kernel_size=(1, 1), strides=(1, 1),
-            padding="VALID", use_bias=True,
+            self.out_channels[2],
+            kernel_size=(1, 1),
+            strides=(1, 1),
+            padding="VALID",
+            use_bias=True,
         )
         self.projects_3 = nn.Conv(
-            self.out_channels[3], kernel_size=(1, 1), strides=(1, 1),
-            padding="VALID", use_bias=True,
+            self.out_channels[3],
+            kernel_size=(1, 1),
+            strides=(1, 1),
+            padding="VALID",
+            use_bias=True,
         )
 
         # resize_layers: ConvTranspose (idx 0,1), Identity (idx 2 -> skip), Conv 3x3 stride 2 (idx 3)
         self.resize_layers_0 = nn.ConvTranspose(
-            self.out_channels[0], kernel_size=(4, 4), strides=(4, 4),
-            padding="VALID", use_bias=True,
+            self.out_channels[0],
+            kernel_size=(4, 4),
+            strides=(4, 4),
+            padding="VALID",
+            use_bias=True,
         )
         self.resize_layers_1 = nn.ConvTranspose(
-            self.out_channels[1], kernel_size=(2, 2), strides=(2, 2),
-            padding="VALID", use_bias=True,
+            self.out_channels[1],
+            kernel_size=(2, 2),
+            strides=(2, 2),
+            padding="VALID",
+            use_bias=True,
         )
         # resize_layers_2 is Identity — no submodule
         self.resize_layers_3 = nn.Conv(
-            self.out_channels[3], kernel_size=(3, 3), strides=(2, 2),
-            padding=((1, 1), (1, 1)), use_bias=True,
+            self.out_channels[3],
+            kernel_size=(3, 3),
+            strides=(2, 2),
+            padding=((1, 1), (1, 1)),
+            use_bias=True,
         )
 
         self.scratch = _Scratch(
@@ -435,7 +475,9 @@ class DPTHead(nn.Module):
 
         features: list[jnp.ndarray] = []
         for dpt_idx, layer_idx in enumerate(self.intermediate_layer_idx):
-            x = aggregated_tokens_list[layer_idx][:, :, patch_start_idx:]  # (B, S, P_patch, dim_in)
+            x = aggregated_tokens_list[layer_idx][
+                :, :, patch_start_idx:
+            ]  # (B, S, P_patch, dim_in)
             x = x.reshape(B * S, patch_h * patch_w, x.shape[-1])
             x = self.norm(x)
             # -> (B*S, dim_in, patch_h, patch_w)

--- a/src/vggt/jax/profile_streaming.py
+++ b/src/vggt/jax/profile_streaming.py
@@ -40,7 +40,9 @@ WARMUP_FRAMES = 3
 PHASES = ("input_prep", "aggregator", "camera_head", "point_head", "pool_transfer")
 
 
-def _profile_one_frame(ext: JAXVGGTFeatureExtractor, rgb: np.ndarray) -> dict[str, float]:
+def _profile_one_frame(
+    ext: JAXVGGTFeatureExtractor, rgb: np.ndarray
+) -> dict[str, float]:
     """Run one streaming frame, returning per-phase wall time in ms.
 
     Mirrors ``JAXVGGTFeatureExtractor.extract`` but inserts
@@ -108,7 +110,9 @@ def _profile_one_frame(ext: JAXVGGTFeatureExtractor, rgb: np.ndarray) -> dict[st
 
     # 4. Point head (DPT, jit-compiled, fixed shapes).
     t0 = time.perf_counter()
-    pts3d, _ = ext._point_head_apply(ext._pt_params, out_list, images, int(np.asarray(patch_start_idx)))
+    pts3d, _ = ext._point_head_apply(
+        ext._pt_params, out_list, images, int(np.asarray(patch_start_idx))
+    )
     pts3d = pts3d[:, 0]
     pts3d.block_until_ready()
     t["point_head"] = (time.perf_counter() - t0) * 1000.0
@@ -152,12 +156,19 @@ def run(n_frames: int, dtype_name: str, trace_dir: Path | None) -> None:
     rows: list[dict[str, float]] = []
     for i in range(n_frames):
         rows.append(_profile_one_frame(ext, make_synthetic_rgb_frame(1000 + i)))
-        print(f"  frame {i+1}/{n_frames}: total={sum(rows[-1].values()):.1f}ms", flush=True)
+        print(
+            f"  frame {i + 1}/{n_frames}: total={sum(rows[-1].values()):.1f}ms",
+            flush=True,
+        )
 
     # Aggregate.
-    print("\nPer-phase wall time (ms), n={} frames, dtype={}".format(n_frames, dtype_name))
+    print(
+        "\nPer-phase wall time (ms), n={} frames, dtype={}".format(n_frames, dtype_name)
+    )
     print("-" * 78)
-    print(f"{'phase':<18} {'mean':>10} {'median':>10} {'std':>10} {'min':>10} {'max':>10} {'%':>6}")
+    print(
+        f"{'phase':<18} {'mean':>10} {'median':>10} {'std':>10} {'min':>10} {'max':>10} {'%':>6}"
+    )
     print("-" * 78)
     totals = np.array([sum(r.values()) for r in rows])
     for phase in PHASES:
@@ -179,7 +190,9 @@ def run(n_frames: int, dtype_name: str, trace_dir: Path | None) -> None:
 
 def main() -> None:
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--n-frames", type=int, default=10, help="Frames to time after warmup.")
+    p.add_argument(
+        "--n-frames", type=int, default=10, help="Frames to time after warmup."
+    )
     p.add_argument("--dtype", choices=["bf16", "fp32"], default="bf16")
     p.add_argument(
         "--trace",

--- a/src/vggt/jax/rope.py
+++ b/src/vggt/jax/rope.py
@@ -34,7 +34,7 @@ def compute_1d_rope_tables(
     if dim % 2 != 0:
         raise ValueError(f"dim must be even, got {dim}")
     exponents = jnp.arange(0, dim, 2, dtype=jnp.float32) / dim
-    inv_freq = 1.0 / (frequency ** exponents)
+    inv_freq = 1.0 / (frequency**exponents)
     positions = jnp.arange(max_pos, dtype=jnp.float32)
     angles = jnp.einsum("i,j->ij", positions, inv_freq)  # (max_pos, dim/2)
     angles = jnp.concatenate([angles, angles], axis=-1)  # (max_pos, dim)

--- a/src/vggt/jax/weight_transfer.py
+++ b/src/vggt/jax/weight_transfer.py
@@ -35,6 +35,7 @@ V1_EXCLUDE_PREFIXES: tuple[str, ...] = ("depth_head.", "track_head.")
 #  Transposition helpers
 # --------------------------------------------------------------------------- #
 
+
 def _conv2d_to_flax(t: np.ndarray) -> np.ndarray:
     """(O, I, H, W) -> (H, W, I, O)."""
     assert t.ndim == 4, t.shape
@@ -57,7 +58,7 @@ def _conv_transpose2d_to_flax(t: np.ndarray) -> np.ndarray:
     ~10-15 max-abs error.
     """
     assert t.ndim == 4, t.shape
-    jax_layout = np.transpose(t, (2, 3, 0, 1))   # (I, O, H, W) -> (H, W, I, O)
+    jax_layout = np.transpose(t, (2, 3, 0, 1))  # (I, O, H, W) -> (H, W, I, O)
     return np.flip(jax_layout, axis=(0, 1)).copy()
 
 
@@ -103,7 +104,10 @@ _LS_MAP = {"gamma": "gamma"}
 #  Rule builders for the repeated block families
 # --------------------------------------------------------------------------- #
 
-def _make_attention_rules(prefix: str, out_prefix: str, has_qk_norm: bool) -> list[_Rule]:
+
+def _make_attention_rules(
+    prefix: str, out_prefix: str, has_qk_norm: bool
+) -> list[_Rule]:
     """Rules for a transformer-block attention submodule."""
     rules = [
         _rule(
@@ -180,6 +184,7 @@ def _make_block_rules(prefix: str, out_prefix: str, has_qk_norm: bool) -> list[_
 # builders that RULES looks up. Instead, we just define them before use --
 # but RULES is computed at import, so we need to define these first.
 
+
 def _dinov2_block_rules(prefix: str, out_prefix: str, block_name: str) -> list[_Rule]:
     # DINOv2 blocks in the reference have no QK norm (qk_norm defaults to False
     # for vit_large) -- no k_norm / q_norm keys appear in the checkpoint under
@@ -240,10 +245,30 @@ RULES = [
     *_aggregator_block_rules(variant="frame"),
     *_aggregator_block_rules(variant="global"),
     _rule(r"camera_head\.empty_pose_tokens", r"camera_head", {}, None),
-    _rule(r"camera_head\.embed_pose\.(weight|bias)", r"camera_head.embed_pose", _LINEAR_MAP, "linear"),
-    _rule(r"camera_head\.token_norm\.(weight|bias)", r"camera_head.token_norm", _NORM_MAP, None),
-    _rule(r"camera_head\.trunk_norm\.(weight|bias)", r"camera_head.trunk_norm", _NORM_MAP, None),
-    _rule(r"camera_head\.adaln_norm\.(weight|bias)", r"camera_head.adaln_norm", _NORM_MAP, None),
+    _rule(
+        r"camera_head\.embed_pose\.(weight|bias)",
+        r"camera_head.embed_pose",
+        _LINEAR_MAP,
+        "linear",
+    ),
+    _rule(
+        r"camera_head\.token_norm\.(weight|bias)",
+        r"camera_head.token_norm",
+        _NORM_MAP,
+        None,
+    ),
+    _rule(
+        r"camera_head\.trunk_norm\.(weight|bias)",
+        r"camera_head.trunk_norm",
+        _NORM_MAP,
+        None,
+    ),
+    _rule(
+        r"camera_head\.adaln_norm\.(weight|bias)",
+        r"camera_head.adaln_norm",
+        _NORM_MAP,
+        None,
+    ),
     _rule(
         r"camera_head\.poseLN_modulation\.1\.(weight|bias)",
         r"camera_head.poseLN_modulation_1",
@@ -313,8 +338,15 @@ RULES = [
 #  Translation
 # --------------------------------------------------------------------------- #
 
-_PARAM_LEAF_NAMES = ("camera_token", "register_token", "cls_token", "mask_token",
-                     "register_tokens", "pos_embed", "empty_pose_tokens")
+_PARAM_LEAF_NAMES = (
+    "camera_token",
+    "register_token",
+    "cls_token",
+    "mask_token",
+    "register_tokens",
+    "pos_embed",
+    "empty_pose_tokens",
+)
 
 
 def _split_key_suffix(key: str) -> tuple[str, str]:
@@ -369,9 +401,7 @@ def _insert(tree: dict[str, Any], path: str, leaf: str, value: np.ndarray) -> No
     node[leaf] = value
 
 
-def _expand_path_template(
-    key: str, path_template: str, match: re.Match[str]
-) -> str:
+def _expand_path_template(key: str, path_template: str, match: re.Match[str]) -> str:
     """Expand a matched output path template for one PyTorch key."""
     try:
         return match.expand(path_template)
@@ -439,6 +469,7 @@ def load_pytorch_weights(
 #  Coverage / round-trip checks (Level-1 exit criterion)
 # --------------------------------------------------------------------------- #
 
+
 def verify_coverage(
     state_dict: dict[str, np.ndarray],
     report: dict[str, list[str]],
@@ -453,7 +484,9 @@ def verify_coverage(
     in_scope = [k for k in state_dict if not k.startswith(V1_EXCLUDE_PREFIXES)]
     mapped = set(report.get("mapped", []))
     missing = [k for k in in_scope if k not in mapped]
-    assert not missing, f"{len(missing)} in-scope keys not mapped; first 10: {missing[:10]}"
+    assert not missing, (
+        f"{len(missing)} in-scope keys not mapped; first 10: {missing[:10]}"
+    )
 
 
 def verify_per_leaf_roundtrip(
@@ -481,7 +514,9 @@ def verify_per_leaf_roundtrip(
                 f"Shape mismatch at {out_path}/{leaf_name}: got {got.shape}, expected {expected.shape} (from {key})"
             )
         if not np.array_equal(got, expected):
-            raise AssertionError(f"Value mismatch at {out_path}/{leaf_name} (from {key})")
+            raise AssertionError(
+                f"Value mismatch at {out_path}/{leaf_name} (from {key})"
+            )
 
 
 def count_leaves(tree: dict[str, Any]) -> int:
@@ -526,7 +561,9 @@ def load_checkpoint(repo: str = _DEFAULT_REPO) -> dict[str, np.ndarray]:
     """
     import sys
 
-    ivggt_src = Path(__file__).resolve().parents[3] / "external" / "InfiniteVGGT" / "src"
+    ivggt_src = (
+        Path(__file__).resolve().parents[3] / "external" / "InfiniteVGGT" / "src"
+    )
     if str(ivggt_src) not in sys.path:
         sys.path.insert(0, str(ivggt_src))
 


### PR DESCRIPTION
## What changed

- Fixed the remaining Ruff lint errors under `src`.
- Applied Ruff formatting across `src` so `ruff format --check src` passes.
- Kept the work scoped to `src` files only.

## Why

The `src` tree had Ruff lint and format failures. This PR makes the full `src` lint gate clean.

## Linear issue

No Linear issue was provided for this no-issue lint cleanup.

## Acceptance criteria checked

- `uvx ruff check src` passes.
- `uvx ruff format --check src` passes.
- `git diff --check` passes.

## Risk

Low. Most changes are mechanical formatting. Functional edits are limited to removing an unused import, renaming an ambiguous local variable, and moving constants below imports to satisfy import-order linting.

## How to test

```bash
uvx ruff check src
uvx ruff format --check src
git diff --check
```

## What was intentionally not done

- No broader tests were run because the requested scope was lint cleanup.
- No Linear issue was updated because no issue key was provided.

## Agent involvement

Implemented by Codex in worktree `worktrees/no-issue-src-lint`.