### PR TITLE
3D-82: Route VGGT variants through observation contract

### DIFF
--- a/src/r2dreamer/adapters/hybrid_adapter.py
+++ b/src/r2dreamer/adapters/hybrid_adapter.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from typing import Any
+
 import jax.numpy as jnp
 import jax
 import numpy as np
@@ -20,13 +23,13 @@ from src.r2dreamer.obs_batch import (
     HYBRID_WP_CP_KEY,
 )
 from src.r2dreamer.observation_preparation.vggt import (
-    HYBRID_IMAGE_SHAPE as IMAGE_SHAPE,
     HYBRID_IMAGE_SIZE as IMAGE_SIZE,
     HYBRID_RGB_DIM,
     VGGT_AGGREGATOR_EMBED_DIM,
     VGGT_AGGREGATOR_TOKEN_COUNT,
     VGGT_FULL_TOKEN_EMBED_DIM,
     build_hybrid_contract,
+    build_vggt_rgb_contract,
     wp_cp_dim,
 )
 from src.shared.video_utils import resize_chw_uint8
@@ -58,14 +61,12 @@ class HybridObsAdapter(ObsAdapter):
         env_render_resolution: int | None = None,
         encoder_module_cls=None,
         agent_overrides=None,
-        design_notes: str = "",
     ):
         self.contract = build_hybrid_contract(
             extractor,
             env_render_resolution=env_render_resolution,
             encoder_module_cls=encoder_module_cls,
             agent_overrides=agent_overrides,
-            design_notes=design_notes,
         )
         super().__init__(
             buffer_dtype=self.contract.replay_observation.buffer_dtype(),
@@ -97,16 +98,29 @@ class _RGBLiveTokenObsAdapter(ObsAdapter):
     token_shape: tuple[int, int]
     token_name: str
 
-    def __init__(self, extractor):
+    encoder_type: str
+
+    def __init__(
+        self,
+        extractor,
+        *,
+        env_render_resolution: int | None = None,
+        encoder_module_cls=None,
+        agent_overrides=None,
+    ):
+        self.contract = build_vggt_rgb_contract(
+            extractor,
+            encoder_type=self.encoder_type,
+            env_render_resolution=env_render_resolution,
+            encoder_module_cls=encoder_module_cls,
+            agent_overrides=agent_overrides,
+        )
         super().__init__(
-            buffer_dtype={HYBRID_IMAGE_KEY: "uint8", self.token_key: "float16"},
-            buffer_shape={HYBRID_IMAGE_KEY: IMAGE_SHAPE, self.token_key: self.token_shape},
-            normalize_on_sample={HYBRID_IMAGE_KEY: True, self.token_key: False},
-            agent_obs_shape={
-                HYBRID_IMAGE_KEY: IMAGE_SHAPE,
-                self.token_key: self.token_shape,
-            },
-            on_episode_reset=None,
+            buffer_dtype=self.contract.replay_observation.buffer_dtype(),
+            buffer_shape=self.contract.replay_observation.buffer_shape(),
+            normalize_on_sample=self.contract.replay_observation.buffer_normalize(),
+            agent_obs_shape=self.contract.encoder_input.buffer_shape(),
+            on_episode_reset=getattr(extractor, "reset", None),
         )
         self._extractor = extractor
 
@@ -138,6 +152,7 @@ class _RGBLiveTokenObsAdapter(ObsAdapter):
 class VGGTHouseFullTokenObsAdapter(_RGBLiveTokenObsAdapter):
     """RGB replay plus live full VGGT tokens for the no-gate Transformer test."""
 
+    encoder_type = "vggt_house_full_tokens_nogate"
     token_key = FULL_TOKENS_KEY
     token_shape = FULL_TOKEN_SHAPE
     token_name = "full tokens"
@@ -149,6 +164,7 @@ class VGGTHouseFullTokenObsAdapter(_RGBLiveTokenObsAdapter):
 class VGGTHouseGlobalTokenObsAdapter(_RGBLiveTokenObsAdapter):
     """RGB replay plus live singleton VGGT global-half tokens."""
 
+    encoder_type = "vggt_house_global_tokens_nogate"
     token_key = GLOBAL_TOKENS_KEY
     token_shape = GLOBAL_TOKEN_SHAPE
     token_name = "global tokens"
@@ -171,16 +187,23 @@ class VGGTHouseContextObsAdapter(ObsAdapter):
         extractor,
         *,
         context_transformer: VGGTFullTokenContextTransformer | None = None,
+        contract_options: Mapping[str, Any] | None = None,
         rng_seed: int = 0,
     ):
+        options = dict(contract_options or {})
+        self.contract = build_vggt_rgb_contract(
+            extractor,
+            encoder_type="vggt_house_context",
+            env_render_resolution=options.get("env_render_resolution"),
+            encoder_module_cls=options.get("encoder_module_cls"),
+            agent_overrides=options.get("agent_overrides"),
+        )
         super().__init__(
-            buffer_dtype={HYBRID_IMAGE_KEY: "uint8", HOUSE_CONTEXT_KEY: "float32"},
-            buffer_shape={
-                HYBRID_IMAGE_KEY: IMAGE_SHAPE,
-                HOUSE_CONTEXT_KEY: (HOUSE_CONTEXT_DIM,),
-            },
-            normalize_on_sample={HYBRID_IMAGE_KEY: True, HOUSE_CONTEXT_KEY: False},
-            on_episode_reset=None,
+            buffer_dtype=self.contract.replay_observation.buffer_dtype(),
+            buffer_shape=self.contract.replay_observation.buffer_shape(),
+            normalize_on_sample=self.contract.replay_observation.buffer_normalize(),
+            agent_obs_shape=self.contract.encoder_input.buffer_shape(),
+            on_episode_reset=getattr(extractor, "reset", None),
         )
         self._extractor = extractor
         self._context_transformer = (
@@ -189,7 +212,6 @@ class VGGTHouseContextObsAdapter(ObsAdapter):
         self._context_params = None
         self._rng = jax.random.PRNGKey(rng_seed)
         self._context: np.ndarray | None = None
-        self.agent_obs_shape = (HOUSE_CONTEXT_FEATURE_DIM,)
 
     def _ensure_context_params(self, tokens: jnp.ndarray):
         if self._context_params is None:

--- a/src/r2dreamer/agent.py
+++ b/src/r2dreamer/agent.py
@@ -246,6 +246,9 @@ def _make_mlp_encoder(cfg: R2DreamerConfig, cls):
 
 
 def _make_rgb_token_encoder(cfg: R2DreamerConfig, cls):
+    kwargs = _contract_encoder_kwargs(cfg)
+    if kwargs:
+        return cls(**kwargs)
     return cls(
         cnn_depth=cfg.encoder_depth,
         cnn_kernel=cfg.encoder_kernel,
@@ -262,6 +265,9 @@ def _make_rgb_token_encoder(cfg: R2DreamerConfig, cls):
 
 
 def _make_token_transformer_encoder(cfg: R2DreamerConfig):
+    kwargs = _contract_encoder_kwargs(cfg)
+    if kwargs:
+        return WMVGGTAggTokenTransformerEncoder(**kwargs)
     return WMVGGTAggTokenTransformerEncoder(
         embed_dim=cfg.vggt_embed_dim,
         token_dim=cfg.vggt_token_dim,

--- a/src/r2dreamer/encoders/__init__.py
+++ b/src/r2dreamer/encoders/__init__.py
@@ -204,7 +204,6 @@ class HybridEncoder(VGGTEncoder):
             env_render_resolution=self.env_render_resolution,
             encoder_module_cls=self.module_cls,
             agent_overrides=self.agent_overrides,
-            design_notes=self.design_notes,
         )
 
 
@@ -260,6 +259,11 @@ class VGGTHouseContextEncoder(VGGTEncoder):
         return VGGTHouseContextObsAdapter(
             extractor,
             context_transformer=self._context_transformer,
+            contract_options={
+                "env_render_resolution": self.env_render_resolution,
+                "encoder_module_cls": self.module_cls,
+                "agent_overrides": self.agent_overrides,
+            },
         )
 
 
@@ -269,7 +273,12 @@ class VGGTHouseFullTokenNoGateEncoder(VGGTHouseContextEncoder):
     variant = VGGT_VARIANTS["vggt_house_full_tokens_nogate"]
 
     def _build_adapter_for_extractor(self, extractor) -> ObsAdapter:
-        return VGGTHouseFullTokenObsAdapter(extractor)
+        return VGGTHouseFullTokenObsAdapter(
+            extractor,
+            env_render_resolution=self.env_render_resolution,
+            encoder_module_cls=self.module_cls,
+            agent_overrides=self.agent_overrides,
+        )
 
 
 class VGGTHouseGlobalTokenNoGateEncoder(VGGTHouseContextEncoder):
@@ -278,4 +287,9 @@ class VGGTHouseGlobalTokenNoGateEncoder(VGGTHouseContextEncoder):
     variant = VGGT_VARIANTS["vggt_house_global_tokens_nogate"]
 
     def _build_adapter_for_extractor(self, extractor) -> ObsAdapter:
-        return VGGTHouseGlobalTokenObsAdapter(extractor)
+        return VGGTHouseGlobalTokenObsAdapter(
+            extractor,
+            env_render_resolution=self.env_render_resolution,
+            encoder_module_cls=self.module_cls,
+            agent_overrides=self.agent_overrides,
+        )

--- a/src/r2dreamer/launch/evaluate.py
+++ b/src/r2dreamer/launch/evaluate.py
@@ -355,19 +355,29 @@ def _run_eval_episode(
         goal_positions,
         record_video,
     )
-    act_state = agent.initial_act_state() if agent is not None else None
+    act_state = (
+        agent.initial_act_state()
+        if agent is not None and hasattr(agent, "initial_act_state")
+        else None
+    )
 
     for _step in range(500):
         if agent is not None:
             rng_key, act_key = jax.random.split(rng_key)
-            action, act_state = agent.act_with_state(
-                agent_obs, act_state, act_key, training=False
-            )
+            if hasattr(agent, "act_with_state"):
+                action, act_state = agent.act_with_state(
+                    agent_obs, act_state, act_key, training=False
+                )
+            else:
+                action = agent.act(agent_obs, act_key, training=False)
         else:
             action = np.random.randint(0, config.num_actions)
 
         next_obs = env_instance.step(action)
-        next_agent_obs = adapter.prepare_env_step(next_obs).agent_obs
+        if hasattr(adapter, "prepare_env_step"):
+            next_agent_obs = adapter.prepare_env_step(next_obs).agent_obs
+        else:
+            _, next_agent_obs = adapter.transform(next_obs)
         actions_taken.append(int(action))
         rewards.append(float(_obs_value(next_obs, "reward")))
 

--- a/src/r2dreamer/obs_batch.py
+++ b/src/r2dreamer/obs_batch.py
@@ -38,6 +38,7 @@ class ObsBatchConfig(Protocol):
     vggt_feature_dim: int
     vggt_token_count: int
     vggt_token_dim: int
+    encoder_input_contract: Mapping[str, Any] | None
 
 
 def compute_jnp_dtype(dtype: str):
@@ -116,11 +117,124 @@ def _flat_obs_shape(cfg: ObsBatchConfig) -> tuple[int, ...]:
     return cfg.obs_shape
 
 
+def _encoder_input_layout(cfg: ObsBatchConfig) -> str:
+    snapshot = getattr(cfg, "encoder_input_contract", None)
+    if isinstance(snapshot, Mapping):
+        return str(snapshot.get("encoder_input_layout", ""))
+    return ""
+
+
+def _contract_structured_keys(cfg: ObsBatchConfig) -> tuple[str, ...]:
+    snapshot = getattr(cfg, "encoder_input_contract", None)
+    if not isinstance(snapshot, Mapping):
+        return ()
+    encoder_input = snapshot.get("encoder_input")
+    if not isinstance(encoder_input, Mapping):
+        return ()
+    fields = encoder_input.get("fields")
+    if not isinstance(fields, Mapping):
+        return ()
+    return tuple(str(key) for key in fields)
+
+
+def _contract_context_key(cfg: ObsBatchConfig, obs: Mapping[str, Any]) -> str:
+    keys = _contract_structured_keys(cfg)
+    for key in keys:
+        if key != HYBRID_IMAGE_KEY:
+            return key
+    for key in obs:
+        if key != HYBRID_IMAGE_KEY:
+            return key
+    raise KeyError("contract RGB layout requires a non-image feature field")
+
+
+def _structured_wp_cp_batch(
+    obs: Mapping[str, Any],
+    cfg: ObsBatchConfig,
+    batch_size: int,
+    time_steps: int,
+    dtype,
+) -> dict[str, jnp.ndarray]:
+    world_points_shape = tuple(cfg.obs_shape[WORLD_POINTS_KEY])  # type: ignore[index]
+    camera_pose_shape = tuple(cfg.obs_shape[CAMERA_POSE_KEY])  # type: ignore[index]
+    world_points = jnp.asarray(obs[WORLD_POINTS_KEY], dtype=dtype).reshape(
+        batch_size * time_steps, *world_points_shape
+    )
+    camera_pose = jnp.asarray(obs[CAMERA_POSE_KEY], dtype=dtype).reshape(
+        batch_size * time_steps, *camera_pose_shape
+    )
+    return {WORLD_POINTS_KEY: world_points, CAMERA_POSE_KEY: camera_pose}
+
+
+def _rgb_tokens_batch(
+    obs: Mapping[str, Any],
+    cfg: ObsBatchConfig,
+    batch_size: int,
+    time_steps: int,
+    dtype,
+) -> dict[str, jnp.ndarray]:
+    token_key = _contract_context_key(cfg, obs)
+    image = normalize_image_obs(obs[HYBRID_IMAGE_KEY]).reshape(
+        batch_size * time_steps, 3, 64, 64
+    )
+    tokens = jnp.asarray(obs[token_key], dtype=dtype)
+    singleton_shape = (1, cfg.vggt_token_count, cfg.vggt_token_dim)
+    if token_key == GLOBAL_TOKENS_KEY:
+        if tokens.shape != singleton_shape:
+            raise ValueError(
+                f"global token replay expects singleton shape {singleton_shape}, "
+                f"got {tokens.shape}"
+            )
+    elif tokens.shape != singleton_shape:
+        tokens = tokens.reshape(
+            batch_size * time_steps, cfg.vggt_token_count, cfg.vggt_token_dim
+        )
+    return {HYBRID_IMAGE_KEY: image, token_key: tokens}
+
+
+def _encoder_obs_from_batch_contract(
+    obs: Any,
+    cfg: ObsBatchConfig,
+    batch_prefix: tuple[int, int],
+    dtype,
+    layout: str,
+) -> EncoderObs:
+    batch_size, time_steps = batch_prefix
+    if layout == "rgb_plus_flat":
+        obs = pack_hybrid_obs(obs)
+    elif layout == "rgb_plus_context":
+        if not isinstance(obs, Mapping):
+            return jnp.asarray(obs, dtype=jnp.float32).reshape(
+                batch_size * time_steps, *_flat_obs_shape(cfg)
+            )
+        obs = pack_rgb_context_obs(obs, context_key=_contract_context_key(cfg, obs))
+    elif layout == "rgb_plus_tokens":
+        if not isinstance(obs, Mapping):
+            raise TypeError("rgb_plus_tokens expects dict obs")
+        return _rgb_tokens_batch(obs, cfg, batch_size, time_steps, dtype)
+    elif layout == "structured_wp_cp":
+        if not isinstance(obs, Mapping):
+            raise TypeError("structured_wp_cp expects dict obs")
+        return _structured_wp_cp_batch(obs, cfg, batch_size, time_steps, dtype)
+    elif layout == "flat_wp_cp" and isinstance(obs, Mapping):
+        obs = pack_world_points_camera_pose_obs(obs, dtype=dtype)
+    elif layout == "world_points" and isinstance(obs, Mapping):
+        obs = jnp.asarray(obs[WORLD_POINTS_KEY], dtype=dtype)
+    else:
+        obs = normalize_image_obs(obs) if layout == "image" else jnp.asarray(obs, dtype=dtype)
+    return obs.reshape(batch_size * time_steps, *_flat_obs_shape(cfg))
+
+
 def encoder_obs_from_batch(batch: dict[str, Any], cfg: ObsBatchConfig) -> EncoderObs:
     """Return flattened per-step observations consumed by ``agent.encoder_mod``."""
     obs = batch["obs"]
-    B, T = obs_leading_shape(obs)
+    batch_size, time_steps = obs_leading_shape(obs)
     compute_dtype = compute_jnp_dtype(cfg.compute_dtype)
+    layout = _encoder_input_layout(cfg)
+    if layout:
+        return _encoder_obs_from_batch_contract(
+            obs, cfg, (batch_size, time_steps), compute_dtype, layout
+        )
     if cfg.encoder_type == "hybrid":
         obs = pack_hybrid_obs(obs)
     elif cfg.encoder_type == "vggt_house_context":
@@ -128,24 +242,28 @@ def encoder_obs_from_batch(batch: dict[str, Any], cfg: ObsBatchConfig) -> Encode
     elif cfg.encoder_type == "vggt_house_full_tokens_nogate":
         if not isinstance(obs, Mapping):
             raise TypeError("vggt_house_full_tokens_nogate expects dict obs")
-        image = normalize_image_obs(obs[HYBRID_IMAGE_KEY]).reshape(B * T, 3, 64, 64)
+        image = normalize_image_obs(obs[HYBRID_IMAGE_KEY]).reshape(
+            batch_size * time_steps, 3, 64, 64
+        )
         tokens = jnp.asarray(
             obs[FULL_TOKENS_KEY], dtype=compute_jnp_dtype(cfg.compute_dtype)
-        ).reshape(B * T, cfg.vggt_token_count, cfg.vggt_token_dim)
+        ).reshape(batch_size * time_steps, cfg.vggt_token_count, cfg.vggt_token_dim)
         return {HYBRID_IMAGE_KEY: image, FULL_TOKENS_KEY: tokens}
     elif cfg.encoder_type == "vggt_house_global_tokens_nogate":
         if not isinstance(obs, Mapping):
             raise TypeError("vggt_house_global_tokens_nogate expects dict obs")
-        image = normalize_image_obs(obs[HYBRID_IMAGE_KEY]).reshape(B * T, 3, 64, 64)
+        image = normalize_image_obs(obs[HYBRID_IMAGE_KEY]).reshape(
+            batch_size * time_steps, 3, 64, 64
+        )
         tokens = jnp.asarray(
             obs[GLOBAL_TOKENS_KEY], dtype=compute_jnp_dtype(cfg.compute_dtype)
         )
-        if tokens.shape == (1, cfg.vggt_token_count, cfg.vggt_token_dim):
-            tokens = jnp.broadcast_to(
-                tokens, (B * T, cfg.vggt_token_count, cfg.vggt_token_dim)
+        singleton_shape = (1, cfg.vggt_token_count, cfg.vggt_token_dim)
+        if tokens.shape != singleton_shape:
+            raise ValueError(
+                f"global token replay expects singleton shape {singleton_shape}, "
+                f"got {tokens.shape}"
             )
-        else:
-            tokens = tokens.reshape(B * T, cfg.vggt_token_count, cfg.vggt_token_dim)
         return {HYBRID_IMAGE_KEY: image, GLOBAL_TOKENS_KEY: tokens}
     elif cfg.encoder_type == "vggt_wp64_cnn_cp_mlp":
         if not isinstance(obs, Mapping):
@@ -153,10 +271,10 @@ def encoder_obs_from_batch(batch: dict[str, Any], cfg: ObsBatchConfig) -> Encode
         world_points_shape = tuple(cfg.obs_shape[WORLD_POINTS_KEY])  # type: ignore[index]
         camera_pose_shape = tuple(cfg.obs_shape[CAMERA_POSE_KEY])  # type: ignore[index]
         world_points = jnp.asarray(obs[WORLD_POINTS_KEY], dtype=compute_dtype).reshape(
-            B * T, *world_points_shape
+            batch_size * time_steps, *world_points_shape
         )
         camera_pose = jnp.asarray(obs[CAMERA_POSE_KEY], dtype=compute_dtype).reshape(
-            B * T, *camera_pose_shape
+            batch_size * time_steps, *camera_pose_shape
         )
         return {WORLD_POINTS_KEY: world_points, CAMERA_POSE_KEY: camera_pose}
     elif cfg.encoder_type in ("vggt", "vggt_wp_cp_64") and isinstance(obs, Mapping):
@@ -167,7 +285,7 @@ def encoder_obs_from_batch(batch: dict[str, Any], cfg: ObsBatchConfig) -> Encode
         obs = normalize_image_obs(obs)
     else:
         obs = jnp.asarray(obs, dtype=compute_dtype)
-    return obs.reshape(B * T, *_flat_obs_shape(cfg))
+    return obs.reshape(batch_size * time_steps, *_flat_obs_shape(cfg))
 
 
 def encoder_obs_from_agent_obs(
@@ -175,7 +293,33 @@ def encoder_obs_from_agent_obs(
 ) -> EncoderObs:
     """Return one-step encoder input for acting."""
     compute_dtype = compute_jnp_dtype(cfg.compute_dtype)
-    if cfg.encoder_type == "hybrid":
+    layout = _encoder_input_layout(cfg)
+    if layout == "rgb_plus_flat":
+        obs = pack_hybrid_obs(obs_dict)
+    elif layout == "rgb_plus_context":
+        obs = pack_rgb_context_obs(
+            obs_dict, context_key=_contract_context_key(cfg, obs_dict)
+        )
+    elif layout == "rgb_plus_tokens":
+        token_key = _contract_context_key(cfg, obs_dict)
+        return {
+            HYBRID_IMAGE_KEY: normalize_image_obs(obs_dict[HYBRID_IMAGE_KEY])[None],
+            token_key: jnp.asarray(obs_dict[token_key], dtype=compute_dtype)[None],
+        }
+    elif layout == "structured_wp_cp":
+        return {
+            WORLD_POINTS_KEY: jnp.asarray(
+                obs_dict[WORLD_POINTS_KEY], dtype=compute_dtype
+            )[None],
+            CAMERA_POSE_KEY: jnp.asarray(
+                obs_dict[CAMERA_POSE_KEY], dtype=compute_dtype
+            )[None],
+        }
+    elif layout == "flat_wp_cp" and WORLD_POINTS_KEY in obs_dict:
+        obs = pack_world_points_camera_pose_obs(obs_dict, dtype=compute_dtype)
+    elif layout == "world_points" and WORLD_POINTS_KEY in obs_dict:
+        obs = jnp.asarray(obs_dict[WORLD_POINTS_KEY], dtype=compute_dtype)
+    elif cfg.encoder_type == "hybrid":
         if "hybrid" in obs_dict:
             obs = jnp.asarray(obs_dict["hybrid"], dtype=jnp.float32)
         else:
@@ -230,7 +374,19 @@ def encoder_obs_from_agent_obs(
 def decoder_rgb_target(batch: dict[str, Any], cfg: ObsBatchConfig) -> jnp.ndarray:
     """Return decoder RGB targets as ``(B*T, 3, 64, 64)`` in ``[0, 1]``."""
     obs = batch["obs"]
-    B, T = obs_leading_shape(obs)
+    batch_size, time_steps = obs_leading_shape(obs)
+    layout = _encoder_input_layout(cfg)
+    if layout in ("rgb_plus_flat", "rgb_plus_context", "rgb_plus_tokens"):
+        if isinstance(obs, Mapping):
+            image = normalize_image_obs(obs[HYBRID_IMAGE_KEY])
+            return image.reshape(batch_size * time_steps, 3, 64, 64)
+        obs_shape = _flat_obs_shape(cfg)
+        rgb_dim = obs_shape[0] - cfg.vggt_feature_dim
+        return (
+            jnp.asarray(obs, dtype=jnp.float32)
+            .reshape(batch_size * time_steps, -1)[:, :rgb_dim]
+            .reshape(batch_size * time_steps, 3, 64, 64)
+        )
     if cfg.encoder_type in (
         "hybrid",
         "vggt_house_context",
@@ -239,13 +395,13 @@ def decoder_rgb_target(batch: dict[str, Any], cfg: ObsBatchConfig) -> jnp.ndarra
     ):
         if isinstance(obs, Mapping):
             image = normalize_image_obs(obs[HYBRID_IMAGE_KEY])
-            return image.reshape(B * T, 3, 64, 64)
+            return image.reshape(batch_size * time_steps, 3, 64, 64)
         obs_shape = _flat_obs_shape(cfg)
         rgb_dim = obs_shape[0] - cfg.vggt_feature_dim
         return (
             jnp.asarray(obs, dtype=jnp.float32)
-            .reshape(B * T, -1)[:, :rgb_dim]
-            .reshape(B * T, 3, 64, 64)
+            .reshape(batch_size * time_steps, -1)[:, :rgb_dim]
+            .reshape(batch_size * time_steps, 3, 64, 64)
         )
     image = normalize_image_obs(obs)
-    return image.reshape(B * T, 3, 64, 64)
+    return image.reshape(batch_size * time_steps, 3, 64, 64)

--- a/src/r2dreamer/observation_preparation/__init__.py
+++ b/src/r2dreamer/observation_preparation/__init__.py
@@ -27,5 +27,6 @@ from src.r2dreamer.observation_preparation.vggt import (
     VGGTDreamerSpec,
     VGGT_IMAGE_SHAPE,
     build_hybrid_contract,
+    build_vggt_rgb_contract,
     build_vggt_contract,
 )

--- a/src/r2dreamer/observation_preparation/contracts.py
+++ b/src/r2dreamer/observation_preparation/contracts.py
@@ -14,6 +14,7 @@ from importlib import import_module
 from typing import Any
 
 import flax.linen as nn
+import jax.numpy as jnp
 import numpy as np
 
 from src.r2dreamer.config import ObservationRunConfig
@@ -82,6 +83,32 @@ def encoder_module_kwargs_from_config(
             "vggt_embed_dim": int(config.vggt_embed_dim),
             "mlp_hidden": int(config.mlp_vggt_hidden),
             "mlp_layers": int(config.mlp_vggt_layers),
+            "vggt_dim": int(config.vggt_feature_dim),
+        }
+    if class_name == "VGGTAggTokenTransformerEncoder":
+        return {
+            "embed_dim": int(config.vggt_embed_dim),
+            "token_dim": int(config.vggt_token_dim),
+            "num_tokens": int(config.vggt_token_count),
+            "projection_dim": int(config.vggt_token_projection_dim),
+            "layers": int(config.vggt_token_transformer_layers),
+            "heads": int(config.vggt_token_transformer_heads),
+            "mlp_ratio": int(config.vggt_token_transformer_mlp_ratio),
+            "keep_register_tokens": bool(config.vggt_keep_register_tokens),
+        }
+    if class_name in ("RGBFullTokenTransformerEncoder", "RGBGlobalTokenTransformerEncoder"):
+        return {
+            "cnn_depth": int(config.encoder_depth),
+            "cnn_kernel": int(config.encoder_kernel),
+            "cnn_mults": _tuple_value(config, "encoder_mults"),
+            "context_dim": int(config.vggt_embed_dim),
+            "token_dim": int(config.vggt_token_dim),
+            "num_tokens": int(config.vggt_token_count),
+            "transformer_layers": int(config.vggt_token_transformer_layers),
+            "transformer_heads": int(config.vggt_token_transformer_heads),
+            "transformer_mlp_ratio": int(config.vggt_token_transformer_mlp_ratio),
+            "transformer_dropout": float(config.vggt_token_transformer_dropout),
+            "compute_dtype": str(config.compute_dtype),
         }
     return {
         "embed_dim": int(config.vggt_embed_dim),
@@ -96,6 +123,14 @@ def normalize_encoder_module_kwargs(kwargs: Mapping[str, Any]) -> dict[str, Any]
     for key in ("mults", "cnn_mults", "conv_mults"):
         if key in normalized:
             normalized[key] = tuple(normalized[key])
+    if "compute_dtype" in normalized:
+        dtype = normalized["compute_dtype"]
+        if dtype == "bfloat16":
+            normalized["compute_dtype"] = jnp.bfloat16
+        elif dtype == "float16":
+            normalized["compute_dtype"] = jnp.float16
+        elif dtype == "float32":
+            normalized["compute_dtype"] = jnp.float32
     return normalized
 
 
@@ -225,6 +260,7 @@ class EncoderInputContract:
     decoder_target: ObservationFormContract | None
     agent_overrides: Mapping[str, Any] = field(default_factory=dict)
     encoder_module_kwargs: Mapping[str, Any] = field(default_factory=dict)
+    encoder_input_layout: str = ""
     design_notes: str = ""
 
     def to_snapshot(self) -> ContractSnapshot:
@@ -245,6 +281,7 @@ class EncoderInputContract:
             ),
             "agent_overrides": dict(self.agent_overrides),
             "encoder_module_kwargs": dict(self.encoder_module_kwargs),
+            "encoder_input_layout": self.encoder_input_layout,
             "design_notes": self.design_notes,
         }
 
@@ -285,6 +322,7 @@ class EncoderInputContract:
             encoder_module_kwargs=normalize_encoder_module_kwargs(
                 snapshot.get("encoder_module_kwargs", {})
             ),
+            encoder_input_layout=str(snapshot.get("encoder_input_layout", "")),
             design_notes=str(snapshot.get("design_notes", "")),
         )
 

--- a/src/r2dreamer/observation_preparation/vggt.py
+++ b/src/r2dreamer/observation_preparation/vggt.py
@@ -580,6 +580,7 @@ def build_vggt_contract(  # pylint: disable=too-many-arguments,too-many-locals
             encoder_input=encoder_input_by_layout[spec.dreamer.input_layout],
             decoder_target=None,
             agent_overrides=resolved_overrides,
+            encoder_input_layout=spec.dreamer.input_layout,
             design_notes=resolved_notes,
         )
 
@@ -605,6 +606,7 @@ def build_vggt_contract(  # pylint: disable=too-many-arguments,too-many-locals
         encoder_input=ObservationFormContract(encoder_field),
         decoder_target=None,
         agent_overrides=resolved_overrides,
+        encoder_input_layout=spec.dreamer.input_layout,
         design_notes=resolved_notes,
     )
 
@@ -656,5 +658,98 @@ def build_hybrid_contract(
         agent_overrides=dict(
             agent_overrides if agent_overrides is not None else spec.agent_overrides
         ),
+        encoder_input_layout=spec.dreamer.input_layout,
         design_notes=design_notes or spec.design_notes,
+    )
+
+
+def _rgb_token_field(
+    spec: VGGTDreamerSpec,
+    token_shape: tuple[int, int],
+) -> tuple[str, ObservationField]:
+    if spec.encoder_type == "vggt_house_full_tokens_nogate":
+        return "full_tokens", ObservationField(
+            token_shape, spec.storage.readout_dtype, normalize_on_sample=False
+        )
+    if spec.encoder_type == "vggt_house_global_tokens_nogate":
+        return "global_tokens", ObservationField(
+            token_shape, spec.storage.readout_dtype, normalize_on_sample=False
+        )
+    return "house_context", ObservationField(
+        (wm_encoders.HOUSE_CONTEXT_DIM,),
+        spec.storage.readout_dtype,
+        normalize_on_sample=False,
+    )
+
+
+def build_vggt_rgb_contract(
+    extractor: Any,
+    *,
+    encoder_type: str,
+    env_render_resolution: int | None = None,
+    encoder_module_cls: type[nn.Module] | None = None,
+    agent_overrides: Mapping[str, Any] | None = None,
+) -> EncoderInputContract:
+    """Build the Encoder Input Contract for RGB replay plus VGGT context/tokens."""
+    spec = VGGT_DREAMER_SPECS[encoder_type]
+    if not spec.storage.replay_rgb:
+        raise ValueError(f"{encoder_type} is not an RGB replay VGGT variant")
+    if spec.dreamer.input_layout not in ("rgb_plus_context", "rgb_plus_tokens"):
+        raise ValueError(
+            f"{encoder_type} does not use an RGB plus context/token layout"
+        )
+    render_resolution = int(
+        env_render_resolution or getattr(extractor, "image_size", VGGT_IMAGE_SIZE)
+    )
+    if isinstance(spec.readout, TokenReadout):
+        token_shape = (spec.readout.num_tokens, spec.readout.token_dim)
+    else:
+        token_shape = VGGT_DEFAULT_AGGREGATOR_SHAPE
+    replay_feature_key, replay_feature_field = _rgb_token_field(spec, token_shape)
+    image_field = ObservationField(
+        HYBRID_IMAGE_SHAPE, "uint8", normalize_on_sample=True
+    )
+    replay_fields = {
+        HYBRID_IMAGE_KEY: image_field,
+        replay_feature_key: replay_feature_field,
+    }
+    agent_fields = {
+        HYBRID_IMAGE_KEY: ObservationField(
+            HYBRID_IMAGE_SHAPE, "uint8", normalize_on_sample=False
+        ),
+        replay_feature_key: ObservationField(
+            replay_feature_field.shape, "float32", normalize_on_sample=False
+        ),
+        "is_first": ObservationField((), "bool"),
+    }
+    if spec.dreamer.input_layout == "rgb_plus_context":
+        encoder_input = ObservationFormContract(
+            ObservationField((HYBRID_RGB_DIM + wm_encoders.HOUSE_CONTEXT_DIM,), "float32")
+        )
+    else:
+        encoder_input = ObservationFormContract(
+            {
+                HYBRID_IMAGE_KEY: ObservationField(HYBRID_IMAGE_SHAPE, "float32"),
+                replay_feature_key: ObservationField(
+                    replay_feature_field.shape, "float32"
+                ),
+            }
+        )
+    return EncoderInputContract(
+        observation_preparation_type=spec.encoder_type,
+        encoder_type=spec.encoder_type,
+        env_render_resolution=render_resolution,
+        encoder_module_cls=encoder_module_cls or spec.module_cls,
+        env_observation=_env_observation(render_resolution),
+        replay_observation=ObservationFormContract(replay_fields),
+        agent_observation=ObservationFormContract(agent_fields),
+        encoder_input=encoder_input,
+        decoder_target=ObservationFormContract(
+            ObservationField(HYBRID_IMAGE_SHAPE, "float32")
+        ),
+        agent_overrides=dict(
+            agent_overrides if agent_overrides is not None else spec.agent_overrides
+        ),
+        encoder_input_layout=spec.dreamer.input_layout,
+        design_notes=spec.design_notes,
     )

--- a/src/r2dreamer/world_model/encoders.py
+++ b/src/r2dreamer/world_model/encoders.py
@@ -487,7 +487,7 @@ class RGBGlobalTokenTransformerEncoder(RGBFullTokenTransformerEncoder):
 
     token_dim: int = 1024
     token_key: str = GLOBAL_TOKENS_KEY
-    singleton_tokens: bool = False
+    singleton_tokens: bool = True
 
 
 class HybridEncoder(nn.Module):

--- a/tests/r2dreamer/launch/test_encoders.py
+++ b/tests/r2dreamer/launch/test_encoders.py
@@ -611,6 +611,8 @@ class TestVGGTHouseContextEncoder:
         spec = enc.spec()
 
         assert isinstance(adapter, VGGTHouseContextObsAdapter)
+        assert isinstance(adapter.contract, EncoderInputContract)
+        assert adapter.contract.encoder_input_layout == "rgb_plus_context"
         assert spec.encoder_type == "vggt_house_context"
         assert adapter.buffer_shape == {
             HYBRID_IMAGE_KEY: (3, 64, 64),
@@ -625,7 +627,8 @@ class TestVGGTHouseContextEncoder:
         assert spec.agent_overrides["vggt_token_transformer_layers"] == 2
         assert spec.agent_overrides["vggt_token_transformer_heads"] == 8
         assert spec.agent_overrides["vggt_token_transformer_dropout"] == 0.0
-        assert adapter.on_episode_reset is None
+        assert spec.contract_snapshot["encoder_input_layout"] == "rgb_plus_context"
+        assert adapter.on_episode_reset is not None
 
     def test_house_context_adapter_stores_rgb_and_context_in_replay(self):
         full_tokens = (
@@ -709,6 +712,8 @@ class TestVGGTHouseFullTokenNoGateEncoder:
         spec = enc.spec()
 
         assert isinstance(adapter, VGGTHouseFullTokenObsAdapter)
+        assert isinstance(adapter.contract, EncoderInputContract)
+        assert adapter.contract.encoder_input_layout == "rgb_plus_tokens"
         assert spec.encoder_type == "vggt_house_full_tokens_nogate"
         assert adapter.buffer_shape == {
             HYBRID_IMAGE_KEY: (3, 64, 64),
@@ -722,7 +727,8 @@ class TestVGGTHouseFullTokenNoGateEncoder:
         assert spec.agent_overrides["buffer_capacity"] == 5_000
         assert spec.agent_overrides["vggt_token_dim"] == 2048
         assert spec.agent_overrides["vggt_token_count"] == 1374
-        assert adapter.on_episode_reset is None
+        assert spec.contract_snapshot["encoder_input_layout"] == "rgb_plus_tokens"
+        assert adapter.on_episode_reset is not None
 
     def test_full_token_adapter_stores_rgb_and_tokens_in_replay(self):
         full_tokens = (
@@ -792,6 +798,8 @@ class TestVGGTHouseGlobalTokenNoGateEncoder:
         spec = enc.spec()
 
         assert isinstance(adapter, VGGTHouseGlobalTokenObsAdapter)
+        assert isinstance(adapter.contract, EncoderInputContract)
+        assert adapter.contract.encoder_input_layout == "rgb_plus_tokens"
         assert spec.encoder_type == "vggt_house_global_tokens_nogate"
         assert adapter.buffer_shape == {
             HYBRID_IMAGE_KEY: (3, 64, 64),
@@ -805,7 +813,8 @@ class TestVGGTHouseGlobalTokenNoGateEncoder:
         assert spec.agent_overrides["buffer_capacity"] == 5_000
         assert spec.agent_overrides["vggt_token_dim"] == 1024
         assert spec.agent_overrides["vggt_token_count"] == 1374
-        assert adapter.on_episode_reset is None
+        assert spec.contract_snapshot["encoder_input_layout"] == "rgb_plus_tokens"
+        assert adapter.on_episode_reset is not None
 
     def test_global_token_adapter_stores_rgb_and_tokens_in_replay(self):
         from src.r2dreamer.adapters.hybrid_adapter import VGGTHouseGlobalTokenObsAdapter

--- a/tests/r2dreamer/test_obs_batch.py
+++ b/tests/r2dreamer/test_obs_batch.py
@@ -4,14 +4,18 @@ import jax.numpy as jnp
 import pytest
 
 from src.r2dreamer.config import R2DreamerConfig
+from src.r2dreamer.observation_preparation import build_vggt_contract
 from src.r2dreamer.obs_batch import (
+    CAMERA_POSE_KEY,
     GLOBAL_TOKENS_KEY,
     HYBRID_IMAGE_KEY,
+    WORLD_POINTS_KEY,
     encoder_obs_from_batch,
 )
 
 
 def test_global_token_nogate_batch_keeps_tokens_singleton_and_flattens_images():
+    """Global-token batches keep one live token set while flattening RGB frames."""
     cfg = R2DreamerConfig(
         encoder_type="vggt_house_global_tokens_nogate",
         obs_shape={HYBRID_IMAGE_KEY: (3, 64, 64), GLOBAL_TOKENS_KEY: (6, 8)},
@@ -35,6 +39,7 @@ def test_global_token_nogate_batch_keeps_tokens_singleton_and_flattens_images():
 
 
 def test_global_token_nogate_batch_rejects_broadcasted_replay_tokens():
+    """Global-token replay rejects per-step token tensors."""
     cfg = R2DreamerConfig(
         encoder_type="vggt_house_global_tokens_nogate",
         obs_shape={HYBRID_IMAGE_KEY: (3, 64, 64), GLOBAL_TOKENS_KEY: (6, 8)},
@@ -50,3 +55,39 @@ def test_global_token_nogate_batch_rejects_broadcasted_replay_tokens():
 
     with pytest.raises(ValueError, match="singleton"):
         encoder_obs_from_batch(batch, cfg)
+
+
+def test_contract_layout_packs_flat_vggt_without_encoder_type_branch():
+    """Contract layout drives flat WP/CP packing when encoder_type is unknown."""
+    class FakeExtractor:
+        """Small metadata-only VGGT extractor fake."""
+
+        aggregator_feature_shape = (1374, 1024)
+        image_size = 518
+        wp_pool_size = 37
+
+        def reset(self):
+            """Match the VGGT extractor lifecycle surface."""
+
+        def extract(self, image):
+            """Match the VGGT extractor readout surface."""
+            return image
+
+    contract = build_vggt_contract(FakeExtractor(), feature_kind="wp_cp")
+    snapshot = contract.to_snapshot()
+    cfg = R2DreamerConfig(
+        encoder_type="contract_only_alias",
+        obs_shape=contract.encoder_input.buffer_shape(),
+        encoder_input_contract=snapshot,
+    )
+    batch = {
+        "obs": {
+            WORLD_POINTS_KEY: jnp.ones((2, 3, 3, 37, 37), dtype=jnp.float16),
+            CAMERA_POSE_KEY: jnp.ones((2, 3, 9), dtype=jnp.float16),
+        }
+    }
+
+    encoder_obs = encoder_obs_from_batch(batch, cfg)
+
+    assert encoder_obs.shape == (6, 4116)
+    assert encoder_obs.dtype == jnp.bfloat16

--- a/tests/r2dreamer/test_observation_preparation.py
+++ b/tests/r2dreamer/test_observation_preparation.py
@@ -9,6 +9,7 @@ from src.environments.observation import ObservationFrame
 from src.r2dreamer.config import (
     ObservationDims,
     ObservationRunConfig,
+    R2DreamerConfig,
     ReplayObservationConfig,
 )
 from src.r2dreamer.observation_preparation import (
@@ -18,12 +19,17 @@ from src.r2dreamer.observation_preparation import (
     VGGTFeatureKind,
     VGGT_DREAMER_SPECS,
     build_hybrid_contract,
+    build_vggt_rgb_contract,
     build_vggt_contract,
+    encoder_module_kwargs_from_config,
     PreparedObservation,
     recover_encoder_input_contract,
 )
 from src.r2dreamer.obs_batch import (
     CAMERA_POSE_KEY,
+    FULL_TOKENS_KEY,
+    GLOBAL_TOKENS_KEY,
+    HOUSE_CONTEXT_KEY,
     HYBRID_IMAGE_KEY,
     HYBRID_WP_CP_KEY,
     WORLD_POINTS_KEY,
@@ -160,6 +166,7 @@ class TestVGGTObservationPreparationContracts:
         assert replay.fields[CAMERA_POSE_KEY].dtype == "float16"
         assert contract.agent_observation.fields[WORLD_POINTS_KEY].shape == (3, 37, 37)
         assert contract.encoder_input.shape == (37 * 37 * 3 + 9,)
+        assert contract.encoder_input_layout == "flat_wp_cp"
         assert contract.decoder_target is None
         assert contract.agent_overrides == {"buffer_capacity": 1_000_000}
 
@@ -183,6 +190,7 @@ class TestVGGTObservationPreparationContracts:
             assert contract.replay_observation.shape == shape
             assert contract.replay_observation.dtype == dtype
             assert contract.encoder_input.shape == shape
+            assert contract.encoder_input_layout == "flat_features"
             assert contract.decoder_target is None
 
     def test_wp_cp_64_contract_is_resolution_ablation(self):
@@ -222,6 +230,7 @@ class TestVGGTObservationPreparationContracts:
         assert contract.replay_observation.fields[CAMERA_POSE_KEY].dtype == "float16"
         assert contract.encoder_input.fields[WORLD_POINTS_KEY].dtype == "float32"
         assert contract.encoder_input.fields[CAMERA_POSE_KEY].dtype == "float32"
+        assert contract.encoder_input_layout == "structured_wp_cp"
         assert contract.decoder_target is None
         assert contract.agent_overrides == {"buffer_capacity": 1_000_000}
 
@@ -240,5 +249,89 @@ class TestVGGTObservationPreparationContracts:
         assert contract.agent_observation.fields[HYBRID_IMAGE_KEY].shape == HYBRID_IMAGE_SHAPE
         assert contract.agent_observation.fields[HYBRID_WP_CP_KEY].shape == (37 * 37 * 3 + 9,)
         assert contract.encoder_input.shape == (HYBRID_FEATURE_DIM,)
+        assert contract.encoder_input_layout == "rgb_plus_flat"
         assert contract.decoder_target is not None
         assert contract.decoder_target.shape == HYBRID_IMAGE_SHAPE
+
+    def test_rgb_vggt_context_contract_declares_replay_agent_and_encoder_forms(self):
+        contract = build_vggt_rgb_contract(
+            self._Extractor(),
+            encoder_type="vggt_house_context",
+        )
+
+        assert contract.observation_preparation_type == "vggt_house_context"
+        assert contract.encoder_type == "vggt_house_context"
+        assert contract.encoder_module_cls is wm_encoders.HybridEncoder
+        assert contract.env_observation.fields[HYBRID_IMAGE_KEY].shape == (3, 518, 518)
+        assert contract.replay_observation.fields[HYBRID_IMAGE_KEY].shape == HYBRID_IMAGE_SHAPE
+        assert contract.replay_observation.fields[HYBRID_IMAGE_KEY].dtype == "uint8"
+        assert contract.replay_observation.fields[HYBRID_IMAGE_KEY].normalize_on_sample is True
+        assert contract.replay_observation.fields[HOUSE_CONTEXT_KEY].shape == (1024,)
+        assert contract.replay_observation.fields[HOUSE_CONTEXT_KEY].dtype == "float32"
+        assert contract.agent_observation.fields[HOUSE_CONTEXT_KEY].dtype == "float32"
+        assert contract.encoder_input.shape == (12288 + 1024,)
+        assert contract.encoder_input_layout == "rgb_plus_context"
+        assert contract.decoder_target is not None
+
+    def test_rgb_vggt_token_contracts_are_structured_encoder_inputs(self):
+        cases = [
+            (
+                "vggt_house_full_tokens_nogate",
+                FULL_TOKENS_KEY,
+                (1374, 2048),
+                wm_encoders.RGBFullTokenTransformerEncoder,
+            ),
+            (
+                "vggt_house_global_tokens_nogate",
+                GLOBAL_TOKENS_KEY,
+                (1374, 1024),
+                wm_encoders.RGBGlobalTokenTransformerEncoder,
+            ),
+        ]
+
+        for encoder_type, token_key, token_shape, module_cls in cases:
+            contract = build_vggt_rgb_contract(
+                self._Extractor(),
+                encoder_type=encoder_type,
+            )
+
+            assert contract.encoder_module_cls is module_cls
+            assert contract.replay_observation.fields[HYBRID_IMAGE_KEY].shape == HYBRID_IMAGE_SHAPE
+            assert contract.replay_observation.fields[token_key].shape == token_shape
+            assert contract.replay_observation.fields[token_key].dtype == "float16"
+            assert contract.encoder_input.fields[HYBRID_IMAGE_KEY].shape == HYBRID_IMAGE_SHAPE
+            assert contract.encoder_input.fields[token_key].shape == token_shape
+            assert contract.encoder_input.fields[token_key].dtype == "float32"
+            assert contract.encoder_input_layout == "rgb_plus_tokens"
+            assert contract.decoder_target is not None
+
+    def test_contract_snapshots_preserve_layout_and_module_kwargs(self):
+        contract = build_vggt_rgb_contract(
+            self._Extractor(),
+            encoder_type="vggt_house_full_tokens_nogate",
+        )
+        config = R2DreamerConfig(
+            encoder_type=contract.encoder_type,
+            encoder_module_cls=contract.encoder_module_cls,
+            obs_shape=contract.encoder_input.buffer_shape(),
+            encoder_input_contract=contract.to_snapshot(),
+            vggt_embed_dim=64,
+            vggt_token_count=1374,
+            vggt_token_dim=2048,
+            vggt_token_transformer_layers=3,
+            vggt_token_transformer_heads=8,
+            compute_dtype="float32",
+        )
+
+        kwargs = encoder_module_kwargs_from_config(config, contract.encoder_module_cls)
+        snapshot = contract.to_snapshot()
+        snapshot["encoder_module_kwargs"] = kwargs
+        recovered = recover_encoder_input_contract(json.loads(json.dumps(snapshot)))
+
+        assert snapshot["encoder_input_layout"] == "rgb_plus_tokens"
+        assert kwargs["context_dim"] == 64
+        assert kwargs["token_dim"] == 2048
+        assert kwargs["transformer_layers"] == 3
+        assert recovered.encoder_input_layout == "rgb_plus_tokens"
+        assert recovered.encoder_module_kwargs["cnn_mults"] == (2, 3, 4, 4)
+        assert recovered.encoder_module_kwargs["compute_dtype"] == np.float32


### PR DESCRIPTION
## What changed

- Added contract-backed VGGT RGB/context/token variants, including house-context, full-token no-gate, and global-token no-gate paths.
- Added `encoder_input_layout` to Encoder Input Contract snapshots and routed replay/agent observation conversion through the contract layout when available.
- Resolved Encoder Module kwargs from contracts for VGGT token Transformer and RGB+token modules.
- Moved Feature Extractor reset lifecycle into the RGB+VGGT Observation Preparation adapters.
- Kept global-token no-gate replay as singleton live tokens and aligned the Encoder Module with that contract.
- Added a small eval compatibility fallback for legacy/simple agent and adapter fakes found by the non-GPU suite.

## Why

Linear 3D-82 requires registered VGGT modes to expose environment, replay, agent, encoder-input, Encoder Module class, and module kwargs through the Observation Preparation contract, without changing VGGT Feature Extractor internals or Encoder Module architecture.

## Linear issue

https://linear.app/3d-wm-objectnav/issue/3D-82/3d-route-vggt-observation-preparation-variants-through-the-contract

## Acceptance criteria checked

- VGGT registered readout variants are contract-backed, including RGB+context/token variants.
- Observation forms now declare raw env observation, replay observation, agent observation, encoder input, and decoder target where applicable.
- Feature Extractor reset lifecycle is owned by Observation Preparation adapters.
- Replay-to-Encoder Module conversion can use `encoder_input_layout` instead of external `encoder_type` branching.
- Encoder Module class and resolved constructor kwargs are recoverable from the Encoder Input Contract snapshot.
- Focused CPU-safe tests cover contract fields, replay conversion, render-resolution metadata, and lifecycle wiring.
- Existing run IDs, W&B names/tags, and VGGT defaults were not renamed.

## Verification

- `uv run pytest tests/r2dreamer/test_observation_preparation.py tests/r2dreamer/launch/test_encoders.py tests/r2dreamer/test_obs_batch.py tests/r2dreamer/test_agent.py::TestR2DreamerAgent::test_train_step_accepts_live_tokens_without_gate tests/r2dreamer/test_agent.py::TestR2DreamerAgent::test_full_token_nogate_uses_configured_bfloat16_compute tests/r2dreamer/test_agent.py::TestR2DreamerAgent::test_train_step_accepts_vggt_house_context_batch -q`
- `uv run pytest tests/r2dreamer/ -m 'not gpu' -q --ignore=tests/r2dreamer/test_cross_framework.py`
- `sbatch --partition=dev_gpu_h100 --time=00:30:00 scripts/r2dreamer/slurm/smoke_curriculum_vggt.sbatch` -> job `5148932`, completed exit code 0, 417 metrics lines, checkpoint saved.

## Known issues

- `python -m pylint ...` is unavailable in the system Python.
- `uv run python -m pylint <changed paths>` still reports inherited repository-wide pylint findings in existing large modules (`contracts.py`, `encoders/__init__.py`, `obs_batch.py`, `agent.py`, `world_model/encoders.py`, `launch/evaluate.py`). The focused tests and smoke pass.
- The full non-GPU suite excluding `test_cross_framework.py` passed; `test_cross_framework.py` still requires the external reference import `rssm`, as documented in `tests/r2dreamer/AGENTS.md`.

## Risk

Medium: this touches shared observation packing and VGGT launch wiring, but is covered by contract tests, broader CPU tests, and a VGGT smoke job.

## What was intentionally not done

- No public run-ID, W&B naming, or CLI rename migration.
- No changes to VGGT Feature Extractor internals.
- No mathematical changes to Encoder Module architectures.

## Agent involvement

Implemented and validated in the repository worktree per the Linear issue.