### PR TITLE
fix(contracts): subclass-aware encoder kwargs dispatch via MRO walk

### DIFF
--- a/src/r2dreamer/observation_preparation/contracts.py
+++ b/src/r2dreamer/observation_preparation/contracts.py
@@ -49,12 +49,60 @@ def _tuple_value(config: Any, name: str) -> tuple[int, ...]:
     return tuple(getattr(config, name))
 
 
+# Encoder Module classes with a dedicated kwargs branch below. Matched by
+# name (not issubclass) so this module stays import-free of the encoder
+# packages, which import contract machinery themselves.
+_HANDLED_ENCODER_CLASS_NAMES = frozenset(
+    {
+        "ConvEncoder",
+        "WP64CNNCPMLPEncoder",
+        "HybridEncoder",
+        "HousePointsCameraEncoder",
+        "HouseGlobalEmbeddingEncoder",
+        "TokenTransformerEncoder",
+    }
+)
+
+
+def _kwargs_dispatch_name(encoder_module_cls: type) -> str:
+    """Return the nearest handled class name along the MRO.
+
+    Subclasses (e.g. the GNN variants of ``HousePointsCameraEncoder``)
+    inherit their parent's constructor kwargs, so dispatch walks the MRO
+    and picks the first ancestor with a dedicated kwargs branch — the
+    name-matching equivalent of an ``issubclass`` chain ordered
+    most-derived-first.
+
+    Args:
+      encoder_module_cls: The Encoder Module class to resolve kwargs for.
+
+    Returns:
+      The matched ancestor's class name, or the class's own name when no
+      ancestor has a dedicated branch (falls through to the MLP tail).
+    """
+    for base in encoder_module_cls.__mro__:
+        if base.__name__ in _HANDLED_ENCODER_CLASS_NAMES:
+            return base.__name__
+    return encoder_module_cls.__name__
+
+
 def encoder_module_kwargs_from_config(
     config: Any,
     encoder_module_cls: type,
 ) -> dict[str, Any]:
-    """Resolve Encoder Module constructor kwargs from an effective config."""
-    class_name = encoder_module_cls.__name__
+    """Resolve Encoder Module constructor kwargs from an effective config.
+
+    Dispatch is subclass-aware: a class without its own branch inherits the
+    kwargs of its nearest handled ancestor (see ``_kwargs_dispatch_name``).
+
+    Args:
+      config: Effective agent config (``R2DreamerConfig`` or equivalent).
+      encoder_module_cls: The Encoder Module class to be constructed.
+
+    Returns:
+      Constructor kwargs for ``encoder_module_cls``.
+    """
+    class_name = _kwargs_dispatch_name(encoder_module_cls)
     if class_name == "ConvEncoder":
         kwargs = {
             "depth": int(config.encoder_depth),

--- a/tests/r2dreamer/launch/test_registries.py
+++ b/tests/r2dreamer/launch/test_registries.py
@@ -3,6 +3,7 @@
 import inspect
 import pytest
 
+from src.configs.agent_config import R2DreamerConfig
 from src.environments.habitat import (
     HABITAT_CURRICULA,
     HabitatEnvConfig,
@@ -10,6 +11,28 @@ from src.environments.habitat import (
 )
 from src.r2dreamer.encoders import Encoder, HybridEncoder
 from src.r2dreamer.launch.registries import encoder_registry, env_registry
+from src.r2dreamer.observation_preparation.contracts import (
+    encoder_module_kwargs_from_config,
+)
+
+
+def _registry_module_cls(encoder_cls: type[Encoder]) -> type:
+    """Resolve an Encoder selection's module class without running __init__.
+
+    ``module_cls`` is either a plain class attribute or a property that only
+    reads class-level state (the ``variant`` descriptor), so an uninitialized
+    instance suffices — full construction would build the VGGT extractor.
+
+    Args:
+      encoder_cls: A launcher-side ``Encoder`` selection class.
+
+    Returns:
+      The Flax Encoder Module class the selection would instantiate.
+    """
+    attr = inspect.getattr_static(encoder_cls, "module_cls")
+    if isinstance(attr, property):
+        return attr.fget(object.__new__(encoder_cls))
+    return attr
 
 
 class TestEncoderRegistry:
@@ -42,6 +65,23 @@ class TestEncoderRegistry:
 
     def test_hybrid_key_resolves_to_hybrid_spec_class(self):
         assert encoder_registry["hybrid"] is HybridEncoder
+
+    @pytest.mark.parametrize(
+        "encoder_type",
+        sorted(encoder_registry),
+    )
+    def test_module_constructs_from_contract_kwargs(self, encoder_type):
+        # Regression: subclass modules (e.g. the GNN variants of
+        # HousePointsCameraEncoder) must dispatch to their parent's kwargs
+        # branch, not the generic MLP tail, on contract-snapshot paths
+        # (make_encoder_module, checkpoint eval) that bypass agent.py.
+        module_cls = _registry_module_cls(encoder_registry[encoder_type])
+        config = R2DreamerConfig(encoder_type=encoder_type)
+
+        kwargs = encoder_module_kwargs_from_config(config, module_cls)
+        module = module_cls(**kwargs)
+
+        assert isinstance(module, module_cls)
 
 
 class TestEnvRegistry:


### PR DESCRIPTION
## What

`encoder_module_kwargs_from_config` in `src/r2dreamer/observation_preparation/contracts.py` matched Encoder Module classes by exact `__name__`, so the GNN subclasses of `HousePointsCameraEncoder` (`GnnHousePointsCameraEncoder`, `GnnEdgeHousePointsCameraEncoder`) fell through to the generic MLP kwargs tail (`embed_dim`/`hidden`/`num_layers`) and crashed with `TypeError: unexpected keyword argument 'hidden'` on construction.

Dispatch now walks the class MRO and picks the nearest ancestor with a dedicated kwargs branch (`_kwargs_dispatch_name`) — the name-matching equivalent of an `issubclass` chain ordered most-derived-first.

## Why

Training only worked because `agent.py` uses its own `issubclass`-based builder; the two dispatch sites had diverged. Every path that constructs from the contract snapshot — `make_encoder_module`, checkpoint eval/loading — crashed for GNN runs.

Name matching (rather than real `issubclass` checks) is kept deliberately: `contracts.py` stays import-free of the encoder packages, which import contract machinery themselves.

## Reviewer notes

- Regression test: `test_module_constructs_from_contract_kwargs` in `tests/r2dreamer/launch/test_registries.py`, parametrized over every `encoder_registry` entry. It resolves each launcher class's `module_cls` without running the heavy VGGT-extractor `__init__` (via `object.__new__` — safe because `module_cls` only reads class-level state) and constructs the module from contract kwargs with a default `R2DreamerConfig`. Before the fix, exactly the two GNN entries failed; all 15 now pass.
- Convention to keep in mind: a future subclass that needs its **own** kwargs branch must also be added to `_HANDLED_ENCODER_CLASS_NAMES`, otherwise dispatch stops at its parent and config-tunable kwargs are silently inherited. (Relevant to the in-progress `HybridHousePointsCameraEncoder` work.)
- Verified end-to-end: `make_encoder_module` and a JSON contract-snapshot round-trip (checkpoint-eval shape) now construct the GNN encoder; observation-preparation and GNN encoder suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)