### PR TITLE
feat(encoder): additive hybrid — rgb64 CNN backbone + gated live house points/pose

### DIFF
--- a/docs/notes/2026-07-06-house-points-vs-cnn-baseline-review-assets/flatten_vs_pool_stability.py
+++ b/docs/notes/2026-07-06-house-points-vs-cnn-baseline-review-assets/flatten_vs_pool_stability.py
@@ -1,0 +1,162 @@
+"""Embedding stability under live-buffer growth: flatten vs masked pooling.
+
+Simulates the HouseContextPoseBuffer snapshot pipeline: a house-like point
+cloud is ingested in exploration order; at several fill levels the buffer is
+snapshotted with the production even-stride rule
+``idx = floor(arange(max_points) * size / max_points)`` (see
+src/buffer/house_context_pose_buffer.py::_house_context_snapshot).
+
+Three fixed random-weight encoders embed each snapshot:
+  pool_mlp      point-MLP (2x Dense(256)+SiLU) -> masked mean+max -> Dense(1024)
+                (same shape as HousePointsCameraEncoder._house_embedding)
+  flat_raw      even-stride subsample to 4096 pts in insertion order,
+                flatten (24576,) -> Dense(1024)
+  flat_sorted   same, but points sorted by voxel key before flattening
+
+Metric: cosine similarity of each snapshot's embedding to the FINAL full-map
+embedding, i.e. "how much does the world-model input churn while the map is
+still growing?". Random weights measure representational stability, not task
+performance (random features approximately preserve geometry).
+"""
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+
+import jax
+import jax.numpy as jnp
+
+MAX_POINTS = 262_144
+FLAT_POINTS = 4_096
+EMBED = 1_024
+HIDDEN = 256
+VOXEL = 0.01
+
+key = jax.random.PRNGKey(0)
+
+
+def make_house_cloud(key, n_target=4_000_000):
+    """Samples a house-like cloud (floor + walls + furniture boxes), 1cm voxels.
+
+    Args:
+      key: PRNG key.
+      n_target: Approximate number of surviving voxel-deduped points.
+
+    Returns:
+      (N,6) float32 xyzrgb in insertion (exploration) order.
+    """
+    ks = jax.random.split(key, 8)
+    n_raw = int(n_target * 1.35)
+    # Floor 12x10m, walls, and 12 furniture boxes.
+    n_floor = n_raw // 3
+    floor = jnp.stack(
+        [
+            jax.random.uniform(ks[0], (n_floor,)) * 12.0,
+            jax.random.uniform(ks[1], (n_floor,)) * 10.0,
+            jnp.zeros(n_floor),
+        ],
+        axis=-1,
+    )
+    n_wall = n_raw // 3
+    t = jax.random.uniform(ks[2], (n_wall,))
+    z = jax.random.uniform(ks[3], (n_wall,)) * 2.5
+    side = jax.random.randint(ks[4], (n_wall,), 0, 4)
+    wx = jnp.where(side == 0, t * 12.0, jnp.where(side == 1, t * 12.0, jnp.where(side == 2, 0.0, 12.0)))
+    wy = jnp.where(side == 0, 0.0, jnp.where(side == 1, 10.0, t * 10.0))
+    walls = jnp.stack([wx, wy, z], axis=-1)
+    n_furn = n_raw - n_floor - n_wall
+    centers = jax.random.uniform(ks[5], (12, 3)) * jnp.array([11.0, 9.0, 0.0]) + jnp.array([0.5, 0.5, 0.4])
+    fi = jax.random.randint(ks[6], (n_furn,), 0, 12)
+    offs = (jax.random.uniform(ks[7], (n_furn, 3)) - 0.5) * jnp.array([1.2, 1.2, 0.8])
+    furn = centers[fi] + offs
+    xyz = jnp.concatenate([floor, walls, furn], axis=0)
+    rgb = jnp.clip(xyz / jnp.array([12.0, 10.0, 2.5]), 0.0, 1.0)  # color ~ position proxy
+    # Voxel dedup at 1cm like the production buffer.
+    vox = jnp.floor(xyz / VOXEL).astype(jnp.int32)
+    hkey = vox[:, 0] * 73_856_093 ^ vox[:, 1] * 19_349_663 ^ vox[:, 2] * 83_492_791
+    _, first = jnp.unique(hkey, return_index=True, size=xyz.shape[0], fill_value=-1)
+    first = first[first >= 0]
+    pts = jnp.concatenate([xyz, rgb], axis=-1)[first]
+    # Exploration order: sweep by angle around the house centre + jitter.
+    ang = jnp.arctan2(pts[:, 1] - 5.0, pts[:, 0] - 6.0)
+    ang = ang + 0.15 * jax.random.normal(jax.random.PRNGKey(9), ang.shape)
+    return pts[jnp.argsort(ang)].astype(jnp.float32)
+
+
+def snapshot(pts, size):
+    """Production even-stride snapshot to fixed (MAX_POINTS,6) + valid count."""
+    size = min(size, pts.shape[0])
+    if size <= MAX_POINTS:
+        out = jnp.zeros((MAX_POINTS, 6), jnp.float32).at[:size].set(pts[:size])
+        return out, size
+    idx = jnp.floor(jnp.arange(MAX_POINTS) * (size / MAX_POINTS)).astype(jnp.int32)
+    return pts[:size][idx], MAX_POINTS
+
+
+kw = jax.random.split(jax.random.PRNGKey(42), 6)
+w1 = (jax.random.normal(kw[0], (6, HIDDEN)) / jnp.sqrt(6)).astype(jnp.bfloat16)
+w2 = (jax.random.normal(kw[1], (HIDDEN, HIDDEN)) / jnp.sqrt(HIDDEN)).astype(jnp.bfloat16)
+w3 = (jax.random.normal(kw[2], (2 * HIDDEN, EMBED)) / jnp.sqrt(2 * HIDDEN)).astype(jnp.bfloat16)
+wf = (jax.random.normal(kw[3], (FLAT_POINTS * 6, EMBED)) / jnp.sqrt(FLAT_POINTS * 6)).astype(jnp.bfloat16)
+
+
+def pool_mlp(snap, size):
+    x = jax.nn.silu(snap.astype(jnp.bfloat16) @ w1)
+    x = jax.nn.silu(x @ w2)
+    valid = (jnp.arange(MAX_POINTS) < size)[:, None]
+    mean = (x * valid).sum(0) / jnp.maximum(size, 1)
+    mx = jnp.where(valid, x, -jnp.inf).max(0)
+    return (jnp.concatenate([mean, mx]) @ w3).astype(jnp.float32)
+
+
+def flat(snap, size, sort):
+    idx = jnp.floor(jnp.arange(FLAT_POINTS) * (min(size, MAX_POINTS) / FLAT_POINTS)).astype(jnp.int32)
+    sub = snap[idx]
+    if sort:
+        vox = jnp.floor(sub[:, :3] / VOXEL).astype(jnp.int32)
+        order = jnp.lexsort((vox[:, 2], vox[:, 1], vox[:, 0]))
+        sub = sub[order]
+    return (sub.astype(jnp.bfloat16).reshape(-1) @ wf).astype(jnp.float32)
+
+
+def cos(a, b):
+    return float(a @ b / (jnp.linalg.norm(a) * jnp.linalg.norm(b) + 1e-8))
+
+
+pts = make_house_cloud(key)
+total = pts.shape[0]
+print(f"house cloud: {total} voxel-deduped points")
+sizes = [s for s in [100_000, 262_144, 500_000, 1_000_000, 2_000_000, total] if s <= total]
+
+ref = {name: None for name in ("pool_mlp", "flat_raw", "flat_sorted")}
+rows = []
+for s in sizes:
+    snap, valid = snapshot(pts, s)
+    e = {
+        "pool_mlp": pool_mlp(snap, valid),
+        "flat_raw": flat(snap, valid, sort=False),
+        "flat_sorted": flat(snap, valid, sort=True),
+    }
+    rows.append((s, e))
+
+final = rows[-1][1]
+print(f"\ncosine similarity to final full-map embedding ({total} pts):")
+print(f"{'buffer size':>12s} {'pool_mlp':>9s} {'flat_raw':>9s} {'flat_sorted':>12s}")
+for s, e in rows:
+    print(
+        f"{s:>12d} {cos(e['pool_mlp'], final['pool_mlp']):>9.4f}"
+        f" {cos(e['flat_raw'], final['flat_raw']):>9.4f}"
+        f" {cos(e['flat_sorted'], final['flat_sorted']):>12.4f}"
+    )
+
+print("\nconsecutive-snapshot similarity (input churn step-to-step):")
+for (s0, e0), (s1, e1) in zip(rows, rows[1:]):
+    print(
+        f"{s0:>9d}->{s1:<9d} pool={cos(e0['pool_mlp'], e1['pool_mlp']):.4f}"
+        f" flat_raw={cos(e0['flat_raw'], e1['flat_raw']):.4f}"
+        f" flat_sorted={cos(e0['flat_sorted'], e1['flat_sorted']):.4f}"
+    )
+
+print("\nparameter counts:")
+print(f"  pool_mlp head (prod shape) : {6*HIDDEN + HIDDEN*HIDDEN + 2*HIDDEN*EMBED:,}")
+print(f"  flatten 4096 pts -> 1024   : {FLAT_POINTS*6*EMBED:,}")
+print(f"  flatten 262144 pts -> 1024 : {MAX_POINTS*6*EMBED:,} (infeasible)")

--- a/docs/notes/2026-07-06-house-points-vs-cnn-baseline-review.md
+++ b/docs/notes/2026-07-06-house-points-vs-cnn-baseline-review.md
@@ -1,0 +1,166 @@
+# Deep review: VGGT house-points-pose (live buffer) vs. CNN image baseline
+
+**Date:** 2026-07-06 · **Run under review:** job 5741728
+(`vggt-house-points-pose-l1-live`, `run-5741728`, ~646k/2M steps at time of
+writing; sibling seed 5764453 same config) · **Baseline:** image-only CNN L1
+(`output/r2dreamer-curriculum-l1/run-4194043` + seed `run-4367942`, 2.4M steps,
+completed).
+
+## 1. What is actually being compared
+
+The two variants do **not** share any input modality — this is the single most
+important caveat for interpreting the numbers:
+
+| | CNN baseline | `vggt_house_points_pose` (5741728) |
+|---|---|---|
+| RGB image | ✅ 64×64, only input | ❌ **not an encoder input at all** |
+| Camera pose (9,) | ❌ | ✅ MLP branch |
+| House point map | ❌ | ✅ (262144, 6) snapshot + valid count |
+| Encoder | `ConvEncoder` (`src/r2dreamer/encoders/cnn.py:28`) | `HousePointsCameraEncoder` (`src/r2dreamer/encoders/mlp.py:105`) |
+| Embedding | 1024 (flattened 4×4×64 conv map, no projection) | 2048 (concat camera 1024 ⊕ house 1024, no gate) |
+| Encoder params | ~0.1M conv stack | ~1.65M (camera branch 1.06M, point head 0.59M) |
+
+In the house-points run the RGB frame is used **only upstream** — VGGT lifts it
+to world points that feed the per-scene buffer. The world model itself is
+image-blind and must navigate from ego-pose + a mostly-static map. So the run
+answers "how far does *map + pose alone* get you", not "does the map *add* to
+vision".
+
+## 2. Results at matched step windows (training episodes, L1 chair-only)
+
+Window = env steps 400k–650k (the house run's most recent quarter):
+
+| Run | success | SPL | n episodes |
+|---|---|---|---|
+| CNN `run-4194043` | **0.696** | **0.498** | 930 |
+| CNN `run-4367942` | **0.717** | **0.520** | 969 |
+| house-points `run-5741728` | 0.338 | 0.237 | 621 |
+
+CNN baseline end-of-training (2.15–2.4M): success 0.671, SPL 0.474 — it
+plateaus by ~500k steps.
+
+House-points trend (thirds of the run so far): success 0.144 → 0.210 → 0.351,
+`metrics/sr_mean` 0.090 → 0.156 → 0.208 (last 0.235), `dtg_mean` 2.14 → 1.86.
+**Still climbing at 646k steps** where the CNN had already plateaued, but at
+roughly **half** the baseline's success and SPL. Extrapolation to 2M is
+uncertain; crossing the CNN plateau would require the current slope to hold
+for another ~500k steps, which the flattening sr_mean curve does not suggest.
+
+Two secondary observations:
+
+- `loss/dyn` = `loss/rep` **rises** through the house run (4.2 → 5.8, last
+  6.9) while the CNN baseline's is flat (~2.86 for 2.4M steps). The world
+  model finds the (pose, map-snapshot) observation stream progressively harder
+  to predict — consistent with a nonstationary global snapshot being broadcast
+  into every replay batch (`hybrid_adapter.py:767`, see §4).
+- Throughput ~171 ms/step (5.9 fps) — in line with the known ~219 ms
+  production-shape cost, dominated by VGGT inference that the baseline
+  (~28 ms/step) doesn't pay.
+- Older baseline `run-4119014` (actfix rerun, Apr 27) only reached 13%
+  success; the May runs `4194043`/`4367942` at 66–72% supersede it. Use the
+  May pair as the canonical L1 CNN reference.
+
+## 3. The "simple flatten" question
+
+Current aggregation (`mlp.py:136-177`) is already the near-simplest
+permutation-invariant design: shared point-MLP (2 × Dense(256)+RMSNorm+SiLU)
+→ masked mean ⊕ max pool → Dense(1024). PointNet-lite, 0.59M params.
+
+A flatten head would replace pooling with `reshape(-1) → Dense`. Measured
+feasibility and stability (experiment below):
+
+| Head | Params | Input coverage |
+|---|---|---|
+| point-MLP + pool (prod) | 0.59M | all 262144 snapshot points |
+| flatten 262144 pts → 1024 | **1.61B — infeasible** | all |
+| flatten 4096 pts → 1024 | 25.2M (42× prod) | 1.6% of snapshot |
+
+**Stability experiment** (`flatten_vs_pool_stability.py`, CPU/JAX): a 5.4M-point
+synthetic house cloud ingested in exploration order, snapshotted at growing
+fill levels with the production even-stride rule
+(`house_context_pose_buffer.py:254-283`), embedded with fixed random-weight
+versions of each head. Cosine similarity of each snapshot's embedding to the
+final full-map embedding:
+
+| buffer size | pool_mlp | flat_raw | flat_sorted |
+|---|---|---|---|
+| 100k | 0.957 | 0.728 | 0.803 |
+| 262k | 0.965 | 0.728 | 0.838 |
+| 500k | 0.978 | 0.691 | 0.859 |
+| 1M | 0.934 | 0.562 | 0.845 |
+| 2M | 0.971 | 0.664 | 0.815 |
+
+While the buffer grows, the even-stride snapshot keeps reassigning which point
+lands in which slot; a flatten head is slot-position-sensitive, so its input
+churns (cos ≈ 0.56–0.73 to the converged map, and 0.66–0.89 between
+*consecutive* snapshots). Pooling is permutation-invariant, so the embedding is
+stable (≥ 0.93) even when only 2% of the final map has been seen. Sorting
+points by voxel key before flattening recovers some stability (≈ 0.80–0.86)
+but stays well below pooling, at 42× the parameters.
+
+**Verdict: keep the pooled head; don't spend a run on naive flatten.** The
+one *principled* flatten variant is what the CNN baseline itself does —
+flatten a **fixed spatial grid**. The equivalent for house points is
+rasterizing the buffer into a BEV/voxel grid and flattening a conv map over
+it (the `wp_dense_cnn` direction), which preserves slot-position meaning by
+construction. That is the flatten experiment worth running, not
+`reshape(points)`.
+
+## 4. Buffer mechanics findings (affect any aggregation choice)
+
+- **Growth does not saturate in the smoke horizon.** All four smokes agree:
+  ~1.73M voxels @ 512 steps → ~4.1M @ ~1–2k steps (fill 0.49 of the 2^23
+  capacity), still climbing ~2k voxels/step. At that rate the buffer hits
+  capacity within the first few thousand steps of the 2M-step run. With **no
+  eviction** (`_insert_unique_voxels` drops new voxels once full,
+  `house_context_pose_buffer.py:127-219`), the "live" map effectively
+  freezes during prefill — everything the agent sees afterwards never enters
+  the map. For a static house this is survivable, but it means (a) early VGGT
+  noise/misalignment is locked in forever, and (b) the `overflow_count`
+  diagnostic is the number to check in the final manifest.
+- **1 cm voxels are too fine for the budget.** 8.4M × 1 cm³ voxels is mostly
+  surface micro-detail; the snapshot then even-strides 4.1M+ stored points
+  down to 262k (≥ 16:1 discard). A 2–4 cm voxel would let the *whole* house fit
+  both capacity and snapshot, making the observation truly stable and the
+  even-stride subsample lossless.
+- **The go/no-go metric is invisible mid-run.** `house_buffer/points_growth`
+  is written only by `_log_adapter_summary` at end of run
+  (`trainer.py:795-812`). For a 2-day job the growth curve — explicitly named
+  in the config as the go/no-go — can't be checked until the job finishes.
+  Logging `adapter.diagnostics()` every N steps alongside train metrics would
+  fix this cheaply.
+- **One global snapshot is broadcast across the replay batch**
+  (`hybrid_adapter.py:767-780`): every sequence in a batch, whatever its age,
+  is paired with *today's* map. Early-run transitions were collected under a
+  sparser map than the one they're trained with — a moving-target effect that
+  plausibly contributes to the rising `loss/dyn`.
+
+## 5. Recommendations
+
+1. **Keep** point-MLP + masked pooling; reject naive flatten (params +
+   stability, §3).
+2. **Let 5741728/5764453 finish** — the run is still improving and is the
+   cleanest measurement of map+pose-only navigation; judge by final manifest
+   (`overflow_count`, growth curve) not exit code.
+3. **Next variant should be additive, not substitutive:** image CNN branch ⊕
+   house-points branch (gated, as in `HybridEncoder`), so the map is tested as
+   *extra* information against the strong 0.70-success CNN baseline rather
+   than as a replacement for vision.
+4. **Coarsen voxels to 2–4 cm** (or add eviction) so the map fits capacity and
+   the snapshot stops discarding ≥ 94% of stored points.
+5. **Log buffer diagnostics mid-run** (periodic `diagnostics()` rows in
+   `metrics.csv`).
+6. If a flatten-style head is still wanted, do it as **BEV rasterization +
+   small CNN** (fixed grid → flatten is then well-posed), reusing the
+   `ConvEncoder(input_kind="world_points")` machinery.
+
+## Appendix: provenance
+
+- Metrics windows computed from long-format `metrics.csv` (step, metric,
+  value); files are not step-sorted — sorted before aggregation.
+- Stability experiment script:
+  `docs/notes/2026-07-06-house-points-vs-cnn-baseline-review-assets/flatten_vs_pool_stability.py`
+  (synthetic house cloud: floor/walls/12
+  furniture boxes, 1 cm voxel dedup, angular exploration order; fixed
+  random-weight heads, bfloat16 compute; cosine in float32).
+- Smoke growth curves: `output/runs/r2dreamer-curriculum-l1-vggt-house-points-pose-live/smoke/slurm-{5738008,5738777,5740085,5764452}.out`.

--- a/scripts/r2dreamer/_run_configs.py
+++ b/scripts/r2dreamer/_run_configs.py
@@ -136,6 +136,21 @@ RUN_CONFIGS: dict[str, dict[str, Any]] = {
             "point-mlp", "jax", "3d-encoder",
         ],
     ),
+    # L1 additive hybrid: rgb64 CNN backbone + zero-init-gated live house
+    # points/pose branches (starts exactly at the CNN baseline).
+    "habitat-l1-vggt-hybrid-house-points-pose": dict(
+        env="habitat",
+        encoder="vggt_hybrid_house_points_pose",
+        curriculum="L1",
+        output_dir="output/runs/r2dreamer-curriculum-l1-vggt-hybrid-house-points-pose",
+        wandb_name="l1_hybrid_house_points_pose",
+        wandb_tags=[
+            "curriculum", "level1", "1house", "chair-only", "vggt",
+            "house-points", "live-buffer", "camera-pose-replay",
+            "point-mlp", "cnn-backbone", "additive-hybrid", "gated",
+            "jax", "3d-encoder",
+        ],
+    ),
     # L1 live house points + GNN house branch (src/r2dreamer/encoders/gnn_house.py).
     "habitat-l1-gnn-house-points-pose": dict(
         env="habitat",

--- a/scripts/slurm/configs/hybrid_house_points_pose_l1_live.yaml
+++ b/scripts/slurm/configs/hybrid_house_points_pose_l1_live.yaml
@@ -1,0 +1,29 @@
+extends: house_points_pose_l1_live
+job_name: vggt-hybrid-house-points-pose-l1-live
+output_dir: output/runs/r2dreamer-curriculum-l1-vggt-hybrid-house-points-pose
+run_id: habitat-l1-vggt-hybrid-house-points-pose
+comments:
+  - "Additive hybrid (src/r2dreamer/encoders/mlp.py HybridHousePointsCameraEncoder): rgb64 CNN backbone (the image-only baseline branch, ungated) + zero-init-gated camera-pose and pooled live house-points branches. At init the embedding equals the CNN baseline's information; training must learn to admit the 3D context."
+  - "Same live per-scene buffer + PERSIST_SCENE pipeline as the parent; the adapter (VGGTHybridHousePointsPoseObsAdapter) additionally replays the 64x64 frame per step (uint8, normalized on sample)."
+  - "Motivation: map-as-replacement reached ~half the CNN baseline's success at matched steps (0.34 vs 0.70 @400-650k, docs/notes/2026-07-06-house-points-vs-cnn-baseline-review.md); this tests map-as-addition against the strong baseline. Watch the gate_camera/gate_house params to see whether the world model uses the extra branches."
+args:
+  output_dir: output/runs/r2dreamer-curriculum-l1-vggt-hybrid-house-points-pose/run-${SLURM_JOB_ID}
+  wandb_name: l1_hybrid_house_points_pose-${SLURM_JOB_ID}
+  wandb_tags: curriculum,level1,1house,chair-only,vggt,house-points,live-buffer,camera-pose-replay,point-mlp,cnn-backbone,additive-hybrid,gated,persist-scene,jax,3d-encoder
+smoke:
+  time: "00:30:00"
+  args:
+    # Mirrors the parent's validated smoke shape (1000 prefill + 2000 train,
+    # ~20 min on H100 incl. compile). Gate params start at zero, so the run
+    # should track the CNN baseline's early curve; check house_buffer growth
+    # and that gate_camera/gate_house move off zero in the first train steps.
+    steps: 2000
+    prefill: 1000
+    batch_size: 4
+    seq_len: 16
+    train_ratio: 16
+    log_every: 50
+    checkpoint_every: 1000000
+    output_dir: output/smoke/vggt-hybrid-house-points-pose-live-${TIMESTAMP}
+    wandb_name: vggt-hybrid-house-points-pose-live-smoke-${TIMESTAMP}
+    wandb_tags: house-points,live-buffer,smoke,camera-pose-replay,point-mlp,cnn-backbone,additive-hybrid,gated,persist-scene

--- a/src/r2dreamer/adapters/hybrid_adapter.py
+++ b/src/r2dreamer/adapters/hybrid_adapter.py
@@ -606,14 +606,7 @@ class VGGTHousePointsPoseObsAdapter(ObsAdapter):
         self._env_steps = 0
         self._growth_history: list[tuple[int, int]] = []
         super().__init__(
-            buffer_dtype={CAMERA_POSE_KEY: "float16"},
-            buffer_shape={CAMERA_POSE_KEY: CAMERA_POSE_SHAPE},
-            normalize_on_sample={CAMERA_POSE_KEY: False},
-            agent_obs_shape={
-                CAMERA_POSE_KEY: CAMERA_POSE_SHAPE,
-                HOUSE_CONTEXT_KEY: (self._max_points, HOUSE_POINT_DIM),
-                HOUSE_CONTEXT_SIZE_KEY: (),
-            },
+            **self._observation_contract_kwargs(),
             on_episode_reset=lambda scene_id="scene": extractor.reset_for_scene(scene_id),
         )
         # Scene-aware episode reset. The trainer calls the callback above at
@@ -633,6 +626,29 @@ class VGGTHousePointsPoseObsAdapter(ObsAdapter):
         # frame (the train loop). Only the point buffer persists across
         # episodes; the VGGT cache is saved/restored per scene.
         self._extractor = extractor
+
+    def _observation_contract_kwargs(self) -> dict[str, Any]:
+        """Return the replay/agent observation contract for ``ObsAdapter``.
+
+        Subclasses extend the returned dicts to replay extra per-step fields
+        alongside ``camera_pose`` (the house context itself is injected live,
+        never stored).
+
+        Returns:
+          Keyword arguments (``buffer_dtype``, ``buffer_shape``,
+          ``normalize_on_sample``, ``agent_obs_shape``) for
+          ``ObsAdapter.__init__``.
+        """
+        return {
+            "buffer_dtype": {CAMERA_POSE_KEY: "float16"},
+            "buffer_shape": {CAMERA_POSE_KEY: CAMERA_POSE_SHAPE},
+            "normalize_on_sample": {CAMERA_POSE_KEY: False},
+            "agent_obs_shape": {
+                CAMERA_POSE_KEY: CAMERA_POSE_SHAPE,
+                HOUSE_CONTEXT_KEY: (self._max_points, HOUSE_POINT_DIM),
+                HOUSE_CONTEXT_SIZE_KEY: (),
+            },
+        }
 
     @staticmethod
     def _load_seed(house_points_path: str | None) -> jnp.ndarray | None:
@@ -778,3 +794,37 @@ class VGGTHousePointsPoseObsAdapter(ObsAdapter):
         obs[HOUSE_CONTEXT_KEY] = self._latest_house_context
         obs[HOUSE_CONTEXT_SIZE_KEY] = self._latest_house_context_size
         return dataclasses.replace(batch, obs=obs)
+
+
+class VGGTHybridHousePointsPoseObsAdapter(VGGTHousePointsPoseObsAdapter):
+    """House-points-pose pipeline plus the rgb64 frame in replay.
+
+    Identical live-buffer/PERSIST_SCENE behaviour to the parent; additionally
+    resizes each env frame to 64x64 and stores it per step so the additive
+    hybrid encoder (``HybridHousePointsCameraEncoder``) can run its CNN
+    baseline branch on replayed images. The house context stays
+    live-injected — only ``camera_pose`` and the image are replayed.
+    """
+
+    def _observation_contract_kwargs(self) -> dict[str, Any]:
+        """Extend the parent contract with the rgb64 replay/agent field.
+
+        Returns:
+          ``ObsAdapter.__init__`` kwargs with ``HYBRID_IMAGE_KEY`` added to
+          every observation form (uint8 in replay, normalized on sample).
+        """
+        kwargs = super()._observation_contract_kwargs()
+        kwargs["buffer_dtype"][HYBRID_IMAGE_KEY] = "uint8"
+        kwargs["buffer_shape"][HYBRID_IMAGE_KEY] = IMAGE_SHAPE
+        kwargs["normalize_on_sample"][HYBRID_IMAGE_KEY] = True
+        kwargs["agent_obs_shape"][HYBRID_IMAGE_KEY] = IMAGE_SHAPE
+        return kwargs
+
+    def transform(
+        self, env_obs: ObservationFrame
+    ) -> tuple[dict[str, np.ndarray], dict]:
+        replay, agent_obs = super().transform(env_obs)
+        image64 = resize_chw_uint8(env_obs.image, IMAGE_SIZE)
+        replay[HYBRID_IMAGE_KEY] = image64
+        agent_obs[HYBRID_IMAGE_KEY] = image64
+        return replay, agent_obs

--- a/src/r2dreamer/agent.py
+++ b/src/r2dreamer/agent.py
@@ -53,6 +53,7 @@ from .encoders.mlp import (
 )
 from .encoders.mlp import (
     HousePointsCameraEncoder,
+    HybridHousePointsCameraEncoder,
     WP64CNNCPMLPEncoder,
 )
 from .encoders.mlp import (
@@ -152,6 +153,7 @@ def _resolve_encoder_cls(cfg: R2DreamerConfig):
             "hybrid": WMHybridEncoder,
             "vggt_house_context": WMHybridEncoder,
             "vggt_house_points_pose": HousePointsCameraEncoder,
+            "vggt_hybrid_house_points_pose": HybridHousePointsCameraEncoder,
             "vggt_house_full_tokens_nogate": WMTokenTransformerEncoder,
             "vggt_house_global_tokens_nogate": WMTokenTransformerEncoder,
             "vggt_house_global_embedding": WMHouseGlobalEmbeddingEncoder,
@@ -256,13 +258,20 @@ def _make_house_points_camera_encoder(
     kwargs = _contract_encoder_kwargs(cfg)
     if kwargs:
         return cls(**kwargs)
-    return cls(
+    kwargs = dict(
         embed_dim=cfg.vggt_embed_dim,
         camera_hidden=cfg.mlp_vggt_hidden,
         camera_layers=cfg.mlp_vggt_layers,
         point_hidden=cfg.mlp_vggt_hidden,
         point_layers=cfg.mlp_vggt_layers,
     )
+    if issubclass(cls, HybridHousePointsCameraEncoder):
+        kwargs.update(
+            cnn_depth=cfg.encoder_depth,
+            cnn_kernel=cfg.encoder_kernel,
+            cnn_mults=cfg.encoder_mults,
+        )
+    return cls(**kwargs)
 
 
 def _make_house_global_embedding_encoder(
@@ -408,18 +417,22 @@ def _dummy_encoder_obs(cfg: R2DreamerConfig):
         }
     if cfg.encoder_type in (
         "vggt_house_points_pose",
+        "vggt_hybrid_house_points_pose",
         "gnn_house_points_pose",
         "gnn_edge_house_points_pose",
     ):
         if not isinstance(cfg.obs_shape, Mapping):
             raise TypeError(f"{cfg.encoder_type} expects structured obs_shape")
-        return {
+        dummy = {
             CAMERA_POSE_KEY: jnp.zeros((1, 9), dtype=jnp.float32),
             HOUSE_CONTEXT_KEY: jnp.zeros(
                 (1, *cfg.obs_shape[HOUSE_CONTEXT_KEY]), dtype=jnp.float32
             ),
             HOUSE_CONTEXT_SIZE_KEY: jnp.zeros((), dtype=jnp.int32),
         }
+        if cfg.encoder_type == "vggt_hybrid_house_points_pose":
+            dummy[HYBRID_IMAGE_KEY] = jnp.zeros((1, 3, 64, 64), dtype=jnp.float32)
+        return dummy
     return jnp.zeros((1, *cfg.obs_shape))
 
 

--- a/src/r2dreamer/encoders/__init__.py
+++ b/src/r2dreamer/encoders/__init__.py
@@ -25,7 +25,10 @@ from src.r2dreamer.encoders.gnn_house import (
 from src.r2dreamer.encoders.house_global_embedding import (
     VGGTHouseGlobalEmbeddingEncoder,
 )
-from src.r2dreamer.encoders.house_points_pose import VGGTHousePointsPoseEncoder
+from src.r2dreamer.encoders.house_points_pose import (
+    VGGTHousePointsPoseEncoder,
+    VGGTHybridHousePointsPoseEncoder,
+)
 from src.r2dreamer.encoders.transformer import TokenTransformerEncoder
 
 if TYPE_CHECKING:

--- a/src/r2dreamer/encoders/house_points_pose.py
+++ b/src/r2dreamer/encoders/house_points_pose.py
@@ -12,6 +12,7 @@ import flax.linen as nn
 from src.r2dreamer.encoders.base import VGGTEncoder
 from src.r2dreamer.encoders.mlp import (
     HousePointsCameraEncoder as ModelHousePointsCameraEncoder,
+    HybridHousePointsCameraEncoder as ModelHybridHousePointsCameraEncoder,
 )
 from src.vggt.jax.feature_extractor import ResetMode
 
@@ -79,6 +80,41 @@ class VGGTHousePointsPoseEncoder(VGGTEncoder):
     def _build_adapter_for_extractor(self, extractor):
         adapter_module = import_module("src.r2dreamer.adapters.hybrid_adapter")
         return adapter_module.VGGTHousePointsPoseObsAdapter(
+            extractor,
+            house_points_path=self._house_points_path,
+        )
+
+
+class VGGTHybridHousePointsPoseEncoder(VGGTHousePointsPoseEncoder):
+    """Additive hybrid: rgb64 CNN backbone plus gated live house points + pose.
+
+    Reuses the whole live house-points-pose pipeline (per-scene buffer,
+    PERSIST_SCENE, camera-pose replay) and additionally replays the 64x64
+    frame so the agent-side module can run the image-only CNN baseline as an
+    ungated backbone branch. Zero-init gates on the pose/house branches make
+    the encoder start exactly at the CNN baseline (see
+    docs/notes/2026-07-06-house-points-vs-cnn-baseline-review.md §5).
+    """
+
+    @property
+    def encoder_type(self) -> str:
+        return "vggt_hybrid_house_points_pose"
+
+    @property
+    def module_cls(self) -> type[nn.Module]:
+        return ModelHybridHousePointsCameraEncoder
+
+    @property
+    def design_notes(self) -> str:
+        return (
+            "RGB64 CNN backbone concatenated with zero-init-gated camera-pose "
+            "and pooled live house-points branches; house context injected "
+            "live, image + camera pose replayed."
+        )
+
+    def _build_adapter_for_extractor(self, extractor):
+        adapter_module = import_module("src.r2dreamer.adapters.hybrid_adapter")
+        return adapter_module.VGGTHybridHousePointsPoseObsAdapter(
             extractor,
             house_points_path=self._house_points_path,
         )

--- a/src/r2dreamer/encoders/mlp.py
+++ b/src/r2dreamer/encoders/mlp.py
@@ -203,6 +203,65 @@ class HousePointsCameraEncoder(nn.Module):
         return self._branches(obs)
 
 
+class HybridHousePointsCameraEncoder(HousePointsCameraEncoder):
+    """Additive hybrid: RGB CNN backbone plus gated pose/house-points branches.
+
+    Extends ``HousePointsCameraEncoder`` with the image-only CNN baseline as
+    an ungated backbone branch and puts zero-initialized scalar gates (the
+    ``HybridEncoder`` pattern) on the camera-pose and pooled house-points
+    branches. At initialization the embedding therefore equals
+    ``[cnn_embed | 0 | 0]`` — exactly the information the CNN baseline sees —
+    and training must learn to admit the extra 3D context, so any gain over
+    the baseline is attributable to the map/pose rather than to architecture
+    drift (docs/notes/2026-07-06-house-points-vs-cnn-baseline-review.md §5).
+
+    Consumes ``HYBRID_IMAGE_KEY`` (rgb64) in addition to the parent's
+    ``camera_pose`` / ``house_context`` (+ size) keys; the fused embedding is
+    ``[cnn | gate_camera * camera | gate_house * house]`` of width
+    ``1024 + 2 * embed_dim``.
+    """
+
+    cnn_depth: int = 16
+    cnn_kernel: int = 5
+    cnn_mults: tuple[int, ...] = (2, 3, 4, 4)
+
+    def _hybrid_branches(
+        self, obs: dict[str, jnp.ndarray]
+    ) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+        """Return ``(cnn, gated_camera, gated_house, gate_camera, gate_house)``."""
+        if not isinstance(obs, Mapping):
+            raise TypeError("HybridHousePointsCameraEncoder expects structured obs")
+        cnn_embed = make_rgb_conv_encoder(
+            depth=self.cnn_depth,
+            kernel_size=self.cnn_kernel,
+            mults=self.cnn_mults,
+            name="cnn",
+        )(jnp.asarray(obs[HYBRID_IMAGE_KEY]))
+        camera_embed, house_embed = self._branches(obs)
+        gate_camera = self.param("gate_camera", nn.initializers.zeros, ())
+        gate_house = self.param("gate_house", nn.initializers.zeros, ())
+        return (
+            cnn_embed,
+            gate_camera * camera_embed,
+            gate_house * house_embed,
+            gate_camera,
+            gate_house,
+        )
+
+    @nn.compact
+    def __call__(self, obs: dict[str, jnp.ndarray]) -> jnp.ndarray:
+        """Return fused ``[cnn | gated camera_pose | gated house_points]``."""
+        cnn_embed, camera_embed, house_embed, _, _ = self._hybrid_branches(obs)
+        return jnp.concatenate([cnn_embed, camera_embed, house_embed], axis=-1)
+
+    @nn.compact
+    def branches(
+        self, obs: dict[str, jnp.ndarray]
+    ) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+        """Diagnostic split: ``(cnn, gated_camera, gated_house, gate_camera, gate_house)``."""
+        return self._hybrid_branches(obs)
+
+
 class HouseGlobalEmbeddingEncoder(nn.Module):
     """PointNet-reducer encoder over VGGT global patch tokens + camera token.
 

--- a/src/r2dreamer/launch/registries.py
+++ b/src/r2dreamer/launch/registries.py
@@ -22,6 +22,7 @@ from src.r2dreamer.encoders import (
     VGGTHouseGlobalEmbeddingEncoder,
     VGGTHouseGlobalTokenNoGateEncoder,
     VGGTHousePointsPoseEncoder,
+    VGGTHybridHousePointsPoseEncoder,
 )
 from src.r2dreamer.launch.habitat_setup import make_habitat_env
 
@@ -42,6 +43,7 @@ encoder_registry: dict[str, type[Encoder]] = {
     "hybrid": HybridEncoder,
     "vggt_house_context": VGGTHouseContextEncoder,
     "vggt_house_points_pose": VGGTHousePointsPoseEncoder,
+    "vggt_hybrid_house_points_pose": VGGTHybridHousePointsPoseEncoder,
     "gnn_house_points_pose": GnnHousePointsPoseEncoder,
     "gnn_edge_house_points_pose": GnnEdgeHousePointsPoseEncoder,
     "vggt_house_full_tokens_nogate": VGGTHouseFullTokenNoGateEncoder,

--- a/src/r2dreamer/observation_preparation/contracts.py
+++ b/src/r2dreamer/observation_preparation/contracts.py
@@ -58,6 +58,7 @@ _HANDLED_ENCODER_CLASS_NAMES = frozenset(
         "WP64CNNCPMLPEncoder",
         "HybridEncoder",
         "HousePointsCameraEncoder",
+        "HybridHousePointsCameraEncoder",
         "HouseGlobalEmbeddingEncoder",
         "TokenTransformerEncoder",
     }
@@ -143,6 +144,17 @@ def encoder_module_kwargs_from_config(
             "camera_layers": int(config.mlp_vggt_layers),
             "point_hidden": int(config.mlp_vggt_hidden),
             "point_layers": int(config.mlp_vggt_layers),
+        }
+    if class_name == "HybridHousePointsCameraEncoder":
+        return {
+            "embed_dim": int(config.vggt_embed_dim),
+            "camera_hidden": int(config.mlp_vggt_hidden),
+            "camera_layers": int(config.mlp_vggt_layers),
+            "point_hidden": int(config.mlp_vggt_hidden),
+            "point_layers": int(config.mlp_vggt_layers),
+            "cnn_depth": int(config.encoder_depth),
+            "cnn_kernel": int(config.encoder_kernel),
+            "cnn_mults": _tuple_value(config, "encoder_mults"),
         }
     if class_name == "HouseGlobalEmbeddingEncoder":
         # token_dim (1024) and num_patch_tokens (1369) use the module defaults

--- a/src/r2dreamer/observation_preparation/module_factory.py
+++ b/src/r2dreamer/observation_preparation/module_factory.py
@@ -15,7 +15,11 @@ import jax.numpy as jnp
 
 from src.configs.config import R2DreamerConfig
 from src.r2dreamer.encoders.constants import HYBRID_RGB_DIM
-from src.r2dreamer.encoders.mlp import HouseGlobalEmbeddingEncoder, HousePointsCameraEncoder
+from src.r2dreamer.encoders.mlp import (
+    HouseGlobalEmbeddingEncoder,
+    HousePointsCameraEncoder,
+    HybridHousePointsCameraEncoder,
+)
 from src.r2dreamer.observation_keys import HYBRID_IMAGE_KEY
 from src.r2dreamer.observation_preparation.cnn import CNNObservationPreparation
 from src.r2dreamer.observation_preparation.contracts import (
@@ -64,6 +68,8 @@ def _encoder_module_cls_from_config(cfg: R2DreamerConfig):
         return CNNObservationPreparation().contract.encoder_module_cls
     if cfg.encoder_type == "vggt_house_points_pose":
         return HousePointsCameraEncoder
+    if cfg.encoder_type == "vggt_hybrid_house_points_pose":
+        return HybridHousePointsCameraEncoder
     if cfg.encoder_type == "vggt_house_global_embedding":
         return HouseGlobalEmbeddingEncoder
     spec = VGGT_DREAMER_SPECS.get(cfg.encoder_type)

--- a/tests/r2dreamer/launch/test_encoders.py
+++ b/tests/r2dreamer/launch/test_encoders.py
@@ -19,6 +19,7 @@ from src.r2dreamer.adapters.hybrid_adapter import (
     VGGTHouseFullTokenObsAdapter,
     VGGTHouseGlobalEmbeddingObsAdapter,
     VGGTHousePointsPoseObsAdapter,
+    VGGTHybridHousePointsPoseObsAdapter,
 )
 from src.r2dreamer.encoders import (
     VGGT_VARIANTS,
@@ -33,6 +34,7 @@ from src.r2dreamer.encoders import (
     VGGTHouseFullTokenNoGateEncoder,
     VGGTHouseGlobalEmbeddingEncoder,
     VGGTHousePointsPoseEncoder,
+    VGGTHybridHousePointsPoseEncoder,
     VGGTWP64CNNCPMLPEncoder,
     VGGTWPCP64Encoder,
 )
@@ -1063,6 +1065,70 @@ class TestVGGTHousePointsPoseEncoder:
         seeded_adapter.transform(_house_frame(2))
         # The seed points are registered in the per-scene buffer.
         assert seeded_adapter._buffers["houseA"].points_xyz.shape[0] > 0
+
+
+class TestVGGTHybridHousePointsPoseEncoder:
+    def test_hybrid_adapter_replays_camera_pose_and_image(self, monkeypatch):
+        monkeypatch.setattr(
+            "src.vggt.jax.feature_extractor.JAXVGGTFeatureExtractor",
+            _FakeHousePointsExtractor,
+        )
+        enc = VGGTHybridHousePointsPoseEncoder()
+        adapter = enc.make_adapter()
+        spec = enc.spec()
+
+        replay, agent_obs = adapter.transform(_house_frame(2))
+
+        assert isinstance(adapter, VGGTHybridHousePointsPoseObsAdapter)
+        assert spec.encoder_type == "vggt_hybrid_house_points_pose"
+        assert spec.obs_shape == {
+            CAMERA_POSE_KEY: (9,),
+            HOUSE_CONTEXT_KEY: (HOUSE_CONTEXT_MAX_POINTS, HOUSE_POINT_DIM),
+            HOUSE_CONTEXT_SIZE_KEY: (),
+            HYBRID_IMAGE_KEY: (3, 64, 64),
+        }
+        assert replay.keys() == {CAMERA_POSE_KEY, HYBRID_IMAGE_KEY}
+        assert replay[CAMERA_POSE_KEY].dtype == np.float16
+        assert replay[HYBRID_IMAGE_KEY].dtype == np.uint8
+        assert replay[HYBRID_IMAGE_KEY].shape == (3, 64, 64)
+        assert set(agent_obs) == {
+            CAMERA_POSE_KEY,
+            HOUSE_CONTEXT_KEY,
+            HOUSE_CONTEXT_SIZE_KEY,
+            HYBRID_IMAGE_KEY,
+            "is_first",
+        }
+        assert agent_obs[HYBRID_IMAGE_KEY].shape == (3, 64, 64)
+        assert int(agent_obs[HOUSE_CONTEXT_SIZE_KEY]) > 0
+
+    def test_hybrid_adapter_keeps_live_house_context_injection(self, monkeypatch):
+        monkeypatch.setattr(
+            "src.vggt.jax.feature_extractor.JAXVGGTFeatureExtractor",
+            _FakeHousePointsExtractor,
+        )
+        enc = VGGTHybridHousePointsPoseEncoder()
+        adapter = enc.make_adapter()
+        adapter.transform(_house_frame(2))
+
+        batch = ReplayBatch(
+            obs={
+                CAMERA_POSE_KEY: np.zeros((1, 2, 9), dtype=np.float16),
+                HYBRID_IMAGE_KEY: np.zeros((1, 2, 3, 64, 64), dtype=np.float32),
+            },
+            actions=np.zeros((1, 2), dtype=np.int32),
+            rewards=np.zeros((1, 2), dtype=np.float32),
+            is_episode_end=np.zeros((1, 2), dtype=bool),
+            is_first=np.zeros((1, 2), dtype=np.float32),
+        )
+        augmented = adapter.augment_replay_batch(batch)
+
+        assert set(augmented.obs) == {
+            CAMERA_POSE_KEY,
+            HYBRID_IMAGE_KEY,
+            HOUSE_CONTEXT_KEY,
+            HOUSE_CONTEXT_SIZE_KEY,
+        }
+        assert augmented.obs[HYBRID_IMAGE_KEY].shape == (1, 2, 3, 64, 64)
 
 
 class TestVGGTHouseFullTokenNoGateEncoder:

--- a/tests/r2dreamer/launch/test_registries.py
+++ b/tests/r2dreamer/launch/test_registries.py
@@ -60,6 +60,7 @@ class TestEncoderRegistry:
         assert "hybrid" in encoder_registry
         assert "vggt_house_context" in encoder_registry
         assert "vggt_house_points_pose" in encoder_registry
+        assert "vggt_hybrid_house_points_pose" in encoder_registry
         assert "vggt_house_full_tokens_nogate" in encoder_registry
         assert "vggt_house_global_tokens_nogate" in encoder_registry
 

--- a/tests/r2dreamer/test_agent.py
+++ b/tests/r2dreamer/test_agent.py
@@ -20,6 +20,7 @@ from src.r2dreamer.observation_keys import (
     GLOBAL_PATCH_TOKENS_KEY,
     HOUSE_CONTEXT_KEY,
     HOUSE_CONTEXT_SIZE_KEY,
+    HYBRID_IMAGE_KEY,
 )
 
 
@@ -308,6 +309,38 @@ class TestR2DreamerAgent:
 
         assert np.isfinite(metrics["total_loss"])
         assert "hybrid/vggt_frac" in metrics
+
+    def test_train_step_accepts_hybrid_house_points_with_image(self):
+        cfg = make_tiny_train_cfg(
+            encoder_type="vggt_hybrid_house_points_pose",
+            obs_shape={
+                HYBRID_IMAGE_KEY: (3, 64, 64),
+                CAMERA_POSE_KEY: (9,),
+                HOUSE_CONTEXT_KEY: (HOUSE_CONTEXT_MAX_POINTS, HOUSE_POINT_DIM),
+                HOUSE_CONTEXT_SIZE_KEY: (),
+            },
+        )
+        agent = R2DreamerAgent(cfg, jax.random.PRNGKey(0))
+        batch = ReplayBatch(
+            obs={
+                HYBRID_IMAGE_KEY: jnp.zeros((1, 2, 3, 64, 64), dtype=jnp.float32),
+                CAMERA_POSE_KEY: jnp.zeros((1, 2, 9), dtype=jnp.float16),
+                HOUSE_CONTEXT_KEY: jnp.ones(
+                    (HOUSE_CONTEXT_MAX_POINTS, HOUSE_POINT_DIM), dtype=jnp.float16
+                ),
+                HOUSE_CONTEXT_SIZE_KEY: jnp.asarray(4, dtype=jnp.int32),
+            },
+            actions=jax.nn.one_hot(
+                jnp.zeros((1, 2), dtype=jnp.int32), cfg.num_actions
+            ),
+            rewards=jnp.zeros((1, 2), dtype=jnp.float32),
+            is_first=jnp.ones((1, 2), dtype=jnp.float32),
+            is_episode_end=jnp.zeros((1, 2), dtype=jnp.float32),
+        )
+
+        metrics = agent.train_step(batch, jax.random.PRNGKey(1))
+
+        assert np.isfinite(metrics["total_loss"])
 
     def test_train_step_accepts_live_house_points_with_camera_pose(self):
         cfg = make_tiny_train_cfg(

--- a/tests/r2dreamer/world_model/test_hybrid_encoder.py
+++ b/tests/r2dreamer/world_model/test_hybrid_encoder.py
@@ -10,9 +10,17 @@ import pytest
 
 from src.r2dreamer.encoders.constants import HYBRID_RGB_DIM, HYBRID_VGGT_DIM
 from src.r2dreamer.encoders.decoder import ConvDecoder
-from src.r2dreamer.encoders.mlp import HousePointsCameraEncoder, HybridEncoder
+from src.r2dreamer.encoders.mlp import (
+    HousePointsCameraEncoder,
+    HybridEncoder,
+    HybridHousePointsCameraEncoder,
+)
 from src.r2dreamer.encoders.transformer import TokenTransformerEncoder
-from src.r2dreamer.observation_keys import CAMERA_POSE_KEY, HOUSE_CONTEXT_KEY
+from src.r2dreamer.observation_keys import (
+    CAMERA_POSE_KEY,
+    HOUSE_CONTEXT_KEY,
+    HYBRID_IMAGE_KEY,
+)
 
 
 @pytest.fixture
@@ -105,6 +113,77 @@ class TestHousePointsCameraEncoder:
         assert fused.shape == (3, 16)
         assert jnp.allclose(house_embed[0], house_embed[1])
         assert jnp.allclose(house_embed[0], house_embed[2])
+
+
+class TestHybridHousePointsCameraEncoder:
+    def _make(self):
+        return HybridHousePointsCameraEncoder(
+            embed_dim=8,
+            camera_hidden=8,
+            camera_layers=1,
+            point_hidden=8,
+            point_layers=1,
+            cnn_depth=2,
+            cnn_kernel=3,
+            cnn_mults=(1, 1),
+        )
+
+    def _obs(self, rng, batch=3):
+        k1, k2 = jax.random.split(rng)
+        return {
+            HYBRID_IMAGE_KEY: jax.random.uniform(k1, (batch, 3, 64, 64)),
+            CAMERA_POSE_KEY: jax.random.normal(k2, (batch, 9)).astype(jnp.float16),
+            HOUSE_CONTEXT_KEY: jnp.ones((1, 5, 6), dtype=jnp.float16),
+        }
+
+    def test_output_is_cnn_plus_two_gated_branches(self, rng):
+        enc = self._make()
+        obs = self._obs(rng)
+        params = enc.init(rng, obs)
+
+        fused = enc.apply(params, obs)
+        cnn_e, cam_e, house_e, _, _ = enc.apply(params, obs, method=enc.branches)
+
+        cnn_dim = _cnn_dim(depth=2, mults=(1, 1))
+        assert cnn_e.shape == (3, cnn_dim * 16)  # 2 stages: 64 -> 16 spatial
+        assert cam_e.shape == (3, 8)
+        assert house_e.shape == (3, 8)
+        assert fused.shape == (3, cnn_e.shape[-1] + 16)
+        assert jnp.allclose(fused, jnp.concatenate([cnn_e, cam_e, house_e], axis=-1))
+
+    def test_gates_zero_at_init_so_output_equals_cnn_baseline(self, rng):
+        enc = self._make()
+        obs = self._obs(rng)
+        params = enc.init(rng, obs)
+
+        cnn_e, cam_e, house_e, gate_cam, gate_house = enc.apply(
+            params, obs, method=enc.branches
+        )
+
+        assert float(gate_cam) == 0.0
+        assert float(gate_house) == 0.0
+        assert float(jnp.max(jnp.abs(cam_e))) == 0.0
+        assert float(jnp.max(jnp.abs(house_e))) == 0.0
+        assert float(jnp.max(jnp.abs(cnn_e))) > 0.0
+
+        # Pose/house content is invisible at init: only the image matters.
+        obs_other = dict(obs)
+        obs_other[CAMERA_POSE_KEY] = obs[CAMERA_POSE_KEY] + 1.0
+        obs_other[HOUSE_CONTEXT_KEY] = obs[HOUSE_CONTEXT_KEY] * 2.0
+        assert jnp.allclose(enc.apply(params, obs), enc.apply(params, obs_other))
+
+    def test_singleton_house_cloud_broadcasts_over_batch(self, rng):
+        enc = self._make()
+        obs = self._obs(rng)
+        params = enc.init(rng, obs)
+        # Force the house gate open so the branch is observable.
+        params = jax.tree_util.tree_map(lambda x: x, params)
+        params["params"]["gate_house"] = jnp.ones(())
+
+        _, _, house_e, _, _ = enc.apply(params, obs, method=enc.branches)
+        assert house_e.shape == (3, 8)
+        assert jnp.allclose(house_e[0], house_e[1])
+        assert jnp.allclose(house_e[0], house_e[2])
 
 
 class TestRGBGlobalTokenTransformerEncoder:

--- a/tests/slurm/test_launch.py
+++ b/tests/slurm/test_launch.py
@@ -601,3 +601,17 @@ def test_gnn_smoke_configs_render_stability_gate(variant: str, run_id: str) -> N
     assert "#SBATCH --partition=gpu_h100_short" in rendered
     assert 'export R2DREAMER_HARD_EXIT_ON_FINISH="1"' in rendered
     assert "metrics.csv" in rendered
+
+
+def test_hybrid_house_points_smoke_config_inherits_parent_shape() -> None:
+    # The additive-hybrid variant reuses the parent's validated smoke shape
+    # (1000 prefill + 2000 train) and maps to its own run_id/output tree.
+    rendered = launch.render_sbatch(
+        launch.load_config("hybrid_house_points_pose_l1_live"), mode="smoke"
+    )
+    _, _, positional, flags = training_command(rendered)
+
+    assert positional == "habitat-l1-vggt-hybrid-house-points-pose"
+    assert flags["--steps"] == "2000"
+    assert flags["--prefill"] == "1000"
+    assert "vggt-hybrid-house-points-pose-live" in flags["--output_dir"]


### PR DESCRIPTION
## What

New encoder variant `vggt_hybrid_house_points_pose`: the image-only CNN baseline branch (ungated) concatenated with **zero-init-gated** camera-pose and pooled live house-points branches. At initialization the embedding is information-identical to the CNN baseline; training must learn to open the gates to admit the 3D context — so any gain over the baseline is causally attributable to the map/pose, not architecture drift.

## Why

The map-as-replacement run (job 5741728, `vggt_house_points_pose`) reached ~half the CNN baseline's success at matched env steps (0.34 vs 0.70 success @400–650k). Full analysis, including the flatten-vs-pooling stability experiment that keeps the pooled point head, is in `docs/notes/2026-07-06-house-points-vs-cnn-baseline-review.md` (§5 motivates this additive design).

## How

- `HybridHousePointsCameraEncoder` (`src/r2dreamer/encoders/mlp.py`): `[cnn | gate_camera·pose | gate_house·points]`; `branches()` exposes the gate scalars for logging
- `VGGTHybridHousePointsPoseObsAdapter` (`src/r2dreamer/adapters/hybrid_adapter.py`): same live per-scene buffer / PERSIST_SCENE pipeline; additionally replays the rgb64 frame per step (uint8, normalized on sample). Parent's obs contract extracted into an overridable `_observation_contract_kwargs()` hook
- Wiring: launch registry, agent type map / dummy obs / builder (cnn kwargs for the subclass), module_factory, contract kwargs branch, `_run_configs.py` entry, SLURM config `hybrid_house_points_pose_l1_live.yaml` (inherits the parent's validated smoke shape)
- Review note + flatten-stability experiment script under `docs/notes/`

## Tests

- Module: fused output layout, gates zero at init (pose/house content provably invisible), singleton house-cloud broadcast
- Adapter: replay = `{camera_pose, image}`, live house-context injection unchanged
- Agent: end-to-end `train_step` with image+pose+points batch → finite loss
- Launch: smoke config renders with correct run_id/shape; registry-wide construct-from-contract-kwargs regression passes
- Suites run green: `test_hybrid_encoder.py`, `tests/r2dreamer/launch/`, `test_agent.py`, `tests/slurm/test_launch.py`

## Runs

Smoke 5812467 + prod 5812468 (`afterok`) submitted from this commit; judge by `MANIFEST.json` status, watch `gate_camera`/`gate_house` move off zero and the early success curve tracking the CNN baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)