### PR TITLE
feat(skills): optimize-step-time — interactive step-time optimization loop

### DIFF
--- a/.claude/skills/optimize-step-time/SKILL.md
+++ b/.claude/skills/optimize-step-time/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: optimize-step-time
+description: Interactive optimization loop for training step time (ms/step). Use whenever the user wants training to run faster, asks to optimize/profile step time, names a wandb run to speed up, or says things like "try variants to reduce step time", "why is training slow", "optimize the step cost". The loop measures a baseline from a wandb run, proposes candidate optimizations for the user to select, benchmarks each selected variant on SLURM, and opens a PR summarizing what was tried and measured.
+---
+
+# Optimize step time
+
+A human-in-the-loop optimization cycle:
+
+1. **Baseline** — pull the step-time breakdown of a reference wandb run.
+2. **Propose** — derive candidate optimizations, notify the user, let them
+   select which to try (AskUserQuestion, multiSelect).
+3. **Experiment** — implement each selected variant minimally, benchmark it
+   on SLURM with a prod-shaped probe, judge by MANIFEST.json.
+4. **Report** — open a PR: results table, winners kept, losers documented.
+
+Run the whole loop on one feature branch. Track state in
+`.scratch/optimize-step-time/<run-id>.md` (repo issue-tracker convention,
+see `docs/agents/issue-tracker.md`) so an interrupted loop can resume.
+
+## Phase 0 — Baseline
+
+Input: a wandb run path like `sailer-luca-university-ulm/3d-vla-objectnav/fvwuoux3`.
+If the user gave none, ask which run is the reference before doing anything else.
+
+Fetch the measured step time with the bundled script (login node is fine —
+this is wandb API I/O, no GPU):
+
+```bash
+.venv/bin/python .claude/skills/optimize-step-time/scripts/fetch_step_time.py \
+    <entity>/<project>/<run_id>
+```
+
+It prints post-warmup median/p10/p90 of `perf/ms_per_step_interval`, the run
+config, and any timing keys in the run summary. If wandb is unreachable or the
+run was offline, fall back to the run dir's `output/**/metrics.csv` — note it
+is long-format `[step, key, value]` and **not step-sorted**; filter the key,
+sort by step, drop the warmup prefix before computing stats.
+
+The wandb ms/step is a whole-step number. To attribute it to components,
+check `run.summary` timing keys first, then — only if attribution is genuinely
+unclear — launch a profiling probe (`scripts/slurm/launch.sh
+profile_training_vggt --smoke`, see `scripts/profiling/README.md`). Known
+reference point: the house-points-pose production shape measured ~219 ms/step
+≈ VGGT encoder 132 ms + `ReplayBuffer.sample` 59 ms amortized + rest. Re-derive
+rather than assume — the codebase moves.
+
+## Phase 1 — Propose variants and let the user pick
+
+From the breakdown, write 3–6 candidate optimizations. Each candidate needs:
+
+- **Name** — short slug, becomes the config/commit name.
+- **Hypothesis** — which component it attacks and why it should help.
+- **Expected saving** — rough ms/step, tied to the measured breakdown.
+- **Risk** — what could regress (loss quality, memory, correctness).
+- **Cost to test** — smoke-only vs. prod-shaped probe.
+
+Candidates the user explicitly named in their request always go on the list.
+Then hand the decision to the user:
+
+1. Load `PushNotification` via ToolSearch and send a short notification that
+   options are ready ("Step-time optimization: N candidates ready to pick").
+2. Call `AskUserQuestion` with `multiSelect: true`, one option per candidate
+   (label = name, description = hypothesis + expected saving + risk).
+
+Do not start implementing before the user has selected. This gate is the
+point of the skill — the user decides what GPU time gets spent on.
+
+## Phase 2 — Try each selected variant
+
+For each selected candidate, in sequence:
+
+1. **Implement the minimal diff.** One candidate = one commit. Prefer a
+   config-gated change (new flag defaulting to old behavior) over an
+   unconditional rewrite — losers are then trivially revertible and winners
+   can ship dark. Follow repo preferences (JAX over NumPy, bfloat16 defaults,
+   Google-style docstrings on touched functions only).
+2. **Create a probe config** `scripts/slurm/configs/<name>_probe.yaml`
+   modeled on the existing `*_prodshape_probe_*.yaml` files: production
+   shapes, short walltime. Smoke shapes understate real step cost (a past
+   variant read 158 ms in smoke vs 219 ms at prod shape), so measure at prod
+   shape whenever the change touches anything shape-dependent.
+3. **Launch:** `bash scripts/slurm/launch.sh <name>_probe --time 01:00:00`
+   (or `--smoke` for a cheap correctness gate first). Poll with a background
+   Bash loop on `squeue -h -j <jobid>`; queue waits can be long, so keep
+   working on the next candidate's implementation while a probe runs.
+4. **Judge by MANIFEST.json, not the SLURM exit code** — habitat's GL
+   teardown can poison exit codes after a fully successful run. The run dir's
+   `MANIFEST.json` gains `"status": "completed"` on success. No manifest end
+   or a non-completed status = failed probe; read the SLURM log for the
+   traceback.
+5. **Measure:** post-warmup median `perf/ms_per_step_interval` from the
+   probe's metrics (same fetch script if the probe ran wandb online,
+   otherwise `metrics.csv`). Also record the loss curves' sanity — a variant
+   that is fast but diverges is a loser.
+6. **Record** the result in the `.scratch/optimize-step-time/<run-id>.md`
+   file immediately: name, commit SHA, job id, ms/step, Δ vs baseline,
+   verdict (keep / revert / needs-longer-run), one-line note.
+
+If a probe fails for a fixable reason (OOM, config typo), fix and relaunch
+once; a second failure marks the candidate `failed` with the reason — don't
+sink the loop into one stubborn variant.
+
+## Phase 3 — PR
+
+When all selected candidates have a verdict:
+
+1. Revert or default-off the losers (keep their probe configs and the issue
+   file — negative results are findings too).
+2. Commit remaining work; push the branch; open a PR against `main` with
+   `gh pr create`. PR body template:
+
+```markdown
+## Step-time optimization: <baseline run id>
+
+Baseline: <ms/step> ms/step (median, post-warmup) — <wandb run link>
+
+| Variant | Hypothesis | ms/step | Δ | Verdict |
+|---|---|---|---|---|
+| <name> | <one line> | <n> | <-x ms / +x ms> | kept / reverted / failed |
+
+## Details
+<per-variant: what was changed, probe job id, wandb link, caveats>
+
+## Not tried
+<candidates the user deselected, for the record>
+```
+
+3. Notify the user (PushNotification) with the PR URL and the headline
+   number: best variant's ms/step vs baseline.
+
+## Ground rules
+
+- Never run VGGT/Habitat/JAX-GPU work on the login node — everything through
+  `scripts/slurm/launch.sh` (canonical launcher; ignore legacy
+  `scripts/r2dreamer/slurm/*.sbatch`).
+- One wandb run of GPU time per candidate probe; don't launch prod-length
+  (2M-step) runs from this skill — recommend one in the PR instead if a
+  winner deserves final validation.
+- Compare like with like: probe vs. probe at identical shapes, never probe
+  vs. the baseline's full prod run without noting the shape difference.

--- a/.claude/skills/optimize-step-time/scripts/fetch_step_time.py
+++ b/.claude/skills/optimize-step-time/scripts/fetch_step_time.py
@@ -1,0 +1,123 @@
+"""Fetch step-time statistics for a wandb run.
+
+Prints post-warmup median/p10/p90 of the step-time metric, selected config
+fields, and any timing-related keys found in the run summary. Host-side I/O
+only — plain NumPy, no JAX, safe on the login node.
+
+Usage:
+    .venv/bin/python fetch_step_time.py <entity>/<project>/<run_id> \
+        [--key perf/ms_per_step_interval] [--warmup-frac 0.1]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import numpy as np
+
+STEP_KEY_DEFAULT = "perf/ms_per_step_interval"
+TIMING_HINTS = ("time", "ms", "fps", "perf", "duration")
+
+
+def fetch_series(run, key: str, samples: int) -> np.ndarray:
+    """Fetches a sampled history series for one metric.
+
+    Uses wandb's server-side sampling (one request) instead of
+    ``scan_history``, which pages through the full history and takes
+    minutes on multi-million-step runs.
+
+    Args:
+      run: A ``wandb.apis.public.Run`` object.
+      key: History key to extract, e.g. ``perf/ms_per_step_interval``.
+      samples: Number of points to sample across the run, spread evenly
+        by the server over the logged steps.
+
+    Returns:
+      float64 array of the metric's sampled values ordered by logged
+      step; empty array if the key never appears.
+    """
+    rows = run.history(keys=["_step", key], samples=samples, pandas=False)
+    values = [row[key] for row in rows if row.get(key) is not None]
+    return np.asarray(values, dtype=np.float64)
+
+
+def print_stats(series: np.ndarray, key: str, warmup_frac: float) -> None:
+    """Prints post-warmup summary statistics for a metric series.
+
+    Args:
+      series: Metric values ordered by step.
+      key: Metric name, used only for labeling the output.
+      warmup_frac: Leading fraction of points dropped as warmup (JIT
+        compilation, cache fill) before computing statistics.
+    """
+    n_warm = int(len(series) * warmup_frac)
+    body = series[n_warm:]
+    if body.size == 0:
+        print(f"  {key}: no data after dropping {n_warm} warmup points")
+        return
+    p10, p50, p90 = np.percentile(body, [10, 50, 90])
+    print(f"  {key}  (n={body.size}, dropped {n_warm} warmup points)")
+    print(f"    median: {p50:.1f}   p10: {p10:.1f}   p90: {p90:.1f}")
+    print(f"    mean:   {body.mean():.1f} ± {body.std():.1f}")
+
+
+def main() -> int:
+    """Entry point: fetches a run and prints its step-time profile.
+
+    Returns:
+      Process exit code: 0 on success, 1 if the run or metric is missing.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("run_path", help="entity/project/run_id")
+    parser.add_argument("--key", default=STEP_KEY_DEFAULT)
+    parser.add_argument("--warmup-frac", type=float, default=0.1)
+    parser.add_argument("--samples", type=int, default=2000)
+    args = parser.parse_args()
+
+    import wandb
+
+    api = wandb.Api()
+    try:
+        run = api.run(args.run_path)
+    except Exception as exc:  # noqa: BLE001 — wandb raises several types here
+        print(f"error: cannot fetch run {args.run_path!r}: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"run: {'/'.join(run.path)}  state={run.state}  name={run.name}")
+    print(f"url: {run.url}")
+
+    interesting_cfg = {
+        k: v
+        for k, v in (run.config or {}).items()
+        if any(s in k.lower() for s in ("encoder", "batch", "step", "budget", "dtype"))
+    }
+    if interesting_cfg:
+        print("config (shape-relevant):")
+        for k, v in sorted(interesting_cfg.items()):
+            print(f"  {k}: {v}")
+
+    series = fetch_series(run, args.key, args.samples)
+    print("history:")
+    if series.size:
+        print_stats(series, args.key, args.warmup_frac)
+    else:
+        print(f"  {args.key}: not logged in this run")
+
+    timing_summary = {
+        k: v
+        for k, v in dict(run.summary).items()
+        if not k.startswith("_")
+        and any(s in k.lower() for s in TIMING_HINTS)
+        and isinstance(v, (int, float))
+    }
+    if timing_summary:
+        print("summary timing keys:")
+        for k, v in sorted(timing_summary.items()):
+            print(f"  {k}: {v:.3f}")
+
+    return 0 if series.size else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

New project skill `.claude/skills/optimize-step-time/` — a human-in-the-loop optimization cycle for training step time:

1. **Baseline** — pull post-warmup ms/step stats from a reference wandb run (bundled `fetch_step_time.py`, sampled history, login-node safe).
2. **Propose** — derive 3–6 candidate optimizations from the breakdown, send a push notification, and let the user select which to try (`AskUserQuestion`, multi-select). No GPU time is spent before the user picks.
3. **Experiment** — one commit per selected variant (config-gated where possible), benchmarked via `scripts/slurm/launch.sh <name>_probe` at production shapes, judged by `MANIFEST.json` status (not SLURM exit code). Results tracked in `.scratch/optimize-step-time/<run-id>.md`.
4. **Report** — PR with a results table (variant / hypothesis / ms/step / Δ / verdict), losers reverted but documented.

## Verified

`fetch_step_time.py` tested against the live baseline run [fvwuoux3](https://wandb.ai/sailer-luca-university-ulm/3d-vla-objectnav/runs/fvwuoux3): median **184.3 ms/step** (p10 177.8, p90 190.5, n=1800 post-warmup). Initial `scan_history` version timed out on the 2M-step run; switched to server-side sampled `run.history()` (~0.3 s).

## Notes

- Files force-added since `.claude/` is gitignored — same convention as the tracked hooks/settings.
- Encodes repo-specific pitfalls: smoke-shape step times understate prod (158 vs 219 ms precedent), `metrics.csv` is long-format and not step-sorted, habitat GL teardown poisons exit codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)