### PR TITLE
perf(step-time): full_bf16 gate — −25% JAX train_step (baseline fvwuoux3)

### DIFF
--- a/.scratch/optimize-step-time/fvwuoux3.md
+++ b/.scratch/optimize-step-time/fvwuoux3.md
@@ -1,0 +1,110 @@
+# Step-time optimization loop — baseline fvwuoux3
+
+Status: ready-for-agent (selection received 2026-07-07)
+
+## Selected
+
+1. **pipeline-full-bf16** (user-proposed): make the entire JAX pipeline run
+   bfloat16 end-to-end — find and convert remaining float32 (params, obs
+   transform, replay batch dtypes, house buffers), config-gated.
+2. **replay-vectorized-storage**: preallocated contiguous arrays + windowed
+   gather instead of per-transition deepcopy objects.
+
+Deselected: vggt-extract-every-2, vggt-compile-fp16, vggt-resolution-down,
+vggt-kv-budget-trim, replay-async-prefetch.
+
+## Baseline
+
+- Run: `sailer-luca-university-ulm/3d-vla-objectnav/fvwuoux3`
+  (l1_hybrid_house_points_pose-5812468, state=running, 2M steps, batch 16, bf16)
+- Measured 2026-07-07 via `fetch_step_time.py`, n=1800 post-warmup samples:
+  **median 184.3 ms/step** (p10 177.8, p90 190.5, mean 184.0 ± 12.9)
+- Attribution (from sibling prod-shape profile, job 5762154,
+  `docs/notes/house-points-pose-profiling.md`): vggt_extract ~132 ms (62%),
+  replay_sample ~59 ms amortized (27%), train_step ~20 ms (9%), agent_act +
+  env_step + house glue ~7 ms. Hybrid run sits at 184 vs 219 for the pure
+  house-points-pose shape; same loop structure, VGGT still the floor.
+
+## Candidates proposed
+
+| # | Name | Attacks | Expected | Risk |
+|---|------|---------|----------|------|
+| 1 | replay-vectorized-storage | replay_sample 59 ms | up to −50 ms (~27%) | batch-assembly correctness (episode boundaries, dtypes) |
+| 2 | replay-async-prefetch | replay_sample 59 ms | −20–40 ms (overlap, bounded) | threading/ordering complexity |
+| 3 | vggt-extract-every-2 | vggt_extract 132 ms | ~−60 ms at K=2 | staler points/pose → quality regression |
+| 4 | vggt-resolution-down | vggt_extract 132 ms | −30–60 ms | coarser geometry, worse house map |
+| 5 | vggt-compile-fp16 | vggt_extract 132 ms | −20–40 ms | compile warmup, numeric drift, KV-cache graph breaks |
+| 6 | vggt-kv-budget-trim | vggt_extract attention | −10–25 ms | multi-frame consistency loss |
+
+Prior art: `scripts/profiling/profile_jax_replay_buffer.py`, modal-replay
+configs (replay side); `ReplayBuffer` object store with `deepcopy` per `add`
+at `src/buffer/replay_buffer.py:251`.
+
+## Results
+
+| Variant | Commit | Job | ms/step | Δ vs 184.3 | Verdict |
+|---|---|---|---|---|---|
+| replay-vectorized-storage | 84e4b3b (pre-existing) | — | — | — | already-landed |
+| control probe (unmodified) | branch feat/step-time-opt-fvwuoux3 | 5837512, 5838392 | — | — | failed (infra) |
+| pipeline-full-bf16 (full probe) | 70e3311 | 5838214 | — | — | failed (infra) |
+| pipeline-full-bf16 (train_step microbench) | e81997d | 5839014 | 44.82 (train_step) | −15.1 ms/call (−25.2%) | keep (gated, default off) |
+
+### Result (H100, prod shape B=16 T=64, 262k house points, n=50)
+- float32 train_step: 59.95 ms/call median (p10 59.4, p90 61.0)
+- full_bf16 train_step: 44.82 ms/call median (p10 44.0, p90 50.0)
+- **−15.13 ms/call (−25.2%)** on the JAX train_step.
+- Env-step projection: at train_ratio 512 the profile amortized train_step at
+  0.5 call/env-step, so ≈ **−7.6 ms/env-step, ~4% of the 184 ms baseline**.
+  (Projection, not an end-to-end measurement — the full training probe that
+  would confirm it is blocked by the venv/habitat infra issue above.)
+- Verdict **keep, gated default-off**: real gain, ships dark safely. Loss-quality
+  parity needs a full training run once the venv is repaired — recommended in PR,
+  not flipped on here.
+
+### Infra blocker: full training probes can't run
+Both full-shape training probes died at env init, NOT in my code:
+- Prod-mode `scripts/slurm/launch.sh` runs `uv run python`, which re-syncs the
+  shared `.venv` ("Uninstalled 37 / Installed 37 packages"; venv had drifted —
+  "missing RECORD file" warnings from out-of-band pip installs). The re-sync
+  leaves habitat un-importable under the locked numpy 2.4.6
+  (`habitat/utils/visualizations/maps.py:44` `.squeeze(1)` raises on a
+  non-size-1 axis). The live baseline 5812468 survives only because it imported
+  habitat before the churn. Repairing the shared venv (`uv sync` / numpy pin)
+  is a destructive action on shared state with a 29h run live on it — NOT done
+  unilaterally; flagged for the user.
+
+### Pivot: isolate what full_bf16 actually changes
+full_bf16 touches only the JAX model compute (encoders/RSSM/heads/optimizer),
+never torch VGGT (132 ms) or the host replay sampler (59 ms). A full training
+probe would bury the effect under those fixed costs anyway. So measure the JAX
+`train_step` directly with a synthetic prod-shape batch — no habitat import,
+`.venv/bin/python` directly (no uv sync). Script:
+`scripts/profiling/profile_full_bf16_step.py` (+ .sbatch), job 5839014.
+CPU tiny-shape smoke already shows the mechanism: the 262k-point house MLP
+dominates train_step and bf16 ~halves it (-45% train_step on CPU).
+
+### Notes
+- **full_bf16 implemented** (70e3311): cfg.full_bf16 gate threads compute_dtype
+  through ConvEncoder / HousePointsCameraEncoder+Hybrid / Deter+BlockLinear /
+  R2RSSM / R2MLP. float32 master params, float32-pinned RSSM+head logits,
+  float32 RMSNorm stats, GNN float32 exemption kept. CPU verified: default path
+  62 tests pass; gate smoke confirms encoder emits bf16 on / float32 off, both
+  finite over 4 train steps, params stay float32, act() works.
+- **Audit finding:** compute_dtype was a near no-op outside the token
+  transformer — CNN/house/pose encoders hard-cast inputs to float32. So the
+  baseline fvwuoux3 (bfloat16 config) was really training float32 end-to-end;
+  full_bf16 is the first real reduced-precision path for this encoder family.
+- **Worktree infra fix:** first control probe (5837512) crashed on habitat
+  import — the worktree had broken *local* .venv/data/output dirs instead of
+  symlinks to the main checkout. Fixed via scripts/setup_worktree.sh; both
+  probes re-launched (control 5838392, bf16 5838214).
+
+- **replay-vectorized-storage: already implemented on main.**
+  `src/buffer/replay_buffer.py` was converted to structure-of-arrays ring
+  storage with vectorized fancy-index gather on 2026-07-04 (84e4b3b,
+  "finish ReplayBatch attribute migration + buffer SoA storage") — citing
+  the exact 119 ms/batch profiling finding this candidate targeted. The
+  baseline run fvwuoux3 (started 2026-07-06 from 3a86501, descendant of
+  84e4b3b) already contains it. The 219→184 ms drop vs the 07-04 profile
+  is consistent with this win (attribution imperfect: encoder also changed
+  house-points-pose → hybrid). No further work; candidate closed.

--- a/scripts/profiling/profile_full_bf16_step.py
+++ b/scripts/profiling/profile_full_bf16_step.py
@@ -1,0 +1,190 @@
+"""Microbenchmark: JAX ``train_step`` cost with and without the ``full_bf16`` gate.
+
+``full_bf16`` only changes the JAX model compute (encoders, RSSM, heads,
+optimizer math) — it does not touch the torch VGGT extractor (~132 ms/step)
+or the host-side replay sampler (~59 ms/step amortized). So a full training
+probe would bury the effect under those fixed costs. This entrypoint isolates
+what the gate actually changes: it builds the hybrid house-points-pose agent
+at production shape, feeds a synthetic ``ReplayBatch``, and times the JIT
+``train_step`` for the gate off vs. on. It never imports habitat, so it runs
+on the shared ``.venv`` even when the habitat/numpy stack is unimportable.
+
+Run on a GPU node with the worktree-local interpreter (no ``uv`` sync):
+
+    .venv/bin/python -m scripts.profiling.profile_full_bf16_step \
+        --batch 16 --seq 64 --iters 50
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+
+import jax
+import jax.numpy as jnp
+
+from src.buffer.replay_buffer import ReplayBatch
+from src.configs.agent_config import R2DreamerConfig
+from src.r2dreamer.agent import R2DreamerAgent
+from src.r2dreamer.encoders.constants import (
+    HOUSE_CONTEXT_MAX_POINTS,
+    HOUSE_POINT_DIM,
+)
+from src.r2dreamer.observation_keys import (
+    CAMERA_POSE_KEY,
+    HOUSE_CONTEXT_KEY,
+    HOUSE_CONTEXT_SIZE_KEY,
+    HYBRID_IMAGE_KEY,
+)
+
+CAMERA_POSE_DIM = 9
+
+
+def build_agent(full_bf16: bool, num_actions: int) -> R2DreamerAgent:
+    """Build the prod-shape hybrid agent with the ``full_bf16`` gate set.
+
+    Args:
+      full_bf16: Whether to enable the model-wide bfloat16 compute gate.
+      num_actions: Discrete action count (habitat objectnav uses 4).
+
+    Returns:
+      An initialized ``R2DreamerAgent`` using production encoder defaults.
+    """
+    cfg = R2DreamerConfig(
+        encoder_type="vggt_hybrid_house_points_pose",
+        obs_shape={
+            HYBRID_IMAGE_KEY: (3, 64, 64),
+            CAMERA_POSE_KEY: (CAMERA_POSE_DIM,),
+            HOUSE_CONTEXT_KEY: (HOUSE_CONTEXT_MAX_POINTS, HOUSE_POINT_DIM),
+            HOUSE_CONTEXT_SIZE_KEY: (),
+        },
+        num_actions=num_actions,
+        compute_dtype="bfloat16",
+        full_bf16=full_bf16,
+        warmup_steps=0,
+    )
+    return R2DreamerAgent(cfg, jax.random.PRNGKey(0))
+
+
+def make_batch(rng, batch: int, seq: int, num_actions: int, house_size: int):
+    """Build a synthetic production-shape replay batch.
+
+    Args:
+      rng: PRNG key.
+      batch: Batch dimension B.
+      seq: Sequence length T.
+      num_actions: Discrete action count for the one-hot actions.
+      house_size: Valid-point count written into the size field (does not
+        change compute — all snapshot rows run through the point MLP).
+
+    Returns:
+      A ``ReplayBatch`` with the hybrid house-points-pose observation layout.
+    """
+    k1, k2, k3, k4 = jax.random.split(rng, 4)
+    return ReplayBatch(
+        obs={
+            HYBRID_IMAGE_KEY: jax.random.uniform(k1, (batch, seq, 3, 64, 64)),
+            CAMERA_POSE_KEY: jax.random.normal(
+                k2, (batch, seq, CAMERA_POSE_DIM)
+            ).astype(jnp.float16),
+            HOUSE_CONTEXT_KEY: jax.random.normal(
+                k3, (HOUSE_CONTEXT_MAX_POINTS, HOUSE_POINT_DIM)
+            ).astype(jnp.float16),
+            HOUSE_CONTEXT_SIZE_KEY: jnp.asarray(house_size, dtype=jnp.int32),
+        },
+        actions=jax.nn.one_hot(
+            jax.random.randint(k4, (batch, seq), 0, num_actions), num_actions
+        ),
+        rewards=jax.random.normal(k4, (batch, seq)),
+        is_first=jnp.zeros((batch, seq)).at[:, 0].set(1.0),
+        is_episode_end=jnp.zeros((batch, seq)),
+    )
+
+
+def time_train_step(agent, batch, iters: int, warmup: int) -> list[float]:
+    """Time ``iters`` JIT train steps after ``warmup`` compile/warm iterations.
+
+    Args:
+      agent: Built agent to step.
+      batch: Fixed synthetic batch reused every step.
+      iters: Number of timed steps.
+      warmup: Number of untimed warmup steps (covers JIT compilation).
+
+    Returns:
+      Per-step wall-clock times in milliseconds.
+    """
+    for i in range(warmup):
+        m = agent.train_step(batch, jax.random.PRNGKey(1000 + i))
+        jax.block_until_ready(m)
+    times = []
+    for i in range(iters):
+        t0 = time.perf_counter()
+        m = agent.train_step(batch, jax.random.PRNGKey(i))
+        jax.block_until_ready(m)
+        times.append((time.perf_counter() - t0) * 1000.0)
+    return times
+
+
+def summarize(label: str, times: list[float]) -> float:
+    """Print and return the median of a per-step timing list.
+
+    Args:
+      label: Row label for the printout.
+      times: Per-step times in milliseconds.
+
+    Returns:
+      The median step time in milliseconds.
+    """
+    med = statistics.median(times)
+    p10 = statistics.quantiles(times, n=10)[0]
+    p90 = statistics.quantiles(times, n=10)[-1]
+    print(
+        f"{label:>14}: median {med:7.2f} ms  p10 {p10:7.2f}  p90 {p90:7.2f}  "
+        f"(n={len(times)})"
+    )
+    return med
+
+
+def main() -> None:
+    """Run the gate-off vs gate-on train_step benchmark and print the delta."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--batch", type=int, default=16)
+    parser.add_argument("--seq", type=int, default=64)
+    parser.add_argument("--iters", type=int, default=50)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--num-actions", type=int, default=4)
+    parser.add_argument("--house-size", type=int, default=200_000)
+    args = parser.parse_args()
+
+    print(f"devices: {jax.devices()}")
+    print(
+        f"shape: B={args.batch} T={args.seq} "
+        f"house_points={HOUSE_CONTEXT_MAX_POINTS} "
+        f"iters={args.iters} warmup={args.warmup}"
+    )
+    batch = make_batch(
+        jax.random.PRNGKey(7), args.batch, args.seq, args.num_actions, args.house_size
+    )
+
+    results = {}
+    for full_bf16 in (False, True):
+        agent = build_agent(full_bf16, args.num_actions)
+        # Confirm the gate actually took effect on the encoder output.
+        embed = agent.encoder_mod.apply(agent.params["encoder"], batch.obs)
+        label = "full_bf16" if full_bf16 else "float32"
+        print(f"{label} encoder embed dtype: {embed.dtype}")
+        times = time_train_step(agent, batch, args.iters, args.warmup)
+        results[label] = summarize(label, times)
+
+    base, gated = results["float32"], results["full_bf16"]
+    delta = gated - base
+    pct = 100.0 * delta / base if base else 0.0
+    print(
+        f"\ntrain_step delta (full_bf16 - float32): {delta:+.2f} ms/step "
+        f"({pct:+.1f}%)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/profiling/profile_full_bf16_step.sbatch
+++ b/scripts/profiling/profile_full_bf16_step.sbatch
@@ -1,0 +1,26 @@
+#!/bin/bash
+#SBATCH --job-name=profile-full-bf16-step
+#SBATCH --partition=gpu_h100_il,gpu_h100
+#SBATCH --gres=gpu:1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=64G
+#SBATCH --time=00:20:00
+#SBATCH --output=output/probes/step-time-opt/full-bf16-microbench/slurm-%j.out
+#SBATCH --error=output/probes/step-time-opt/full-bf16-microbench/slurm-%j.err
+
+# Direct worktree-local interpreter — deliberately NOT `uv run python`, which
+# re-syncs (and here corrupts) the shared .venv. This microbench imports only
+# the JAX stack, never habitat, so the broken habitat/numpy import is irrelevant.
+set -euo pipefail
+mkdir -p output/probes/step-time-opt/full-bf16-microbench
+
+export XLA_PYTHON_CLIENT_PREALLOCATE=false
+export XLA_PYTHON_CLIENT_MEM_FRACTION=0.7
+export JAX_PLATFORMS=""
+
+echo "Job $SLURM_JOB_ID on $(hostname) at $(date)"
+nvidia-smi --query-gpu=name --format=csv,noheader || true
+
+.venv/bin/python -m scripts.profiling.profile_full_bf16_step \
+    --batch 16 --seq 64 --iters 50 --warmup 5

--- a/scripts/slurm/configs/hybrid_hpp_bf16_prodshape_probe.yaml
+++ b/scripts/slurm/configs/hybrid_hpp_bf16_prodshape_probe.yaml
@@ -1,0 +1,10 @@
+extends: hybrid_hpp_prodshape_probe
+job_name: vggt-hybrid-hpp-bf16-prodshape-probe
+output_dir: output/probes/step-time-opt/hybrid-bf16-prodshape
+comments:
+  - "Step-time optimization pipeline-full-bf16 probe: identical to hybrid_hpp_prodshape_probe except full_bf16=true — the whole JAX model (CNN backbone, house/pose MLPs, RSSM, heads) computes in bfloat16 with float32 master params and float32-pinned logits. Probe-vs-probe partner of the control; see .scratch/optimize-step-time/fvwuoux3.md."
+args:
+  full_bf16: true
+  output_dir: output/probes/step-time-opt/hybrid-bf16-prodshape/run-${SLURM_JOB_ID}
+  wandb_name: hybrid-bf16-prodshape-probe-${SLURM_JOB_ID}
+  wandb_tags: step-time-opt,prodshape-probe,full-bf16,hybrid,b16,t64,ratio512,seed-42

--- a/scripts/slurm/configs/hybrid_hpp_prodshape_probe.yaml
+++ b/scripts/slurm/configs/hybrid_hpp_prodshape_probe.yaml
@@ -1,0 +1,21 @@
+extends: hybrid_house_points_pose_l1_live
+job_name: vggt-hybrid-hpp-prodshape-probe
+output_dir: output/probes/step-time-opt/hybrid-control-prodshape
+comments:
+  - "Step-time optimization control probe (baseline fvwuoux3 = 184.3 ms/step median): unmodified hybrid house-points-pose at explicit production shape, short walltime. Probe-vs-probe partner of hybrid_hpp_bf16_prodshape_probe; see .scratch/optimize-step-time/fvwuoux3.md."
+sbatch:
+  time: "01:00:00"
+args:
+  steps: 8000
+  prefill: 5000
+  batch_size: 16
+  seq_len: 64
+  train_ratio: 512
+  seed: 42
+  log_every: 100
+  checkpoint_every: 1000000
+  video_log_every: 0
+  val_every: 0
+  output_dir: output/probes/step-time-opt/hybrid-control-prodshape/run-${SLURM_JOB_ID}
+  wandb_name: hybrid-control-prodshape-probe-${SLURM_JOB_ID}
+  wandb_tags: step-time-opt,prodshape-probe,control,hybrid,b16,t64,ratio512,seed-42

--- a/src/configs/agent_config.py
+++ b/src/configs/agent_config.py
@@ -109,6 +109,12 @@ class R2DreamerConfig:
     design_notes: str = ""
     encoder_input_contract: dict[str, Any] | None = None
     compute_dtype: str = "bfloat16"
+    # Extend compute_dtype from the token transformer + replay scalars to the
+    # whole JAX model (encoders, RSSM, heads) — mixed precision with float32
+    # master params and float32-pinned logits. Off by default because
+    # compute_dtype was historically a near no-op for CNN/house encoders and
+    # existing runs compare against that behavior.
+    full_bf16: bool = False
 
     # --- MLP heads ---
     mlp_units: int = 256

--- a/src/r2dreamer/agent.py
+++ b/src/r2dreamer/agent.py
@@ -111,6 +111,22 @@ class R2DTrainState(NamedTuple):
 # ---------------------------------------------------------------------------
 
 
+def _model_compute_dtype(cfg: R2DreamerConfig):
+    """Resolve the model-wide compute dtype for the ``full_bf16`` gate.
+
+    Args:
+      cfg: Agent config supplying ``full_bf16`` and ``compute_dtype``.
+
+    Returns:
+      ``compute_dtype`` as a jnp dtype when ``cfg.full_bf16`` is set,
+      otherwise ``jnp.float32`` (the historical behavior, where only the
+      token transformer and replay scalars honored ``compute_dtype``).
+    """
+    if getattr(cfg, "full_bf16", False):
+        return compute_jnp_dtype(cfg.compute_dtype)
+    return jnp.float32
+
+
 def _make_rssm(cfg: R2DreamerConfig) -> R2RSSM:
     return R2RSSM(
         deter_size=cfg.deter_size,
@@ -123,6 +139,7 @@ def _make_rssm(cfg: R2DreamerConfig) -> R2RSSM:
         obs_layers=cfg.obs_layers,
         img_layers=cfg.img_layers,
         unimix_ratio=cfg.unimix_ratio,
+        compute_dtype=_model_compute_dtype(cfg),
     )
 
 
@@ -192,6 +209,7 @@ def _make_conv_encoder(cfg: R2DreamerConfig):
         depth=cfg.encoder_depth,
         kernel_size=cfg.encoder_kernel,
         mults=cfg.encoder_mults,
+        compute_dtype=_model_compute_dtype(cfg),
     )
 
 
@@ -266,6 +284,7 @@ def _make_house_points_camera_encoder(
         camera_layers=cfg.mlp_vggt_layers,
         point_hidden=cfg.mlp_vggt_hidden,
         point_layers=cfg.mlp_vggt_layers,
+        compute_dtype=_model_compute_dtype(cfg),
     )
     if issubclass(cls, HybridHousePointsCameraEncoder):
         kwargs.update(
@@ -646,11 +665,13 @@ class R2DreamerAgent:
 
         # MLP heads (outscale matches PyTorch: 0.0 for reward/critic, 0.01 for actor)
         rng_key, k_rew, k_con, k_act, k_cri = jax.random.split(rng_key, 5)
+        head_dtype = _model_compute_dtype(config)
         self.reward_mod = R2MLP(
             hidden=config.mlp_units,
             layers=config.mlp_layers_reward,
             out_dim=config.twohot_bins,
             outscale=0.0,
+            compute_dtype=head_dtype,
         )
         rew_params = self.reward_mod.init(k_rew, feat0)
 
@@ -658,6 +679,7 @@ class R2DreamerAgent:
             hidden=config.mlp_units,
             layers=config.mlp_layers_cont,
             out_dim=1,
+            compute_dtype=head_dtype,
         )
         con_params = self.cont_mod.init(k_con, feat0)
 
@@ -666,6 +688,7 @@ class R2DreamerAgent:
             layers=config.mlp_layers_actor,
             out_dim=config.num_actions,
             outscale=0.01,
+            compute_dtype=head_dtype,
         )
         act_params = self.actor_mod.init(k_act, feat0)
 
@@ -674,6 +697,7 @@ class R2DreamerAgent:
             layers=config.mlp_layers_critic,
             out_dim=config.twohot_bins,
             outscale=0.0,
+            compute_dtype=head_dtype,
         )
         cri_params = self.critic_mod.init(k_cri, feat0)
 

--- a/src/r2dreamer/agent.py
+++ b/src/r2dreamer/agent.py
@@ -111,20 +111,23 @@ class R2DTrainState(NamedTuple):
 # ---------------------------------------------------------------------------
 
 
-def _model_compute_dtype(cfg: R2DreamerConfig):
-    """Resolve the model-wide compute dtype for the ``full_bf16`` gate.
+def _compute_dtype_kwargs(cfg: R2DreamerConfig) -> dict[str, Any]:
+    """Return the ``compute_dtype`` override for the ``full_bf16`` gate.
+
+    Only supplies ``compute_dtype`` when ``cfg.full_bf16`` is set, so that
+    with the gate off each module keeps its own default — historically
+    float32 for the CNN/house/pose/RSSM/head path, but bfloat16 for modules
+    that already opted in on their own (e.g. the PointNet house branch).
 
     Args:
       cfg: Agent config supplying ``full_bf16`` and ``compute_dtype``.
 
     Returns:
-      ``compute_dtype`` as a jnp dtype when ``cfg.full_bf16`` is set,
-      otherwise ``jnp.float32`` (the historical behavior, where only the
-      token transformer and replay scalars honored ``compute_dtype``).
+      ``{"compute_dtype": <jnp dtype>}`` when the gate is on, else ``{}``.
     """
     if getattr(cfg, "full_bf16", False):
-        return compute_jnp_dtype(cfg.compute_dtype)
-    return jnp.float32
+        return {"compute_dtype": compute_jnp_dtype(cfg.compute_dtype)}
+    return {}
 
 
 def _make_rssm(cfg: R2DreamerConfig) -> R2RSSM:
@@ -139,7 +142,7 @@ def _make_rssm(cfg: R2DreamerConfig) -> R2RSSM:
         obs_layers=cfg.obs_layers,
         img_layers=cfg.img_layers,
         unimix_ratio=cfg.unimix_ratio,
-        compute_dtype=_model_compute_dtype(cfg),
+        **_compute_dtype_kwargs(cfg),
     )
 
 
@@ -209,7 +212,7 @@ def _make_conv_encoder(cfg: R2DreamerConfig):
         depth=cfg.encoder_depth,
         kernel_size=cfg.encoder_kernel,
         mults=cfg.encoder_mults,
-        compute_dtype=_model_compute_dtype(cfg),
+        **_compute_dtype_kwargs(cfg),
     )
 
 
@@ -284,7 +287,7 @@ def _make_house_points_camera_encoder(
         camera_layers=cfg.mlp_vggt_layers,
         point_hidden=cfg.mlp_vggt_hidden,
         point_layers=cfg.mlp_vggt_layers,
-        compute_dtype=_model_compute_dtype(cfg),
+        **_compute_dtype_kwargs(cfg),
     )
     if issubclass(cls, HybridHousePointsCameraEncoder):
         kwargs.update(
@@ -665,13 +668,13 @@ class R2DreamerAgent:
 
         # MLP heads (outscale matches PyTorch: 0.0 for reward/critic, 0.01 for actor)
         rng_key, k_rew, k_con, k_act, k_cri = jax.random.split(rng_key, 5)
-        head_dtype = _model_compute_dtype(config)
+        head_dtype_kwargs = _compute_dtype_kwargs(config)
         self.reward_mod = R2MLP(
             hidden=config.mlp_units,
             layers=config.mlp_layers_reward,
             out_dim=config.twohot_bins,
             outscale=0.0,
-            compute_dtype=head_dtype,
+            **head_dtype_kwargs,
         )
         rew_params = self.reward_mod.init(k_rew, feat0)
 
@@ -679,7 +682,7 @@ class R2DreamerAgent:
             hidden=config.mlp_units,
             layers=config.mlp_layers_cont,
             out_dim=1,
-            compute_dtype=head_dtype,
+            **head_dtype_kwargs,
         )
         con_params = self.cont_mod.init(k_con, feat0)
 
@@ -688,7 +691,7 @@ class R2DreamerAgent:
             layers=config.mlp_layers_actor,
             out_dim=config.num_actions,
             outscale=0.01,
-            compute_dtype=head_dtype,
+            **head_dtype_kwargs,
         )
         act_params = self.actor_mod.init(k_act, feat0)
 
@@ -697,7 +700,7 @@ class R2DreamerAgent:
             layers=config.mlp_layers_critic,
             out_dim=config.twohot_bins,
             outscale=0.0,
-            compute_dtype=head_dtype,
+            **head_dtype_kwargs,
         )
         cri_params = self.critic_mod.init(k_cri, feat0)
 

--- a/src/r2dreamer/encoders/cnn.py
+++ b/src/r2dreamer/encoders/cnn.py
@@ -5,6 +5,7 @@ from typing import Literal
 
 import flax.linen as nn
 import jax.numpy as jnp
+from jax.typing import DTypeLike
 
 from src.r2dreamer.encoders.shape_utils import (
     flatten_event,
@@ -40,6 +41,7 @@ class ConvEncoder(nn.Module):
     mults: tuple[int, ...] = (2, 3, 4, 4)
     input_kind: Literal["rgb", "world_points"] = "rgb"
     embed_dim: int | None = None
+    compute_dtype: DTypeLike = jnp.float32
 
     @nn.compact
     def __call__(self, obs: jnp.ndarray) -> jnp.ndarray:
@@ -55,9 +57,9 @@ class ConvEncoder(nn.Module):
                 obs = obs[HYBRID_IMAGE_KEY]
         x, leading_shape = flatten_event(obs, event_ndims=3)
         if self.input_kind == "rgb":
-            x = normalize_image_obs(x) - 0.5
+            x = normalize_image_obs(x, dtype=self.compute_dtype) - 0.5
         elif self.input_kind == "world_points":
-            x = _symlog(x.astype(jnp.float32))
+            x = _symlog(x.astype(self.compute_dtype))
         else:
             raise ValueError(
                 f"input_kind must be 'rgb' or 'world_points', got {self.input_kind!r}"
@@ -70,6 +72,7 @@ class ConvEncoder(nn.Module):
                 (self.kernel_size, self.kernel_size),
                 padding="SAME",
                 name=f"conv{i}",
+                dtype=self.compute_dtype,
             )(x)
             x = nn.max_pool(x, (2, 2), strides=(2, 2))
             x = RMSNorm(name=f"norm{i}")(x)
@@ -78,12 +81,23 @@ class ConvEncoder(nn.Module):
         x = jnp.transpose(x, (0, 3, 1, 2))
         x = x.reshape(x.shape[0], -1)
         if self.embed_dim is not None:
-            x = nn.Dense(self.embed_dim, name="proj")(x)
+            x = nn.Dense(self.embed_dim, name="proj", dtype=self.compute_dtype)(x)
         return restore_leading(x, leading_shape)
 
 
 def make_rgb_conv_encoder(
-    *, depth: int, kernel_size: int, mults: tuple[int, ...], name: str
+    *,
+    depth: int,
+    kernel_size: int,
+    mults: tuple[int, ...],
+    name: str,
+    compute_dtype: DTypeLike = jnp.float32,
 ) -> ConvEncoder:
     """Create a named RGB ``ConvEncoder`` submodule with shared defaults."""
-    return ConvEncoder(depth=depth, kernel_size=kernel_size, mults=mults, name=name)
+    return ConvEncoder(
+        depth=depth,
+        kernel_size=kernel_size,
+        mults=mults,
+        name=name,
+        compute_dtype=compute_dtype,
+    )

--- a/src/r2dreamer/encoders/mlp.py
+++ b/src/r2dreamer/encoders/mlp.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 
 import flax.linen as nn
 import jax.numpy as jnp
+from jax.typing import DTypeLike
 
 from src.r2dreamer.encoders.cnn import ConvEncoder, make_rgb_conv_encoder
 from src.r2dreamer.encoders.constants import (
@@ -119,6 +120,7 @@ class HousePointsCameraEncoder(nn.Module):
     point_layers: int = 2
     camera_pose_dim: int = 9
     house_point_dim: int = 6
+    compute_dtype: DTypeLike = jnp.float32
 
     def _camera_embedding(self, camera_pose: jnp.ndarray) -> jnp.ndarray:
         if camera_pose.ndim < 1 or camera_pose.shape[-1] != self.camera_pose_dim:
@@ -126,12 +128,14 @@ class HousePointsCameraEncoder(nn.Module):
                 f"camera_pose must have shape (..., {self.camera_pose_dim}), "
                 f"got {camera_pose.shape}"
             )
-        x = camera_pose.astype(jnp.float32)
+        x = camera_pose.astype(self.compute_dtype)
         for i in range(self.camera_layers):
-            x = nn.Dense(self.camera_hidden, name=f"camera_hidden{i}")(x)
+            x = nn.Dense(
+                self.camera_hidden, name=f"camera_hidden{i}", dtype=self.compute_dtype
+            )(x)
             x = RMSNorm(name=f"camera_norm{i}")(x)
             x = nn.silu(x)
-        return nn.Dense(self.embed_dim, name="camera_proj")(x)
+        return nn.Dense(self.embed_dim, name="camera_proj", dtype=self.compute_dtype)(x)
 
     def _house_embedding(
         self,
@@ -146,9 +150,11 @@ class HousePointsCameraEncoder(nn.Module):
                 "house_points must have shape (N, 6) or (S, N, 6), "
                 f"got {house_points.shape}"
             )
-        x = house_points.astype(jnp.float32)
+        x = house_points.astype(self.compute_dtype)
         for i in range(self.point_layers):
-            x = nn.Dense(self.point_hidden, name=f"point_hidden{i}")(x)
+            x = nn.Dense(
+                self.point_hidden, name=f"point_hidden{i}", dtype=self.compute_dtype
+            )(x)
             x = RMSNorm(name=f"point_norm{i}")(x)
             x = nn.silu(x)
         # Rows >= house_size are zero padding from the fixed-shape snapshot;
@@ -166,7 +172,9 @@ class HousePointsCameraEncoder(nn.Module):
         maxp = jnp.where(valid, x, -jnp.inf).max(axis=1)
         maxp = jnp.where((size > 0)[:, None], maxp, jnp.zeros_like(maxp))
         pooled = jnp.concatenate([mean, maxp], axis=-1)
-        house_embed = nn.Dense(self.embed_dim, name="house_proj")(pooled)
+        house_embed = nn.Dense(
+            self.embed_dim, name="house_proj", dtype=self.compute_dtype
+        )(pooled)
         if house_embed.shape[0] == 1 and batch_size != 1:
             house_embed = jnp.broadcast_to(house_embed, (batch_size, self.embed_dim))
         elif house_embed.shape[0] != batch_size:
@@ -236,14 +244,18 @@ class HybridHousePointsCameraEncoder(HousePointsCameraEncoder):
             kernel_size=self.cnn_kernel,
             mults=self.cnn_mults,
             name="cnn",
+            compute_dtype=self.compute_dtype,
         )(jnp.asarray(obs[HYBRID_IMAGE_KEY]))
         camera_embed, house_embed = self._branches(obs)
         gate_camera = self.param("gate_camera", nn.initializers.zeros, ())
         gate_house = self.param("gate_house", nn.initializers.zeros, ())
+        # Cast the float32 scalar gates down so the gated products (and the
+        # fused concat) keep the branches' compute dtype instead of promoting
+        # the whole embedding back to float32.
         return (
             cnn_embed,
-            gate_camera * camera_embed,
-            gate_house * house_embed,
+            gate_camera.astype(camera_embed.dtype) * camera_embed,
+            gate_house.astype(house_embed.dtype) * house_embed,
             gate_camera,
             gate_house,
         )

--- a/src/r2dreamer/encoders/shape_utils.py
+++ b/src/r2dreamer/encoders/shape_utils.py
@@ -6,16 +6,24 @@ from typing import Any
 import jax.numpy as jnp
 
 
-def normalize_image_obs(image: Any) -> jnp.ndarray:
-    """Return CHW image observations as float32 in ``[0, 1]``.
+def normalize_image_obs(image: Any, dtype: Any = jnp.float32) -> jnp.ndarray:
+    """Return CHW image observations as ``dtype`` in ``[0, 1]``.
 
     Accepts either uint8 images or already-normalized floating arrays and
     preserves all leading dimensions before the final ``(3, H, W)`` axes.
+
+    Args:
+        image: uint8 or floating image array with trailing ``(3, H, W)`` axes.
+        dtype: Floating dtype of the returned array (default float32; encoders
+            pass their compute dtype under the full_bf16 gate).
+
+    Returns:
+        Image array in ``[0, 1]`` with dtype ``dtype`` and unchanged shape.
     """
     image = jnp.asarray(image)
     if image.dtype == jnp.uint8:
-        return image.astype(jnp.float32) / 255.0
-    return image.astype(jnp.float32)
+        return image.astype(dtype) / 255.0
+    return image.astype(dtype)
 
 
 def flatten_event(x: Any, event_ndims: int) -> tuple[jnp.ndarray, tuple[int, ...]]:

--- a/src/r2dreamer/launch/parser.py
+++ b/src/r2dreamer/launch/parser.py
@@ -6,6 +6,32 @@ from src.configs.config import LATENT_PRESETS
 from src.r2dreamer.encoder_types import EVAL_ENCODER_TYPES
 
 
+def _str2bool(value: str | bool) -> bool:
+    """Parse a boolean CLI value.
+
+    The Slurm launcher renders YAML ``args`` as ``--flag value`` pairs, so
+    boolean flags must accept an explicit value (``--full_bf16 True``) in
+    addition to bare ``--full_bf16`` usage.
+
+    Args:
+      value: Raw CLI token (or an already-parsed bool from ``const=True``).
+
+    Returns:
+      The parsed boolean.
+
+    Raises:
+      argparse.ArgumentTypeError: If the token is not a recognized boolean.
+    """
+    if isinstance(value, bool):
+        return value
+    lowered = value.strip().lower()
+    if lowered in {"1", "true", "yes", "on"}:
+        return True
+    if lowered in {"0", "false", "no", "off"}:
+        return False
+    raise argparse.ArgumentTypeError(f"expected a boolean, got {value!r}")
+
+
 def _add_basic_train_args(p: argparse.ArgumentParser) -> None:
     p.add_argument("--steps", type=int, default=2_400_000)
     p.add_argument("--prefill", type=int, default=5000)
@@ -309,6 +335,18 @@ def _add_token_transformer_train_args(p: argparse.ArgumentParser) -> None:
         default=None,
         help="Override cfg.compute_dtype for large encoder activations. "
         "Use bfloat16 for full-token memory ablations.",
+    )
+    p.add_argument(
+        "--full_bf16",
+        nargs="?",
+        const=True,
+        default=False,
+        type=_str2bool,
+        help="Run the whole JAX model (encoders, RSSM, heads) in "
+        "cfg.compute_dtype instead of only the token transformer — mixed "
+        "precision with float32 master params and float32-pinned logits. "
+        "Accepts bare --full_bf16 or an explicit value (launcher YAML "
+        "renders 'full_bf16: true' as '--full_bf16 True').",
     )
 
 

--- a/src/r2dreamer/launch/train.py
+++ b/src/r2dreamer/launch/train.py
@@ -161,6 +161,8 @@ def _agent_overrides_from_args(
         elif dtype == "fp16":
             dtype = "float16"
         agent_overrides["compute_dtype"] = dtype
+    if getattr(args, "full_bf16", False):
+        agent_overrides["full_bf16"] = True
     return agent_overrides
 
 

--- a/src/r2dreamer/world_model/heads.py
+++ b/src/r2dreamer/world_model/heads.py
@@ -12,6 +12,7 @@ fine — actor/critic share the same head primitive as reward.
 import jax
 import jax.numpy as jnp
 import flax.linen as nn
+from jax.typing import DTypeLike
 
 from .rssm import RMSNorm
 
@@ -129,17 +130,23 @@ def onehot_mode_st(logits: jnp.ndarray, unimix_ratio: float = 0.0) -> jnp.ndarra
 
 
 class R2MLP(nn.Module):
-    """MLP with RMSNorm, matching PyTorch R2-Dreamer's MLP + MLPHead."""
+    """MLP with RMSNorm, matching PyTorch R2-Dreamer's MLP + MLPHead.
+
+    ``compute_dtype`` sets the Dense computation dtype (params stay float32
+    masters); the output logits are always returned float32 so downstream
+    losses and distributions are full-precision regardless of the gate.
+    """
 
     hidden: int = 256
     layers: int = 2
     out_dim: int = 1
     outscale: float = 1.0
+    compute_dtype: DTypeLike = jnp.float32
 
     @nn.compact
     def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
         for i in range(self.layers):
-            x = nn.Dense(self.hidden, name=f"fc{i}")(x)
+            x = nn.Dense(self.hidden, name=f"fc{i}", dtype=self.compute_dtype)(x)
             x = RMSNorm(name=f"norm{i}")(x)
             x = nn.silu(x)
         if self.outscale == 0.0:
@@ -151,5 +158,7 @@ class R2MLP(nn.Module):
                 return base_init(key, shape, dtype) * self.outscale
         else:
             out_init = nn.initializers.lecun_normal()
-        x = nn.Dense(self.out_dim, kernel_init=out_init, name="out")(x)
-        return x
+        x = nn.Dense(
+            self.out_dim, kernel_init=out_init, name="out", dtype=self.compute_dtype
+        )(x)
+        return x.astype(jnp.float32)

--- a/src/r2dreamer/world_model/rssm.py
+++ b/src/r2dreamer/world_model/rssm.py
@@ -83,6 +83,12 @@ class Deter(nn.Module):
     @nn.compact
     def __call__(self, stoch, deter, action):
         # stoch: (B, stoch_size), deter: (B, deter_size), action: (B, act_dim)
+        # Keep the deterministic recurrent state as a float32 master (like
+        # DreamerV3 mixed precision): compute the GRU internally in
+        # compute_dtype for speed, but carry `deter` across timesteps in its
+        # original dtype so the recurrence stays stable and the jitted acting
+        # cond (initial vs. carried state) sees matching dtypes.
+        deter_dtype = deter.dtype
         stoch = stoch.astype(self.compute_dtype)
         deter = deter.astype(self.compute_dtype)
         action = action.astype(self.compute_dtype)
@@ -145,7 +151,8 @@ class Deter(nn.Module):
         cand = gate_chunks[1].reshape(gates.shape[0], -1)
         update = jax.nn.sigmoid(gate_chunks[2].reshape(gates.shape[0], -1) - 1.0)
 
-        return update * jnp.tanh(reset * cand) + (1.0 - update) * deter
+        new_deter = update * jnp.tanh(reset * cand) + (1.0 - update) * deter
+        return new_deter.astype(deter_dtype)
 
 
 class R2RSSM(nn.Module):

--- a/src/r2dreamer/world_model/rssm.py
+++ b/src/r2dreamer/world_model/rssm.py
@@ -11,18 +11,27 @@ RSSM's deterministic head; encoders and MLP heads have their own conventions.
 import jax
 import jax.numpy as jnp
 import flax.linen as nn
+from jax.typing import DTypeLike
 
 
 class RMSNorm(nn.Module):
-    """Root Mean Square Layer Normalization."""
+    """Root Mean Square Layer Normalization.
+
+    Follows the input dtype: statistics are accumulated in float32 for
+    stability, then the normalized output is returned in ``x.dtype`` so
+    reduced-precision activations stay reduced through the norm.
+    """
 
     eps: float = 1e-4
 
     @nn.compact
     def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
         scale = self.param("scale", nn.initializers.ones, (x.shape[-1],))
-        rms = jnp.sqrt(jnp.mean(x**2, axis=-1, keepdims=True) + self.eps)
-        return (x / rms) * scale
+        rms = jnp.sqrt(
+            jnp.mean(jnp.square(x.astype(jnp.float32)), axis=-1, keepdims=True)
+            + self.eps
+        )
+        return (x / rms.astype(x.dtype)) * scale.astype(x.dtype)
 
 
 class BlockLinear(nn.Module):
@@ -33,6 +42,7 @@ class BlockLinear(nn.Module):
 
     out_features: int
     blocks: int = 8
+    compute_dtype: DTypeLike = jnp.float32
 
     @nn.compact
     def __call__(self, x: jnp.ndarray) -> jnp.ndarray:
@@ -47,6 +57,11 @@ class BlockLinear(nn.Module):
         )
         bias = self.param("bias", nn.initializers.zeros, (self.out_features,))
 
+        # Params stay float32 masters; the einsum runs in compute_dtype
+        # (mixed precision when the full_bf16 gate sets it to bfloat16).
+        x = x.astype(self.compute_dtype)
+        kernel = kernel.astype(self.compute_dtype)
+        bias = bias.astype(self.compute_dtype)
         batch_shape = x.shape[:-1]
         x = x.reshape(*batch_shape, self.blocks, in_per_block)
         x = jnp.einsum("...gi,oig->...go", x, kernel)
@@ -63,19 +78,30 @@ class Deter(nn.Module):
     hidden: int = 256
     blocks: int = 8
     dyn_layers: int = 1
+    compute_dtype: DTypeLike = jnp.float32
 
     @nn.compact
     def __call__(self, stoch, deter, action):
         # stoch: (B, stoch_size), deter: (B, deter_size), action: (B, act_dim)
+        stoch = stoch.astype(self.compute_dtype)
+        deter = deter.astype(self.compute_dtype)
+        action = action.astype(self.compute_dtype)
 
         # Normalize action magnitude
         action = action / jnp.clip(jnp.abs(action), min=1.0)
 
         # Three input projections
-        x0 = nn.silu(RMSNorm(name="in_norm0")(nn.Dense(self.hidden, name="in0")(deter)))
-        x1 = nn.silu(RMSNorm(name="in_norm1")(nn.Dense(self.hidden, name="in1")(stoch)))
+        dt = self.compute_dtype
+        x0 = nn.silu(
+            RMSNorm(name="in_norm0")(nn.Dense(self.hidden, name="in0", dtype=dt)(deter))
+        )
+        x1 = nn.silu(
+            RMSNorm(name="in_norm1")(nn.Dense(self.hidden, name="in1", dtype=dt)(stoch))
+        )
         x2 = nn.silu(
-            RMSNorm(name="in_norm2")(nn.Dense(self.hidden, name="in2")(action))
+            RMSNorm(name="in_norm2")(
+                nn.Dense(self.hidden, name="in2", dtype=dt)(action)
+            )
         )
 
         # Concatenate: (B, 3*hidden)
@@ -97,12 +123,19 @@ class Deter(nn.Module):
         for i in range(self.dyn_layers):
             x = nn.silu(
                 RMSNorm(name=f"hid_norm{i}")(
-                    BlockLinear(self.deter_size, self.blocks, name=f"hid{i}")(x)
+                    BlockLinear(
+                        self.deter_size,
+                        self.blocks,
+                        compute_dtype=dt,
+                        name=f"hid{i}",
+                    )(x)
                 )
             )
 
         # GRU gates: (B, 3*deter_size)
-        gates = BlockLinear(3 * self.deter_size, self.blocks, name="gru")(x)
+        gates = BlockLinear(
+            3 * self.deter_size, self.blocks, compute_dtype=dt, name="gru"
+        )(x)
 
         # Split block-wise: reshape to (B, blocks, 3*dpb), then chunk
         dpb = self.deter_size // self.blocks
@@ -133,6 +166,7 @@ class R2RSSM(nn.Module):
     obs_layers: int = 1
     img_layers: int = 2
     unimix_ratio: float = 0.01
+    compute_dtype: DTypeLike = jnp.float32
 
     @property
     def stoch_size(self):
@@ -150,24 +184,28 @@ class R2RSSM(nn.Module):
             hidden=self.hidden,
             blocks=self.blocks,
             dyn_layers=self.dyn_layers,
+            compute_dtype=self.compute_dtype,
         )
 
         # Posterior head (obs_net): obs_layers Dense+RMSNorm+SiLU then Dense→logits
+        dt = self.compute_dtype
         self.obs_fcs = [
-            nn.Dense(self.hidden, name=f"obs_fc{i}") for i in range(self.obs_layers)
+            nn.Dense(self.hidden, name=f"obs_fc{i}", dtype=dt)
+            for i in range(self.obs_layers)
         ]
         self.obs_norms = [RMSNorm(name=f"obs_norm{i}") for i in range(self.obs_layers)]
         self.obs_out = nn.Dense(
-            self.stoch_classes * self.stoch_discrete, name="obs_out"
+            self.stoch_classes * self.stoch_discrete, name="obs_out", dtype=dt
         )
 
         # Prior head (img_net): img_layers Dense+RMSNorm+SiLU then Dense→logits
         self.img_fcs = [
-            nn.Dense(self.hidden, name=f"img_fc{i}") for i in range(self.img_layers)
+            nn.Dense(self.hidden, name=f"img_fc{i}", dtype=dt)
+            for i in range(self.img_layers)
         ]
         self.img_norms = [RMSNorm(name=f"img_norm{i}") for i in range(self.img_layers)]
         self.img_out = nn.Dense(
-            self.stoch_classes * self.stoch_discrete, name="img_out"
+            self.stoch_classes * self.stoch_discrete, name="img_out", dtype=dt
         )
 
     def __call__(self, stoch, deter, action, embed):
@@ -192,10 +230,16 @@ class R2RSSM(nn.Module):
         self._prior(deter)
 
         # Posterior: condition on deter + embed
-        x = jnp.concatenate([deter, embed], axis=-1)
+        x = jnp.concatenate([deter, embed.astype(deter.dtype)], axis=-1)
         for fc, norm in zip(self.obs_fcs, self.obs_norms):
             x = nn.silu(norm(fc(x)))
-        logit = self.obs_out(x).reshape(B, self.stoch_classes, self.stoch_discrete)
+        # Logits are pinned float32 so sampling, KL, and entropy stay
+        # full-precision even when the layers above compute in bfloat16.
+        logit = (
+            self.obs_out(x)
+            .astype(jnp.float32)
+            .reshape(B, self.stoch_classes, self.stoch_discrete)
+        )
         stoch = self._sample(logit)
         return stoch, deter, logit
 
@@ -223,7 +267,12 @@ class R2RSSM(nn.Module):
         x = deter
         for fc, norm in zip(self.img_fcs, self.img_norms):
             x = nn.silu(norm(fc(x)))
-        logit = self.img_out(x).reshape(B, self.stoch_classes, self.stoch_discrete)
+        # Same float32 logit pin as the posterior head (see __call__).
+        logit = (
+            self.img_out(x)
+            .astype(jnp.float32)
+            .reshape(B, self.stoch_classes, self.stoch_discrete)
+        )
         stoch = self._sample(logit)
         return stoch, logit
 


### PR DESCRIPTION
## Step-time optimization: baseline run [fvwuoux3](https://wandb.ai/sailer-luca-university-ulm/3d-vla-objectnav/runs/fvwuoux3)

Interactive `/optimize-step-time` loop. Baseline **184.3 ms/step** (median, post-warmup, n=1800) — hybrid house-points-pose, batch 16, bf16 config, 2M steps.

You selected two candidates: **pipeline-full-bf16** (your idea — end-to-end JAX bfloat16) and **replay-vectorized-storage**.

| Variant | Hypothesis | Result | Verdict |
|---|---|---|---|
| pipeline-full-bf16 | Extend bf16 from the token transformer to the whole JAX model (encoders/RSSM/heads); the 262k-point house MLP + CNN backbone run in float32 today | **train_step 59.95 → 44.82 ms/call (−15.1 ms, −25.2%)** at prod shape on H100 | **keep, gated default-off** |
| replay-vectorized-storage | Replace per-transition object store + deepcopy with SoA arrays + windowed gather | **already on main** (84e4b3b, 2026-07-04) — baseline already includes it | closed, no work needed |

### pipeline-full-bf16

**Audit finding first:** `cfg.compute_dtype` was a near no-op outside the token transformer. The CNN/house/pose encoders hard-cast their inputs to float32 and no other module took a dtype, so the baseline `fvwuoux3` — a "bfloat16" config — was actually training **float32 end-to-end** on the model side. This is the first real reduced-precision path for this encoder family.

**Change:** new `cfg.full_bf16` (default **off**, CLI `--full_bf16`) threads a compute dtype through `ConvEncoder`, `HousePointsCameraEncoder`/`Hybrid`, `Deter`/`BlockLinear`, `R2RSSM`, and `R2MLP`. Mixed precision done right:
- float32 **master params** (Flax `param_dtype` stays float32; optimizer state untouched)
- RSSM logits and MLP-head outputs **pinned float32** (sampling, KL, two-hot stay full precision)
- RSSM deterministic state carried in float32 across the recurrence (DreamerV3 convention)
- RMSNorm statistics accumulated in float32
- GNN graph math keeps its existing float32 exemption

Gate-off is behavior-preserving and each module keeps its native default — including PointNet (PR #201), which already opted into bf16 on its own.

**Measurement:** `full_bf16` only touches JAX model compute — not the torch VGGT extractor (~132 ms/step) or the host replay sampler (~59 ms/step). A full training probe would bury the effect under those fixed costs, so `scripts/profiling/profile_full_bf16_step.py` isolates the JAX `train_step` on a synthetic prod-shape batch (job 5839014, H100, n=50):

```
float32   train_step: 59.95 ms/call  (p10 59.4, p90 61.0)
full_bf16 train_step: 44.82 ms/call  (p10 44.0, p90 50.0)
delta: -15.13 ms/call (-25.2%)
```

**Env-step projection:** at `train_ratio` 512 the profile amortizes train_step at ~0.5 call/env-step, so ≈ **−7.6 ms/env-step, ~4% of the 184 ms baseline** — plus lower activation memory. This is a projection; the end-to-end training probe that would confirm it (and loss-quality parity) is blocked — see below.

### ⚠️ Infra blocker (needs your call)

The full-shape training probes (`hybrid_hpp_prodshape_probe`, `hybrid_hpp_bf16_prodshape_probe`) could **not** run. Prod-mode `scripts/slurm/launch.sh` invokes `uv run python`, which re-synced the shared `.venv` ("Uninstalled 37 / Installed 37 packages"; the venv had drifted — "missing RECORD file" warnings). The re-sync left habitat un-importable under the locked numpy 2.4.6 (`habitat/utils/visualizations/maps.py:44` `.squeeze(1)`). The live 29h baseline `5812468` survives only because it imported habitat before the churn.

I did **not** try to repair the shared venv — `uv sync` / pinning numpy is a destructive action on shared state with a run live on it. Suggested fix when convenient: reconcile the venv to the lock (or pin numpy) at a moment no job is mid-import, then run `hybrid_hpp_bf16_prodshape_probe` vs the control for the end-to-end number and a loss-curve sanity check before flipping `full_bf16` on for a real run.

### Verification
- 54 encoder/world-model/agent tests pass on CPU (incl. PointNet + GNN + hybrid), rebased on main (PR #201).
- Gate smoke: encoder emits bf16 on / float32 off; 4 finite train steps each; params stay float32; multi-step acting works (caught + fixed a bf16 recurrent-state dtype-mismatch bug in the jitted acting path).
- PointNet stays bf16 with the gate off — no regression to PR #201.

### Not tried (deselected)
vggt-extract-every-2, vggt-compile-fp16, vggt-resolution-down, vggt-kv-budget-trim (VGGT side), replay-async-prefetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
