### PR TITLE
perf(step-time): fuse ReplayBuffer.sample transfers + defer train_step metric sync

### DIFF
--- a/scripts/slurm/configs/jax_buffer_stepopt_probe.yaml
+++ b/scripts/slurm/configs/jax_buffer_stepopt_probe.yaml
@@ -1,0 +1,24 @@
+extends: hybrid_house_points_pose_l1_live
+job_name: jax-buffer-stepopt-probe-l1
+output_dir: output/probes/stepopt/jax-buffer
+comments:
+  - "Step-time probe for the fvwuoux3 baseline (l1_hybrid_house_points_pose, 184.4 ms/step median). Measures the combined effect of two host-NumPy->JAX hot-path fixes: (1) train_step defers metric device sync to log steps (agent.py), (2) ReplayBuffer.sample fuses per-leaf host->device transfers into one device_put (replay_buffer.py)."
+  - "Prod shape matched to the baseline run (batch 16, seq 64, train_ratio 512, compute_dtype bfloat16, render 518). Enough post-prefill train steps to get a stable post-warmup median of perf/ms_per_step_interval; compare probe-vs-baseline at identical shape."
+sbatch:
+  time: "01:00:00"
+args:
+  steps: 12000
+  prefill: 5000
+  batch_size: 16
+  seq_len: 64
+  train_ratio: 512
+  compute_dtype: bfloat16
+  log_every: 100
+  checkpoint_every: 1000000
+  seed: 42
+  output_dir: output/probes/stepopt/jax-buffer/run-${SLURM_JOB_ID}
+  wandb_project: 3d-vla-objectnav
+  wandb_name: jax-buffer-stepopt-probe-${SLURM_JOB_ID}
+  wandb_tags: stepopt,prodshape-probe,jax-buffer,defer-metric-sync,fused-device-put,b16,t64,bf16,seed-42
+  video_log_every: 0
+  val_every: 0

--- a/scripts/slurm/configs/jax_buffer_stepopt_probe.yaml
+++ b/scripts/slurm/configs/jax_buffer_stepopt_probe.yaml
@@ -13,6 +13,10 @@ args:
   seq_len: 64
   train_ratio: 512
   compute_dtype: bfloat16
+  # Pinned explicitly (inherited value is 518 via house_context_l1) so the
+  # probe's render shape stays locked to the fvwuoux3 baseline even if an
+  # ancestor config changes; keeps the ms/step comparison apples-to-apples.
+  render_resolution: 518
   log_every: 100
   checkpoint_every: 1000000
   seed: 42

--- a/src/buffer/replay_buffer.py
+++ b/src/buffer/replay_buffer.py
@@ -278,13 +278,6 @@ class ReplayBuffer:
         """
         ring = self._sample_ring_indices(batch_size, seq_len)
 
-        obs_fields = {
-            key: jnp.asarray(store[ring]) for key, store in self._obs_store.items()
-        }
-        obs: ReplayObservationBatch = (
-            obs_fields[_ARRAY_FIELD] if self._obs_kind == "array" else obs_fields
-        )
-
         episode_ends = self._is_episode_end[ring]
         # A window resets sequence state at its start, at stored episode
         # starts, and on the frame after an episode end.
@@ -292,15 +285,33 @@ class ReplayBuffer:
         is_first[:, 0] = True
         is_first[:, 1:] |= episode_ends[:, :-1]
 
-        actions = jax.nn.one_hot(
-            jnp.asarray(self._actions[ring]), self.num_actions, dtype=self.float_dtype
+        # Gather every sampled leaf host-side, then move it to the device with
+        # a single ``device_put`` instead of one ``jnp.asarray`` per field. The
+        # per-field variant paid fixed transfer/dispatch overhead once per leaf
+        # (six times for a hybrid-image adapter); fusing them into one pytree
+        # transfer cuts that to a single dispatch on the hot sampling path.
+        payload = jax.device_put(
+            {
+                "obs": {key: store[ring] for key, store in self._obs_store.items()},
+                "actions": self._actions[ring],
+                "rewards": self._rewards[ring],
+                "is_first": is_first,
+                "is_episode_end": episode_ends,
+            }
+        )
+
+        obs_fields = payload["obs"]
+        obs: ReplayObservationBatch = (
+            obs_fields[_ARRAY_FIELD] if self._obs_kind == "array" else obs_fields
         )
         return ReplayBatch(
             obs=obs,
-            actions=actions,
-            rewards=jnp.asarray(self._rewards[ring], dtype=self.float_dtype),
-            is_first=jnp.asarray(is_first, dtype=self.float_dtype),
-            is_episode_end=jnp.asarray(episode_ends, dtype=self.float_dtype),
+            actions=jax.nn.one_hot(
+                payload["actions"], self.num_actions, dtype=self.float_dtype
+            ),
+            rewards=payload["rewards"].astype(self.float_dtype),
+            is_first=payload["is_first"].astype(self.float_dtype),
+            is_episode_end=payload["is_episode_end"].astype(self.float_dtype),
         )
 
     def sample_transitions(

--- a/src/r2dreamer/agent.py
+++ b/src/r2dreamer/agent.py
@@ -933,14 +933,36 @@ class R2DreamerAgent:
     # Training
     # ------------------------------------------------------------------
 
-    def train_step(self, batch: ReplayBatch , rng_key: jnp.ndarray) -> Dict[str, float]:
-        """One LaProp step on `batch`. Returns Python-float metrics."""
+    def train_step(
+        self,
+        batch: ReplayBatch,
+        rng_key: jnp.ndarray,
+        *,
+        materialize: bool = True,
+    ) -> Dict[str, Any]:
+        """One LaProp step on `batch`.
+
+        Args:
+          batch: The replay batch to train on.
+          rng_key: PRNG key for the step.
+          materialize: When ``True`` (default), block and return Python-float
+            metrics. When ``False``, return the raw device-array metrics
+            without forcing a device->host sync. The hot training loop passes
+            ``False`` on non-logging steps so JAX async dispatch is not
+            serialized ~every step for metrics that would be discarded.
+
+        Returns:
+          A dict of metric name to value. Python floats when ``materialize``,
+          otherwise device ``jax.Array`` scalars.
+        """
         self.train_state, metrics = self._jitted_train_step.__call__(
             self.train_state,
             batch,
             rng_key,
         )
-        return {k: float(v) for k, v in metrics.items()}
+        if materialize:
+            return {k: float(v) for k, v in metrics.items()}
+        return dict(metrics)
 
     def eval_loss(self, batch: Any, rng_key: jnp.ndarray) -> Dict[str, float]:
         """Evaluate the current objective on a batch without updating state."""

--- a/src/r2dreamer/trainer.py
+++ b/src/r2dreamer/trainer.py
@@ -615,14 +615,17 @@ class Trainer:
             # --- Train ---
             if self.buffer.size >= batch_steps:
                 train_credit += acfg.train_ratio / batch_steps
+                will_log = step % tcfg.log_every == 0
                 while train_credit >= 1.0:
                     rng_key, train_key = jax.random.split(rng_key)
                     batch = self.buffer.sample(acfg.batch_size, acfg.seq_len)
                     batch = self.obs_adapter.augment_replay_batch(batch)
-                    metrics = self.agent.train_step(batch, train_key)
+                    metrics = self.agent.train_step(
+                        batch, train_key, materialize=will_log
+                    )
                     train_credit -= 1.0
 
-                if step % tcfg.log_every == 0 and metrics:
+                if will_log and metrics:
                     self._log_train_metrics(metrics, step, writer, f)
                     if getattr(acfg, "decoder", False):
                         self._maybe_log_recon(batch, step)

--- a/tests/buffer/test_replay_buffer.py
+++ b/tests/buffer/test_replay_buffer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import jax.numpy as jnp
 import numpy as np
 import pytest
 
@@ -147,6 +148,29 @@ class TestReplayBufferUnitBehavior:
         np.testing.assert_allclose(np.asarray(batch.rewards), np.array([[3.0]]))
         np.testing.assert_allclose(np.asarray(batch.is_episode_end), np.array([[1.0]]))
         np.testing.assert_allclose(np.asarray(batch.is_first), np.array([[1.0]]))
+
+    def test_sample_preserves_configured_float_dtype(self) -> None:
+        """Sampled float leaves must carry the buffer's configured float_dtype.
+
+        Locks the dtype invariant the fused single-``device_put`` sample path
+        relies on: actions, rewards, is_first and is_episode_end are cast to
+        ``float_dtype`` on-device. A regression that dropped the per-leaf cast
+        (e.g. leaving rewards as the stored float32 or is_first as bool) would
+        silently change model-input precision, so assert bfloat16 end-to-end.
+        """
+        buffer = ReplayBuffer(
+            capacity=4, num_actions=10, float_dtype=jnp.bfloat16
+        )
+        buffer.add(_transition(0, is_first=True))
+        buffer.add(_transition(1))
+        buffer.add(_transition(2))
+
+        batch = buffer.sample(batch_size=2, seq_len=2)
+
+        assert batch.actions.dtype == jnp.bfloat16
+        assert batch.rewards.dtype == jnp.bfloat16
+        assert batch.is_first.dtype == jnp.bfloat16
+        assert batch.is_episode_end.dtype == jnp.bfloat16
 
     def test_invalid_capacity_raises(self) -> None:
         """Capacity must be positive."""


### PR DESCRIPTION
## What

Two host-NumPy → JAX hot-path optimizations for the training step, plus a prod-shaped probe config and a dtype-invariant regression test.

1. `perf(buffer)`: `ReplayBuffer.sample` fuses per-leaf host→device transfers into a single `jax.device_put` (was one `jnp.asarray` per leaf — six for a hybrid-image adapter). one_hot and dtype casts applied on-device. Semantics unchanged.
2. `perf(train)`: `train_step` defers metric device-sync (materialize) to log steps only, instead of syncing every step.
3. `chore(probe)`: `scripts/slurm/configs/jax_buffer_stepopt_probe.yaml` — prod-shaped step-time probe matched to the fvwuoux3 baseline.
4. `test(buffer)`: new `test_sample_preserves_configured_float_dtype` locks that sampled actions/rewards/is_first/is_episode_end carry the buffer's configured `float_dtype` (bfloat16), the invariant the fused single-`device_put` path relies on. Pinned `render_resolution: 518` explicitly in the probe YAML (was inherited via house_context_l1) so the ms/step comparison stays apples-to-apples if an ancestor config changes.

## Verification

CPU-verified (JAX_PLATFORMS=cpu):
- tests/buffer/test_replay_buffer.py + tests/buffer/test_house_context_pose_buffer.py: 28 passed
- tests/r2dreamer/test_agent.py: 15 passed (covers materialize=True metric contract)
- New bf16 dtype test: passing

> **Independently re-verified**: a separate adversarial agent re-ran all three test files from a clean detached checkout of this exact commit (43 green) and confirmed the deferred-sync change does **not** weaken divergence protection — the NaN guard + param rollback is device-side inside the jitted `_train_step_pure` (`agent.py:1011-1033`) and runs every step regardless of host materialization. Verdict: CONFIRMED.

## GPU pending

The actual ms/step number needs a SLURM probe run with `jax_buffer_stepopt_probe.yaml` vs the fvwuoux3 baseline (184.4 ms/step median). Not run here — CPU-only environment. **Merge should follow that measurement.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
