### PR TITLE
feat(encoder): house_point_norm knob for house-branch XYZ symlog

### DIFF
--- a/scripts/slurm/configs/hybrid_house_points_pose_l1_live_rawpts.yaml
+++ b/scripts/slurm/configs/hybrid_house_points_pose_l1_live_rawpts.yaml
@@ -1,0 +1,25 @@
+extends: hybrid_house_points_pose_l1_live
+job_name: vggt-hybrid-house-points-pose-l1-live-rawpts
+output_dir: output/runs/r2dreamer-curriculum-l1-vggt-hybrid-house-points-pose-rawpts
+run_id: habitat-l1-vggt-hybrid-house-points-pose-rawpts
+comments:
+  - "Raw-coordinates ablation arm of hybrid_house_points_pose_l1_live: sets house_point_norm=none so the house-branch MLP sees unnormalized metric XYZ (the pre-fix behavior). The default config now symlogs XYZ (channels [:3]) to match the world-points CNN path; this variant is the A/B baseline to measure whether that normalization helps the house branch."
+args:
+  output_dir: output/runs/r2dreamer-curriculum-l1-vggt-hybrid-house-points-pose-rawpts/run-${SLURM_JOB_ID}
+  wandb_name: l1_hybrid_house_points_pose_rawpts-${SLURM_JOB_ID}
+  house_point_norm: none
+  wandb_tags: curriculum,level1,1house,chair-only,vggt,house-points,live-buffer,camera-pose-replay,point-mlp,cnn-backbone,additive-hybrid,gated,persist-scene,jax,3d-encoder,ablation,raw-points
+smoke:
+  time: "00:30:00"
+  args:
+    steps: 2000
+    prefill: 1000
+    batch_size: 4
+    seq_len: 16
+    train_ratio: 16
+    log_every: 50
+    checkpoint_every: 1000000
+    house_point_norm: none
+    output_dir: output/smoke/vggt-hybrid-house-points-pose-live-rawpts-${TIMESTAMP}
+    wandb_name: vggt-hybrid-house-points-pose-live-rawpts-smoke-${TIMESTAMP}
+    wandb_tags: house-points,live-buffer,smoke,camera-pose-replay,point-mlp,cnn-backbone,additive-hybrid,gated,persist-scene,ablation,raw-points

--- a/src/configs/agent_config.py
+++ b/src/configs/agent_config.py
@@ -104,6 +104,10 @@ class R2DreamerConfig:
     vggt_token_dim: int = 1024
     mlp_vggt_hidden: int = 1024
     mlp_vggt_layers: int = 2
+    # House-branch metric XYZ normalization for the MLP/Hybrid house-points
+    # encoders: "symlog" compresses channels [:3] (default), "none" passes raw
+    # coordinates. PointNet/GNN house encoders ignore this knob.
+    house_point_norm: str = "symlog"
     decoder: bool = False
     scale_decoder: float = 1.0
     design_notes: str = ""

--- a/src/r2dreamer/agent.py
+++ b/src/r2dreamer/agent.py
@@ -287,6 +287,7 @@ def _make_house_points_camera_encoder(
         camera_layers=cfg.mlp_vggt_layers,
         point_hidden=cfg.mlp_vggt_hidden,
         point_layers=cfg.mlp_vggt_layers,
+        house_point_norm=cfg.house_point_norm,
         **_compute_dtype_kwargs(cfg),
     )
     if issubclass(cls, HybridHousePointsCameraEncoder):

--- a/src/r2dreamer/encoders/mlp.py
+++ b/src/r2dreamer/encoders/mlp.py
@@ -6,7 +6,7 @@ import flax.linen as nn
 import jax.numpy as jnp
 from jax.typing import DTypeLike
 
-from src.r2dreamer.encoders.cnn import ConvEncoder, make_rgb_conv_encoder
+from src.r2dreamer.encoders.cnn import ConvEncoder, _symlog, make_rgb_conv_encoder
 from src.r2dreamer.encoders.constants import (
     AGG_RAW_DIM,
     HYBRID_RGB_DIM,
@@ -111,6 +111,13 @@ class HousePointsCameraEncoder(nn.Module):
     broadcast across all camera poses after the house branch is pooled. When
     ``HOUSE_CONTEXT_SIZE_KEY`` is present in the obs, rows past that count are
     treated as zero padding and masked out of the mean/max pooling.
+
+    Attributes:
+        house_point_norm: Normalization applied to the house-point metric XYZ
+            channels ``[:3]`` before the point MLP. ``"symlog"`` (default)
+            compresses the unbounded metric range with ``sign(x)*log1p(|x|)``
+            and leaves the RGB channels ``[3:]`` untouched; ``"none"`` passes
+            the raw coordinates through. Any other value raises ``ValueError``.
     """
 
     embed_dim: int = 1024
@@ -120,6 +127,7 @@ class HousePointsCameraEncoder(nn.Module):
     point_layers: int = 2
     camera_pose_dim: int = 9
     house_point_dim: int = 6
+    house_point_norm: str = "symlog"
     compute_dtype: DTypeLike = jnp.float32
 
     def _camera_embedding(self, camera_pose: jnp.ndarray) -> jnp.ndarray:
@@ -151,6 +159,15 @@ class HousePointsCameraEncoder(nn.Module):
                 f"got {house_points.shape}"
             )
         x = house_points.astype(self.compute_dtype)
+        # Normalize the metric XYZ channels [:3] before the point MLP; RGB
+        # channels [3:] are already in [0, 1] and pass through untouched.
+        if self.house_point_norm == "symlog":
+            x = jnp.concatenate([_symlog(x[..., :3]), x[..., 3:]], axis=-1)
+        elif self.house_point_norm != "none":
+            raise ValueError(
+                "house_point_norm must be 'symlog' or 'none', got "
+                f"{self.house_point_norm!r}"
+            )
         for i in range(self.point_layers):
             x = nn.Dense(
                 self.point_hidden, name=f"point_hidden{i}", dtype=self.compute_dtype

--- a/src/r2dreamer/launch/evaluate.py
+++ b/src/r2dreamer/launch/evaluate.py
@@ -172,6 +172,7 @@ def _load_arch_overrides_from_manifest(eff_checkpoint: str | None) -> dict:
         "vggt_token_count",
         "vggt_token_dim",
         "mlp_vggt_layers",
+        "house_point_norm",
         "mlp_units",
         "mlp_layers_reward",
         "mlp_layers_cont",

--- a/src/r2dreamer/launch/parser.py
+++ b/src/r2dreamer/launch/parser.py
@@ -288,6 +288,14 @@ def _add_latent_decoder_train_args(p: argparse.ArgumentParser) -> None:
         default=None,
         help="Override cfg.mlp_vggt_layers (hybrid WP/CP MLP depth).",
     )
+    p.add_argument(
+        "--house_point_norm",
+        type=str,
+        default=None,
+        choices=["symlog", "none"],
+        help="Override cfg.house_point_norm: house-branch metric XYZ "
+        "normalization for MLP/Hybrid house-points encoders.",
+    )
 
 
 def _add_token_transformer_train_args(p: argparse.ArgumentParser) -> None:

--- a/src/r2dreamer/launch/train.py
+++ b/src/r2dreamer/launch/train.py
@@ -140,6 +140,7 @@ def _agent_overrides_from_args(
         "stoch_discrete",
         "mlp_vggt_hidden",
         "mlp_vggt_layers",
+        "house_point_norm",
         "scale_decoder",
         "vggt_token_transformer_layers",
         "vggt_token_transformer_heads",

--- a/tests/r2dreamer/test_house_points_norm.py
+++ b/tests/r2dreamer/test_house_points_norm.py
@@ -1,0 +1,102 @@
+"""CPU tests for house-branch XYZ normalization (``house_point_norm``).
+
+Covers the symlog transform added to ``HousePointsCameraEncoder._house_embedding``:
+that it compresses the metric XYZ channels, leaves RGB untouched, that ``"none"``
+reproduces the raw-coordinate behavior, and that an invalid value raises.
+"""
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from src.r2dreamer.encoders.mlp import HousePointsCameraEncoder
+from src.r2dreamer.observation_keys import (
+    CAMERA_POSE_KEY,
+    HOUSE_CONTEXT_KEY,
+    HOUSE_CONTEXT_SIZE_KEY,
+)
+
+
+def _make_obs(batch: int, n_points: int, size: int, key: int = 0):
+    """Obs with large-magnitude metric XYZ (so symlog materially differs) and RGB in [0, 1]."""
+    rng = jax.random.PRNGKey(key)
+    k_pose, k_xyz, k_rgb = jax.random.split(rng, 3)
+    xyz = jax.random.uniform(k_xyz, (1, n_points, 3), minval=-12.0, maxval=12.0)
+    rgb = jax.random.uniform(k_rgb, (1, n_points, 3), minval=0.0, maxval=1.0)
+    points = jnp.concatenate([xyz, rgb], axis=-1)
+    mask = (jnp.arange(n_points) < size)[None, :, None]
+    return {
+        CAMERA_POSE_KEY: jax.random.normal(k_pose, (batch, 9), dtype=jnp.float32),
+        HOUSE_CONTEXT_KEY: jnp.where(mask, points, 0.0).astype(jnp.float16),
+        HOUSE_CONTEXT_SIZE_KEY: jnp.asarray(size, dtype=jnp.int32),
+    }
+
+
+def _make_encoder(norm: str) -> HousePointsCameraEncoder:
+    return HousePointsCameraEncoder(
+        embed_dim=32,
+        camera_hidden=16,
+        camera_layers=1,
+        point_hidden=16,
+        point_layers=2,
+        house_point_norm=norm,
+    )
+
+
+def _symlog_xyz(house_context: jnp.ndarray) -> jnp.ndarray:
+    """Reference: symlog channels [:3], leave [3:] untouched (float32, matching the encoder cast)."""
+    x = house_context.astype(jnp.float32)
+    xyz = jnp.sign(x[..., :3]) * jnp.log1p(jnp.abs(x[..., :3]))
+    return jnp.concatenate([xyz, x[..., 3:]], axis=-1)
+
+
+def test_symlog_equals_none_on_presymlogged_xyz():
+    """symlog encoder on raw XYZ == none encoder on pre-symlogged XYZ (shared params).
+
+    This pins down exactly what the transform does: symlog on channels [:3] and
+    nothing on RGB [3:]. If RGB were also transformed, or a different function
+    applied, the two outputs would diverge.
+    """
+    enc_symlog = _make_encoder("symlog")
+    enc_none = _make_encoder("none")
+    obs = _make_obs(batch=5, n_points=256, size=200)
+
+    params = enc_symlog.init(jax.random.PRNGKey(1), obs)
+    out_symlog = enc_symlog.apply(params, obs)
+
+    ref_obs = dict(obs)
+    ref_obs[HOUSE_CONTEXT_KEY] = _symlog_xyz(obs[HOUSE_CONTEXT_KEY])
+    out_none = enc_none.apply(params, ref_obs)
+
+    assert jnp.allclose(out_symlog, out_none, atol=1e-5)
+
+
+def test_symlog_changes_output_versus_raw():
+    """With large metric XYZ, symlog must actually change the encoding vs raw."""
+    enc_symlog = _make_encoder("symlog")
+    enc_none = _make_encoder("none")
+    obs = _make_obs(batch=4, n_points=256, size=180)
+
+    params = enc_symlog.init(jax.random.PRNGKey(2), obs)
+    out_symlog = enc_symlog.apply(params, obs)
+    out_none = enc_none.apply(params, obs)
+
+    assert not jnp.allclose(out_symlog, out_none, atol=1e-3)
+    assert bool(jnp.isfinite(out_symlog).all())
+
+
+def test_empty_house_stays_finite_under_symlog():
+    """size==0 zeros the house branch; symlog(0)==0 must not introduce NaN/Inf."""
+    enc = _make_encoder("symlog")
+    obs = _make_obs(batch=3, n_points=256, size=0)
+    params = enc.init(jax.random.PRNGKey(3), obs)
+    out = enc.apply(params, obs)
+    assert out.shape == (3, 64)
+    assert bool(jnp.isfinite(out).all())
+
+
+def test_invalid_norm_raises():
+    enc = _make_encoder("standardize")
+    obs = _make_obs(batch=2, n_points=64, size=32)
+    with pytest.raises(ValueError, match="house_point_norm"):
+        enc.init(jax.random.PRNGKey(4), obs)


### PR DESCRIPTION
## What

Lands the previously-designed-but-never-merged `house_point_norm` encoder knob (PR-A).

`HousePointsCameraEncoder` now has a `house_point_norm: str = "symlog"` field. In `_house_embedding` the metric XYZ channels `[:3]` are symlog-compressed with `sign(x)*log1p(|x|)` (reusing `cnn._symlog`, matching the world-points CNN path) while RGB `[3:]` passes through untouched. `"none"` passes raw coordinates; any other value raises `ValueError`.

Because it is a Flax dataclass field, `HybridHousePointsCameraEncoder` honors it via the inherited `_house_embedding`/`_branches`. `PointNet`/`GNN` subclasses inherit the field but override `_house_embedding`, so they ignore the knob (as documented).

## Wiring
- `R2DreamerConfig.house_point_norm` (default `"symlog"`)
- `_make_house_points_camera_encoder` builder passes it through
- `--house_point_norm` CLI flag (choices `symlog`/`none`)
- Added to the train.py agent-override list and evaluate.py manifest `arch_fields` so it round-trips through checkpoints
- Adds the rawpts A/B config (`house_point_norm=none`) and the spec test

## Verification
- `tests/r2dreamer/test_house_points_norm.py`: 4 passed (symlog==none on pre-symlogged XYZ, symlog changes output vs raw, empty-house stays finite, invalid raises)
- `tests/r2dreamer/test_agent.py`: 15 passed (no regression)
- `--house_point_norm none|symlog` parses; invalid choice rejected by argparse
- CPU only.

> **Independently re-verified**: a separate adversarial agent re-checked out this exact commit, re-ran the norm + agent tests (4/4 and 15/15 green), and read `mlp.py` source directly to confirm the test passes **for the right reason** — the assertions are intact (not weakened), symlog is applied to `[:3]` only, and the Hybrid arm inherits the knob. Verdict: CONFIRMED.

## GPU pending
No SLURM/GPU run was performed. Before merge, a live habitat train/eval run should confirm the flag flows end-to-end and that `house_point_norm=none` reproduces pre-fix behavior.

Note: the design doc referenced `shape_utils.py` for the symlog helper, but the existing helper is `_symlog` in `cnn.py` — reused that (mlp.py already imports from cnn.py).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
