### PR TITLE
fix(deps): gate CUDA and habitat deps to Linux so macOS can install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,11 @@ dependencies = [
     "wandb",
     "moviepy",
     # DreamerV3 / JAX
-    "jax[cuda12]==0.6.2; python_version < '3.11'",
-    "jax[cuda12]==0.10.2; python_version >= '3.11'",
+    # CUDA wheels are Linux-only; macOS resolves the plain CPU build.
+    "jax==0.6.2; python_version < '3.11'",
+    "jax==0.10.2; python_version >= '3.11'",
+    "jax[cuda12]==0.6.2; python_version < '3.11' and sys_platform == 'linux'",
+    "jax[cuda12]==0.10.2; python_version >= '3.11' and sys_platform == 'linux'",
     "flax>=0.10",
     "optax>=0.2",
     "pydantic>=2",
@@ -42,8 +45,9 @@ dependencies = [
     "gym>=0.22",
     "tensorboard",
     # Habitat
-    "habitat-sim @ git+https://github.com/facebookresearch/habitat-sim.git@main",
-    "habitat-lab @ git+https://github.com/facebookresearch/habitat-lab.git@main#subdirectory=habitat-lab",
+    # Built from source; the CMake build only succeeds on the Linux cluster.
+    "habitat-sim @ git+https://github.com/facebookresearch/habitat-sim.git@main ; sys_platform == 'linux'",
+    "habitat-lab @ git+https://github.com/facebookresearch/habitat-lab.git@main#subdirectory=habitat-lab ; sys_platform == 'linux'",
     # dev
     "pytest",
     "pylint",
@@ -51,7 +55,8 @@ dependencies = [
     "transformers>=5.3.0",
     "pyvista>=0.47.1",
     "open3d>=0.19.0",
-    "jaxkd[cuda]>=0.1.2",
+    "jaxkd>=0.1.2",
+    "jaxkd[cuda]>=0.1.2; sys_platform == 'linux'",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/environments/test_spl.py
+++ b/tests/environments/test_spl.py
@@ -10,6 +10,9 @@ import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
 import pytest
+
+pytest.importorskip("habitat", reason="habitat-lab installs on Linux only")
+
 from habitat.tasks.nav.shortest_path_follower import ShortestPathFollower
 from src.environments.habitat import HabitatEnvConfig, HabitatObjectNavEnv
 

--- a/tests/r2dreamer/test_cross_framework.py
+++ b/tests/r2dreamer/test_cross_framework.py
@@ -22,6 +22,10 @@ sys.path.insert(0, EXT)
 
 import jax
 import jax.numpy as jnp
+
+pytest.importorskip("omegaconf", reason="omegaconf ships with habitat-lab, which installs on Linux only")
+pytest.importorskip("rssm", reason="requires the PyTorch R2-Dreamer clone in external/r2dreamer")
+
 from omegaconf import OmegaConf
 
 # -- PyTorch imports --


### PR DESCRIPTION
## Problem

`uv run pytest` fails on macOS arm64:

```
error: Distribution `jax-cuda12-plugin==0.10.2` can't be installed because it
doesn't have a source distribution or wheel for the current platform
```

Two independent blockers:

1. **`jax[cuda12]` and `jaxkd[cuda]`** pulled `jax-cuda12-plugin` unconditionally. It ships only `manylinux_2_27_{aarch64,x86_64}` wheels.
2. **`habitat-sim` / `habitat-lab`** build from git; the CMake build fails on macOS.

Gating habitat then surfaced a third: `test_spl.py` and `test_cross_framework.py` import `habitat` / `omegaconf` at module scope, so collection errored out and no tests ran at all.

## Fix

**`pyproject.toml`** — gate all four deps behind `sys_platform == 'linux'`, with plain `jax` / `jaxkd` for other platforms.

Note the whitespace before `;` on the habitat lines — PEP 508 requires it for direct-reference URLs, otherwise the `;` is parsed as part of the URL and setuptools rejects the dependency.

**Tests** — guard the two habitat-dependent modules with `pytest.importorskip` so they skip cleanly. `test_cross_framework` also needs the PyTorch reference clone in `external/r2dreamer`, which is gitignored and absent by default, so it guards on `rssm` too.

## Verification

- `uv sync` completes on macOS arm64 (previously failed).
- Bare `uv run pytest` collects with **no errors**: **422 passed, 58 skipped**.
- Linux is unchanged: the universal lock still resolves `jax-cuda12-plugin` and both habitat git sources under `sys_platform == 'linux'`. Same version pins; uv unions the extras.
- `uv.lock` is gitignored, so nothing to commit there — re-run `uv sync` to regenerate.

## Known remaining (pre-existing, not from this change)

12 failures that reproduce on `main` regardless of platform: 11 from the gitignored `data/` directory being absent (curriculum files), plus `tests/slurm/test_launch.py::test_smoke_then_prod_uses_afterok_dependency_before_prod_submit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)