### PR TITLE
fix(loops): log training metrics again - latch the pending log until an update runs

### DIFF
--- a/scripts/slurm/configs/_base.yaml
+++ b/scripts/slurm/configs/_base.yaml
@@ -39,7 +39,15 @@ smoke:
   assert_min_rows: 5
   args:
     steps: 1500
-    prefill: 500
+    # Must stay >= batch_size * seq_len (16 * 64 = 1024), the replay gate in
+    # train_loop. Below that the gate opens mid-run instead of at step 0, which
+    # shifts the parity of the gradient-update steps and puts the smoke in a
+    # different regime than prod (which prefills 5000). That divergence is what
+    # let the train-metric logging bug reach production unseen: the smoke's
+    # updates happened to land on the log_every steps, so it logged metrics
+    # while every prod run silently logged none. 2048 = 2x the gate, so the
+    # smoke keeps matching prod if batch_size or seq_len grow moderately.
+    prefill: 2048
     checkpoint_every: 1000000
     seed: 42
     log_every: 50

--- a/src/r2dreamer/launch/loops.py
+++ b/src/r2dreamer/launch/loops.py
@@ -426,6 +426,7 @@ def train_loop(
     logger.start_timing(start_step)
     batch_steps = acfg.batch_size * acfg.seq_len
     train_credit = 0.0
+    log_pending = False
     video_next_step = start_step
     if _should_record_video(tcfg, logger, experience, start_step, video_next_step):
         experience.start_video_capture()
@@ -451,7 +452,11 @@ def train_loop(
         # --- Train ---
         if experience.buffer_size >= batch_steps:
             train_credit += acfg.train_ratio / batch_steps
-            will_log = step % tcfg.log_every == 0
+            if step % tcfg.log_every == 0:
+                log_pending = True
+            # With fractional credit the update and the log cadence can have
+            # opposite parity, so a due log waits for the next real update.
+            will_log = log_pending and train_credit >= 1.0
             batch = None
             metrics = None
             while train_credit >= 1.0:
@@ -462,6 +467,7 @@ def train_loop(
 
             if will_log and metrics is not None:
                 logger.log_train_metrics(metrics, step)
+                log_pending = False
                 if (
                     getattr(acfg, "decoder", False)
                     and batch is not None

--- a/tests/r2dreamer/test_training_loops.py
+++ b/tests/r2dreamer/test_training_loops.py
@@ -144,6 +144,7 @@ class _FakeLogger:
 
     def __init__(self):
         self.rows: list[list] = []
+        self.train_metric_calls: list[tuple[int, dict]] = []
         self.videos: list[tuple[str, int]] = []
         self.adapter_summaries: list[tuple[dict, int]] = []
         self.wandb_active = False
@@ -159,6 +160,7 @@ class _FakeLogger:
         self.videos.append((key, step))
 
     def log_train_metrics(self, metrics, step: int) -> None:
+        self.train_metric_calls.append((step, dict(metrics)))
         for k, v in metrics.items():
             self.rows.append([step, k, v])
 
@@ -514,10 +516,28 @@ class TestTrainLoopCadences:
     def test_materialize_is_true_only_on_log_steps(self, tmp_path, build_agent):
         cfg, agent, spy = build_agent(train_ratio=2)
 
-        _run_train_loop(tmp_path, cfg, agent, total_steps=6, log_every=2)
+        logger, _ = _run_train_loop(tmp_path, cfg, agent, total_steps=6, log_every=2)
 
-        # Gate opens at step 1, one update per step for steps 1..5;
-        # will_log = step % 2 == 0 => True at steps 2 and 4.
+        # Gate opens at step 1, one update per step for steps 1..5; credit is
+        # always >= 1.0 here, so the pending log fires on its own step:
+        # steps 2 and 4.
+        assert spy.materialize_flags == [False, True, False, True, False]
+        assert [step for step, _ in logger.train_metric_calls] == [2, 4]
+
+    def test_fractional_credit_still_logs_train_metrics(self, tmp_path, build_agent):
+        # batch_steps = 1 * 9 = 9, train_ratio 3 => +1/3 credit per env step.
+        # The gate opens at step 8, so updates land on steps 10, 13, 16, 19, 22
+        # while log_every=6 marks steps 12 and 18: no update ever coincides
+        # with a log step, which is the production parity mismatch.
+        cfg, agent, spy = build_agent(seq_len=9, train_ratio=3)
+
+        logger, _ = _run_train_loop(tmp_path, cfg, agent, total_steps=24, log_every=6)
+
+        assert spy.train_steps == 5
+        # The latched flag defers each pending log to the next real update.
+        assert [step for step, _ in logger.train_metric_calls] == [13, 19]
+        assert all(metrics for _, metrics in logger.train_metric_calls)
+        # materialize is True exactly on the iterations that log.
         assert spy.materialize_flags == [False, True, False, True, False]
 
     def test_val_loop_runs_on_cadence_when_val_experience_present(


### PR DESCRIPTION
No production run has ever logged training metrics. Confirmed on job 6056750
(L3 CNN, 59322 env steps): `metrics.csv` held only `episode/*` and `action/*`,
and the `.out` had zero `[step ...]` lines. Training itself was fine (~29660
gradient steps) - only the logging was lost.

## Root cause

In `train_loop`, gradient steps are driven by a fractional credit counter while
logging is driven by the env step:

```python
train_credit += acfg.train_ratio / batch_steps   # 512 / (16*64) = 0.5
will_log = step % tcfg.log_every == 0            # log_every = 250
```

Credit grows by exactly 0.5 per env step, so the `while train_credit >= 1.0`
loop that assigns `metrics` runs only on odd steps, while `will_log` selects
only even ones. `metrics` is therefore `None` on every logging step and the
guard `if will_log and metrics is not None` drops the log every single time.
The two parities can never align.

This is the norm, not an edge case: it follows from the shipped defaults
(batch_size 16, seq_len 64, train_ratio 512, log_every 250), so every arm and
every curriculum level at HEAD is affected.

## Fix

Decouple "it is time to log" from "an update happened in this iteration". A
`log_pending` flag latches when the log falls due and is cleared only once the
metrics are actually logged; `will_log` is evaluated after the credit increment
so it predicts whether the while loop will run.

`materialize=will_log` is preserved, so metrics are still materialized only on
iterations that log - the step-time optimization is intact. Gradient-step count
and train_ratio accounting are unchanged.

## Smoke ran in a different regime than prod

The smoke profile prefilled 500 transitions, below the replay gate
(`batch_size * seq_len` = 1024). The gate opened around env step 523 instead of
at step 0, which shifted the update parity - under the smoke's parity the
updates landed exactly on the log_every steps. That is why the smoke logged
metrics normally while every prod run logged none, and why the bug survived.

`_base.yaml` now prefills 2048 (2x the gate) so smoke and prod share the regime.

## Verification

Regression test `test_fractional_credit_still_logs_train_metrics` drives
`train_loop` in the fractional regime with an even `log_every`. It fails on the
unfixed code with `assert [] == [13, 19]` (zero logger calls) and passes after.
Full file: 18 passed.

E2E on SLURM, job 6057103 (prefill 1100, log_every 50, MANIFEST `completed`):
training metrics logged at steps

```
1 51 101 151 ... 1401 1451
```

All odd, each exactly one step after a due log step - the latch firing. Before
the fix this list is empty, which is what prod job 6056750 shows.

## Left out

The VGGT-family configs override smoke prefill to 200 (live house arms: 1000)
for cost reasons and remain below the gate, so their smokes keep the blind
spot. Raising them changes their smoke cost and belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)