### PR TITLE
docs: stop calling VGGT world points metric

### DIFF
--- a/src/adapters/contract.py
+++ b/src/adapters/contract.py
@@ -40,7 +40,7 @@ class Encoder(Enum):
     """
 
     CONV = auto()
-    # Spatial convolution over a metric point map rather than an image: same
+    # Spatial convolution over a world-point map rather than an image: same
     # architecture, but symlog compression instead of RGB centering, because
     # world coordinates are unbounded.
     CONV_POINTS = auto()

--- a/src/adapters/house_cloud_episodes.py
+++ b/src/adapters/house_cloud_episodes.py
@@ -40,7 +40,7 @@ class HouseCloudEpisodesAdapter:
     VOXELS_PER_EXTENT = 1000
     # Floor for the voxel edge: a degenerate cloud (all points coincident, e.g.
     # a collapsed point map) has zero extent, and a zero edge is not a valid
-    # voxel size. Sub-millimeter, so it never affects a real house.
+    # voxel size. Far below any real cloud extent, so it never binds.
     MIN_VOXEL_M = 1e-6
 
     def __init__(self, extractor: FeatureExtractor) -> None:

--- a/src/adapters/house_voxels.py
+++ b/src/adapters/house_voxels.py
@@ -87,9 +87,9 @@ class HouseVoxelsAdapter:
     HOUSE_POINTS = 16384
     VOXEL_SIZE_M = 0.01
     CONFIDENCE_SCORE = 1.5
-    # 1 cm voxels on full-res input reach ~210k points in 50 steps on one L1
-    # scene; a whole house is bounded by surface area (~500 m^2 -> ~5M voxels),
-    # so 2^23 (~293 MB device memory) covers any realistic scene outright.
+    # 0.01-unit voxels on full-res input reach ~210k points in 50 steps on one
+    # L1 scene (the cloud is scale-free, so the pitch is relative, not 1 cm);
+    # 2^23 (~293 MB device memory) leaves ~40x headroom over that growth.
     BUFFER_CAPACITY = 1 << 23
     BUFFER_HASH_TABLE_SIZE = 1 << 24
 
@@ -158,10 +158,12 @@ class HouseVoxelsAdapter:
         below replaces that padding with a cycle over the valid rows, so the
         cloud branch needs no validity mask.
 
-        float16 rather than the repo-default bfloat16: these are metric world
-        coordinates, and bfloat16's 8-bit mantissa resolves ~3 cm at 10 m - three
-        times coarser than the 1 cm voxel grid being stored. The cloud branch
-        re-centers in float32 before casting to its compute dtype.
+        float16 rather than the repo-default bfloat16: these are raw world
+        coordinates in VGGT's scale-free frame, stored on a 0.01-unit voxel
+        grid, and bfloat16's 8-bit mantissa resolves only ~1/256 of a
+        coordinate's magnitude - too coarse to keep neighboring voxels distinct
+        away from the origin. The cloud branch re-centers in float32 before
+        casting to its compute dtype.
         """
         snapshot, count = buffer.house_context_array(self.HOUSE_POINTS, jnp.float16)
         indices = jnp.arange(self.HOUSE_POINTS) % jnp.maximum(count, 1)
@@ -210,7 +212,8 @@ class HouseVoxelsAdapter:
                 key="camera_pose",
                 encoder=Encoder.MLP,
                 buffer=True,
-                # Metric pose: float32, same reasoning as the cloud's float16.
+                # Raw world-frame pose: float32, same reasoning as the cloud's
+                # float16.
                 value=jnp.ravel(features.camera_pose).astype(jnp.float32),
             ),
             AdapterField(

--- a/src/adapters/pointmap.py
+++ b/src/adapters/pointmap.py
@@ -25,11 +25,12 @@ def pool_point_map(world_points: jnp.ndarray, side: int) -> jnp.ndarray:
     """Downsample an HWC point map to ``(side, side, 3)``.
 
     An exact integer factor (the production case, 518 -> 37) is a box mean,
-    which keeps metric coordinates unbiased; other ratios fall back to an
+    which keeps the coordinates unbiased; other ratios fall back to an
     antialiased linear resize.
 
     Args:
-        world_points: ``(H, W, 3)`` or ``(1, H, W, 3)`` metric point map.
+        world_points: ``(H, W, 3)`` or ``(1, H, W, 3)`` scale-free world-point
+            map (first-frame reference, not metric).
         side: Target side length.
 
     Returns:

--- a/src/adapters/pointmap_dense.py
+++ b/src/adapters/pointmap_dense.py
@@ -18,7 +18,7 @@ from src.vggt.jax.feature_extractor import VGGT_IMAGE_SIZE
 class PointMapDenseAdapter:
     """Routes the unpooled ``(518, 518, 3)`` point map to a spatial conv branch.
 
-    No pooling and no appearance channel: the conv stack sees metric world
+    No pooling and no appearance channel: the conv stack sees raw world
     coordinates at render resolution, so the geometry keeps its spatial structure
     instead of being flattened into a vector. ``Encoder.CONV_POINTS`` selects the
     symlog input transform - RGB centering would be meaningless on unbounded

--- a/src/adapters/pointmap_pose.py
+++ b/src/adapters/pointmap_pose.py
@@ -28,9 +28,10 @@ class PointMapPoseAdapter:
     observation and needs no live slot. Nothing accumulates across steps: this
     is the per-frame-geometry arm.
 
-    Metric XYZ stays float32: the values are world coordinates in meters, whose
-    magnitude exceeds bfloat16's resolution. The encoder casts to its own
-    compute dtype after normalization.
+    XYZ stays float32: the values are raw world coordinates in VGGT's
+    scale-free frame (first-frame reference, not meters), whose magnitude
+    exceeds bfloat16's resolution. The encoder casts to its own compute dtype
+    after normalization.
 
     Two class constants define the family: ``WP_SIDE`` sets the reduction, and
     ``WITH_RGB`` decides whether the appearance channel is observed at all.

--- a/src/r2dreamer/encoders/cnn.py
+++ b/src/r2dreamer/encoders/cnn.py
@@ -18,8 +18,8 @@ def _symlog(x: jnp.ndarray) -> jnp.ndarray:
     """Symmetric log compression, ``sign(x) * log1p(|x|)``.
 
     Dreamer's standard transform for unbounded inputs. Used by
-    ``ConvEncoder(input_kind="world_points")`` to tame the metric XYZ range of
-    full-resolution world points.
+    ``ConvEncoder(input_kind="world_points")`` to tame the unbounded XYZ range
+    of full-resolution world points.
     """
     return jnp.sign(x) * jnp.log1p(jnp.abs(x))
 
@@ -27,7 +27,7 @@ def _symlog(x: jnp.ndarray) -> jnp.ndarray:
 class ConvEncoder(nn.Module):
     """Shared spatial convolutional encoder for RGB images or world-point maps.
 
-    ``input_kind`` is explicit because RGB and metric XYZ world points can share
+    ``input_kind`` is explicit because RGB and XYZ world points can share
     the same ``(B, H, W, 3)`` shape but need different preprocessing: RGB uses
     Dreamer's ``obs - 0.5`` centering, world points use symlog. ``embed_dim`` is
     optional for historical RGB compatibility; set it for world-point variants

--- a/src/r2dreamer/encoders/pointnet.py
+++ b/src/r2dreamer/encoders/pointnet.py
@@ -130,7 +130,7 @@ class PointNetCloudEncoder(nn.Module):
         n_points = points.shape[0]
         m = min(self.num_points, n_points)
         sample_idx = (jnp.arange(m, dtype=jnp.int32) * n_points) // m
-        # Centering/scale in float32: metric world offsets exceed reduced-
+        # Centering/scale in float32: raw world offsets exceed reduced-
         # precision resolution, and the 1e-6 floor below is subnormal in
         # float16 - it flushes to zero, turning a degenerate (zero-extent)
         # cloud into 0/0 = NaN. The normalized cloud is O(1), so casting down


### PR DESCRIPTION
## What changed

Reworded nine docstrings/comments across eight files that described VGGT world points as "metric" or meter-scaled. They now say scale-free / raw world coordinates (first-frame reference). Comments only, no behavior change (py_compile on all eight files passes).

- src/adapters/pointmap.py - pool_point_map docstring (both the box-mean rationale and the Args entry)
- src/r2dreamer/encoders/cnn.py - _symlog and ConvEncoder docstrings
- src/adapters/pointmap_pose.py - claimed "world coordinates in meters"; float32 rationale kept, meter claim dropped
- src/adapters/pointmap_dense.py - "metric world coordinates" -> "raw world coordinates"
- src/adapters/contract.py - CONV_POINTS enum comment
- src/adapters/house_voxels.py - float16 precision rationale (was "~3 cm at 10 m" vs "1 cm voxel grid") now argued relatively; capacity comment no longer sized by "~500 m^2 house"; "Metric pose" -> "Raw world-frame pose"
- src/r2dreamer/encoders/pointnet.py - "metric world offsets" -> "raw world offsets"
- src/adapters/house_cloud_episodes.py - "Sub-millimeter, so it never affects a real house" -> extent-relative wording

## Why

The metric claim is refuted: the DPT head activates world points with sign(y)*expm1(|y|) (src/vggt/jax/heads/dpt_head.py, _activate_head_inv_log_expp1) and nothing in src/vggt/** or src/adapters/** rescales against Habitat depth, so the points are defined only up to scale in the first-frame reference. Measured in prototyp/kv-budget-pointcloud/PROBLEMS.md (2026-07-28): the scene diagonal of an L3 apartment scene is ~0.4 units.

## Reviewer notes

- Left untouched on purpose: "before any metric moved" (house_voxels.py, means a measured KPI) and "instead of with a metric constant" (house_cloud_episodes.py, correctly states that no meter constant is used there).
- Out of scope but flagged as a follow-up task: VOXEL_SIZE_M = 0.01 in house_voxels.py is an absolute pitch chosen under the meter assumption; at ~0.4-unit scene diagonals the relative grid is much coarser than the 1-cm intent. The _M constant-name suffixes were also left as-is since renaming touches code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)