### PR TITLE
docs(prototyp): Duell-3-Spec - Frame- und Kamera-Tokens im gepoolten Arm

### DIFF
--- a/prototyp/duell-vggt-integration/2026-07-29-r3/GOAL.md
+++ b/prototyp/duell-vggt-integration/2026-07-29-r3/GOAL.md
@@ -1,0 +1,211 @@
+# Goal - Duell 3: Frame-Tokens und Kamera-Tokens in den gepoolten Arm
+
+## Ziel
+
+Innerhalb von **drei Stunden Gesamtzeit** den bestaetigten Sieger von Duell 2
+schlagen, indem die **Frame-Haelfte** der VGGT-Aggregator-Tokens und **beide
+Kamera-Tokens** in den Beobachtungsvektor aufgenommen werden. Gemessen auf
+**Curriculum Level 3**, in einem **30-Minuten-Trainingslauf**.
+
+Der heutige Arm `AggregatorPooledAdapter` (`src/adapters/global_tokens.py:127`)
+liest ausschliesslich die **globale Haelfte** der Aggregator-Tokens und poolt
+sie zu `[camera token, patch mean, patch max]` = 3 x 1024 = 3072. Die
+Frame-Haelfte faellt im Extractor ohnehin an
+(`src/vggt/jax/feature_extractor.py:992` splittet die 2048 Kanaele in
+`frame_tokens` und `global_tokens`) und wird verworfen.
+
+Ein gewerteter Lauf ist immer ein **`--prod`-Lauf mit 30 Minuten Walltime**,
+nie `--smoke`. Der gewertete Lauf laeuft in die Walltime und endet als SLURM
+`TIMEOUT`. Das ist erwartetes Verhalten, kein Fehler; die `metrics.csv` wird
+fortlaufend geschrieben und verliert dadurch nichts.
+
+## Format
+
+Der Agent laeuft **allein**. Es gibt keine Gegenseite und keine Blindheit. Der
+Agent meldet nach jeder Welle in drei Zeilen den Stand an Luca.
+
+## Die zwei Vergleichsebenen
+
+Dieses Duell beantwortet zwei getrennte Fragen und haelt sie deshalb
+auseinander:
+
+1. **Headline - bringen Frame-Tokens ueberhaupt etwas?**
+   **P1 gegen C.** Genau eine Variable: Frame-Haelfte drin oder nicht. P1
+   benutzt deshalb **denselben MLP-Encoder wie C**, unveraendert.
+2. **Interne Rangliste - wie kodiert man sie am besten?**
+   Alle weiteren Arme werden **gegen P1** verglichen und gegen P1 gerankt.
+
+Die **PR-Entscheidung laeuft ausschliesslich gegen C**, damit die Schwelle
+zwischen den Duellen vergleichbar bleibt. P1 ist PR-Kandidat wie jeder andere
+Arm.
+
+Faellt der Headline-Vergleich negativ aus, ist das ein Ergebnis und wird als
+solches ins Ledger geschrieben. Die interne Rangliste laeuft trotzdem weiter.
+
+## P1 - der Pflichtarm
+
+```
+tokens_full = concat([frame_tokens, global_tokens], axis=-1)   # (1374, 2048)
+patches     = tokens_full[AGG_PATCH_START_IDX:]                # (1369, 2048)
+
+P1 = concat([ tokens_full[AGG_CAMERA_TOKEN_IDX],   # 2048, beide Kamera-Tokens
+              patches.mean(axis=0),                # 2048
+              patches.max(axis=0) ])               # 2048
+                                                   # = 6144 float32, 24 KB/Step
+```
+
+Das ist wortwoertlich das Muster der Referenz, nur auf voller Kanalbreite. Der
+Kamera-Token kommt damit aus beiden Haelften; die Register-Tokens bleiben wie
+in der Referenz draussen (`AGG_PATCH_START_IDX = 1 + AGG_REGISTER_TOKENS`,
+`src/adapters/global_tokens.py:24`).
+
+Adapter-Name in `ADAPTERS`: `aggregator_pooled_full`.
+
+**P1 ist VGGT-kostenneutral.** Beide Token-Haelften fallen im Extractor
+ohnehin an, das Pooling ist ein mean/max ueber 1369 Zeilen, und die
+Replay-Zeile waechst von 12 auf 24 KB. Weicht `ms/Step` von P1 spuerbar von
+Cs 66.8 ab, ist das ein Befund und gehoert ins Ledger.
+
+## Startpunkte fuer die weiteren Arme
+
+Vorschlaege, keine Vorschrift. Der Agent darf eigene Richtungen einschlagen,
+solange die harte Bedingung aus `RULES.md` Abschnitt 3 gilt: **jeder gewertete
+Arm enthaelt die Frame-Haelfte.**
+
+| | Idee | Warum |
+|---|---|---|
+| P2 | `[cam_global, mean_g, max_g, mean_f]` = 4096 | isoliert, ob der Frame-Mittelwert allein schon traegt - die billige Halbstufe zu P1 |
+| P3 | Pose-Delta: `cam_t - cam_0` als eigener Block | Jianyuans offener Faden aus dem r2-Ledger. Frame 0 ist permanenter Cache-Anker, also 0 ms VGGT-Kosten. Die metrische Form fuer `dtg`/`softspl`, nie ablatiert |
+| P4 | gelerntes Attention-Pooling / Query-Token statt mean/max | mean/max sind die billigste, nicht die beste Reduktion |
+| P5 | getrennte `AdapterField`s pro Block statt eines breiten Vektors | gibt jedem Block einen eigenen Encoder-Zweig statt einer 6144 -> 1024 Projektion |
+
+## Referenz - die Latte, paarweise gewertet
+
+Der bestaetigte Sieger von Duell 2: Arm C, `aggregator_pooled_b200k` mit
+`prefill 1024`, `train_ratio 128`, `act_entropy 0.1`, 30 Minuten `--prod`.
+
+| Referenz | Seed | Treffer | sr | spl | softspl | dtg | ms/Step | Episoden | N |
+|---|---|---|---|---|---|---|---|---|---|
+| **6060404** | 42 | 1 | 0.0227 | 0.0119 | 0.0866 | 6.379 | 66.8 | 44 | 21751 |
+| **6061173** | 43 | 1 | 0.0244 | 0.0062 | 0.0539 | 4.975 | 69.1 | 41 | 20267 |
+
+Quellen: `prototyp/duell-vggt-integration/2026-07-27-r2/runs/6060404-aggpool-b200k-tr128/metrics.csv`
+und `.../6061173-aggpool-b200k-tr128-s43/metrics.csv`.
+
+**Die Wertung ist paarweise pro Seed:** ein Seed-42-Lauf wird gegen 6060404
+gewertet, der Seed-43-Bestaetigungslauf gegen 6061173. Der Grund steht in den
+Zahlen: Cs beide Seeds unterscheiden sich in `softspl` um 60 % (0.0866 gegen
+0.0539) und in `dtg` um 22 %. Gegen einen festen Seed-42-Vektor gewertet,
+bekaeme der Bestaetigungslauf einen Grossteil davon geschenkt, und die
+Bestaetigung waere wertlos.
+
+## Erfolgskriterien - die Wertungsmatrix
+
+Unveraendert aus Duell 2, nur auf Cs Zahlen gestellt. Jede Metrik geht als
+**relative Aenderung zur Referenz** ein, richtungskorrigiert, gekappt,
+gewichtet summiert:
+
+```
+rel = (wert - referenz) / |referenz|          fuer "hoeher ist besser"
+rel = (referenz - wert) / |referenz|          fuer "niedriger ist besser"
+
+Score = Summe ueber alle Metriken von (Gewicht * rel)
+```
+
+| Metrik | Richtung | Referenz s42 | Referenz s43 | Gewicht | Kappung |
+|---|---|---|---|---|---|
+| **Treffer** | hoch | 1 | 1 | **0.45** | +200 % |
+| `softspl` | hoch | 0.0866 | 0.0539 | 0.15 | +/-100 % |
+| `dtg` | niedrig | 6.379 | 4.975 | 0.15 | +/-100 % |
+| `spl` | hoch | 0.0119 | 0.0062 | 0.10 | +/-100 % |
+| `ms/Step` | niedrig | 66.8 | 69.1 | 0.10 | +/-100 % |
+| Episoden | hoch | 44 | 41 | 0.05 | +/-100 % |
+| (`sr`) | hoch | 0.0227 | 0.0244 | nur Bericht | - |
+
+- **Score > 0** heisst besser und kommt so ins Ledger.
+- **Score >= +0.10** ist die PR-Schwelle, als **Mittelwert beider Seeds**.
+- Der Arm mit dem hoechsten Score wird auf **Seed 43** bestaetigt. Bei
+  Gleichstand bekommen beide einen Bestaetigungslauf.
+- Ein Job, der nicht durchkommt, ist `gescheitert`: kein Score, zaehlt nicht
+  gegen die Variante.
+
+**`ms/Step` hat in diesem Duell eine andere Rolle als in Duell 2.** Dort waren
+die Trainingsknobs frei und Geschwindigkeit war der staerkste Hebel. Hier sind
+sie eingefroren, Cs Tempo-Sockel ist praktisch ausgereizt - von 66.8 ms sind
+laut Jianyuans Kostenzerlegung aus r2 rund 57 ms fixer VGGT-Sockel. Nach oben
+ist wenig zu holen. `ms/Step` und Episoden wirken deshalb vor allem als
+**Strafklausel gegen teure Encoder**: genau deswegen bleiben sie in der Matrix,
+obwohl der Encoder freies Spielfeld ist.
+
+## Ableseprotokoll
+
+- **Treffer** = Anzahl der Zeilen mit `episode/success == 1` in der
+  `metrics.csv`. Nicht aus `sr * Episoden` gerechnet.
+- Alle uebrigen Werte = **letzter geloggter Wert innerhalb des Slots**
+  (`metrics/spl`, `metrics/softspl`, `metrics/dtg`, `episode/count`,
+  `perf/ms_per_step_interval`).
+- Die `metrics.csv` ist im Langformat `step,metric,value` - eine Zeile pro
+  Messpunkt, nicht eine Spalte pro Metrik.
+- Fehlt `perf/ms_per_step_interval` in einem Lauf, gilt ersatzweise
+  `Elapsed_s / N * 1000` mit Vermerk im Ledger.
+
+## Was sich gegenueber Duell 2 geaendert hat, und warum
+
+**Die Latte ist jetzt Cs eigene Config, nicht mehr 6057641.** Gegen die alte
+Referenz gewinnt schon die reine Knob-Kombi aus Duell 2 (+0.09) ohne jeden
+Adapter-Beitrag. Der Score wuerde dann nicht messen, was dieses Duell fragt.
+Gegen C misst er den Adapter.
+
+**Die Trainings-Hyperparameter sind eingefroren.** In Duell 2 waren sie frei,
+und der Agent hat den Grossteil seines Budgets in Lotterie-Knobs gesteckt statt
+in die Integration. Hier ist der Adapter die einzige freie Achse - plus der
+Encoder, siehe unten.
+
+**Der Encoder ist freies Spielfeld.** Der Agent darf eigene Encoder-Module
+bauen und routen. Das ist eine bewusste Ausweitung: der reine Pooling-Raum
+waere eng, und dieses Duell soll die Richtungen finden, die ein spaeteres
+Duell dann verengen kann. `ms/Step` und Episoden bleiben deshalb in der Matrix.
+
+**`buffer_capacity` ist frei, aber gedeckelt.** Mit freiem Encoder darf der
+Agent die volle 1374-Token-Sequenz routen. Das ist erlaubt, hat aber einen
+Preis, den er kennen muss: siehe `RULES.md` Abschnitt 3.
+
+## Hypothese
+
+Die Frame-Haelfte der Aggregator-Tokens traegt frame-lokale Information, die
+die globale Haelfte nicht enthaelt, und der Kamera-Token der Frame-Haelfte
+traegt die Blickrichtung. Beides sollte `dtg` und `softspl` frueher bewegen
+als der rein globale Vektor - bei praktisch unveraenderten Kosten pro Step.
+
+## Ehrlicher Vorbehalt
+
+Die Referenz steht bei **einem** Treffer in 44 Episoden. Zwei Treffer statt
+einem sind statistisch kaum von einem Muenzwurf zu unterscheiden. Der Score
+wird real ueber `softspl` und `dtg` entschieden - die sind dicht, jede Episode
+liefert einen Wert.
+
+Rechne mit: **ohne Zweit-Treffer verlangt +0.10 ungefaehr `softspl` +40 %,
+`dtg` -15 % und `spl` +30 % gleichzeitig.** Ein Duell, das ohne PR endet, ist
+ein plausibler Ausgang. Es beantwortet trotzdem die Frage, um die es geht,
+naemlich P1 gegen C.
+
+Das Ledger von r2 beziffert ausserdem die **reine Ziehungsvarianz identischer
+Configs auf ~+/-0.04 Score**. Ein einzelner Score unter ~0.05 Abstand ist kein
+belastbares Ranking. Deshalb laeuft in Welle 2 ein Kontrolllauf von C auf
+Seed 42 mit.
+
+## Kontext zu Level 3
+
+| | |
+|---|---|
+| Curriculum | `data/curriculum/level3_10houses_1goal.json`, 10 HM3D-Haeuser, nur `chair`, 74 997 Train-Episoden |
+| Observation | ein RGB-Frame, 518x518 (VGGT), keine Goal-Conditioning |
+| Episode | max. 500 Steps (`src/environments/habitat.py:49`) |
+| Aktionen | 4 diskret, STOP ist ein No-op und beendet die Episode nicht |
+| Success | geodaetische Distanz < `GOAL_RADIUS = 0.2` m (`habitat.py:36`) |
+| Reward | `geodesic_delta` + `success_bonus 10.0` + `step_penalty -0.01` |
+
+Zur Einordnung des Duell-Fensters: die CNN-Baseline 6056750 erreichte in
+30 Minuten 59 322 Steps bei 2 % SR, also unter dem Random-Agenten (3.84 %). In
+diesem Fenster lernt kein Arm die Aufgabe. Gemessen wird, welche Integration am
+schnellsten anfaengt, sich in die richtige Richtung zu bewegen.

--- a/prototyp/duell-vggt-integration/2026-07-29-r3/LEDGER.md
+++ b/prototyp/duell-vggt-integration/2026-07-29-r3/LEDGER.md
@@ -1,0 +1,90 @@
+# Duell-3-Ledger 2026-07-29-r3 (Agent)
+
+Gepflegt vom Orchestrator. Eine Zeile pro Versuch, sofort nach der Auswertung.
+
+## Rahmen
+
+- Start (Wall-Clock): <UTC, erster Tool-Call>
+- Deadline: Start + 3:00. Letzte Welle spaetestens Start + 1:45.
+- Eingefrorener Seed: 42 (Bestaetigung des Fuehrenden: SEED=43 per CLI)
+- verify.sh beim Start: <PASS/FAIL, Uhrzeit>
+
+## Referenz (die Latte, paarweise gewertet)
+
+Duell-2-Sieger C: `aggregator_pooled_b200k` + prefill 1024 + train_ratio 128 +
+act_entropy 0.1, 30 min --prod.
+
+| Referenz | Seed | Treffer | sr | spl | softspl | dtg | ms/Step | Ep. | N |
+|---|---|---|---|---|---|---|---|---|---|
+| 6060404 | 42 | 1 | 0.0227 | 0.0119 | 0.0866 | 6.379 | 66.8 | 44 | 21751 |
+| 6061173 | 43 | 1 | 0.0244 | 0.0062 | 0.0539 | 4.975 | 69.1 | 41 | 20267 |
+
+Quellen: `../2026-07-27-r2/runs/6060404-aggpool-b200k-tr128/metrics.csv`,
+`../2026-07-27-r2/runs/6061173-aggpool-b200k-tr128-s43/metrics.csv`.
+
+## Wertungsmatrix (aus GOAL.md, hier nur als Gedaechtnisstuetze)
+
+Score = 0.45*rel(Treffer, hoch, Kappung +200%) + 0.15*rel(softspl, hoch)
+      + 0.15*rel(dtg, niedrig) + 0.10*rel(spl, hoch) + 0.10*rel(ms/Step, niedrig)
+      + 0.05*rel(Episoden, hoch); alle ausser Treffer auf +/-100% gekappt.
+Seed 42 gegen 6060404, Seed 43 gegen 6061173.
+Ablesung: Treffer = Zeilen mit `episode/success == 1`; Rest = letzter
+geloggter Wert. `metrics.csv` ist Langformat `step,metric,value`.
+
+## Welle 1 (submittet <UTC>, T+<h:mm>)
+
+| Slot | Config | Adapter / Encoder | Zeile / Kapazitaet | SLURM | Status |
+|---|---|---|---|---|---|
+| A | | P1 - `aggregator_pooled_full`, MLP wie C | 24 KB / 500 000 | | |
+| B | | | | | |
+| C | | | | | |
+| D | | | | | |
+
+## Welle 2 (submittet <UTC>, T+<h:mm>)
+
+| Slot | Config | Zweck | SLURM | Status |
+|---|---|---|---|---|
+| E | | Seed-43-Bestaetigung des Fuehrenden | | |
+| F | | Kontrolllauf C, Seed 42 (Ziehungsvarianz) | | |
+| G | | | | |
+| H | | | | |
+
+## Versuche (Scores gegen C)
+
+| # | Config | SLURM | Seed | Treffer | softspl | dtg | spl | ms/Step | Ep. | N | Score | Verdikt |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| | | | | | | | | | | | | |
+
+Verdikt-Vokabular: `besser` / `schlechter` / `neutral` / `gescheitert`
+(gescheitert = Job kam nicht durch, keine verwertbare Zahl).
+
+## Headline: P1 gegen C - bringen Frame-Tokens etwas?
+
+<Score von P1 gegen C, Einzelbeitraege, und die Antwort in einem Satz.>
+
+## Interne Rangliste gegen P1
+
+| Arm | Aenderung gegenueber P1 | Delta zu P1 | Verdikt |
+|---|---|---|---|
+| | | | |
+
+## Kontrolllauf
+
+<Cs frische Ziehung auf Seed 42 gegen 6060404. Beziffert, wie viel des
+beobachteten Abstands blosse Ziehungsvarianz ist. r2-Erwartung: ~+/-0.04.>
+
+## Erkenntnisse
+
+(folgen)
+
+## Sackgassen
+
+(folgen)
+
+## Offene Faeden
+
+(folgen)
+
+## Pull Request
+
+<PR-Nummer und Score, oder: keiner, mit Begruendung an der Schwelle.>

--- a/prototyp/duell-vggt-integration/2026-07-29-r3/README.md
+++ b/prototyp/duell-vggt-integration/2026-07-29-r3/README.md
@@ -1,0 +1,38 @@
+# Duell 3 - 2026-07-29-r3
+
+Dritter Durchlauf des VGGT-Integrationsduells. Frage: **Bringen die
+Frame-Haelfte der Aggregator-Tokens und beide Kamera-Tokens etwas, und wie
+kodiert man sie am besten?**
+
+## Die Dateien
+
+| Datei | Inhalt |
+|---|---|
+| `GOAL.md` | Ziel, die zwei Vergleichsebenen, P1, die Latte, Wertungsmatrix, Ableseprotokoll |
+| `RULES.md` | Zeit, eingefrorene Zone, freies Spielfeld, Compute, Wellenplan, PR |
+| `LEDGER.md` | eine Zeile pro Versuch, gepflegt vom Orchestrator |
+| `agents/<name>/NOTES.md` | Arbeitsnotizen, ein Ordner pro Agent |
+| `runs/<jobid>-<slot>/` | kopierte `metrics.csv`, Logs, sbatch-Skripte |
+
+`verify.sh` und `expected_curriculum.sha256` liegen eine Ebene hoeher und
+werden **nicht** veraendert. `GOAL.md` und `RULES.md` im Elternordner gehoeren
+zu Duell 2 und bleiben unangetastet.
+
+## Der Kern in fuenf Zeilen
+
+- **Latte:** Duell-2-Sieger C, paarweise pro Seed - 6060404 (s42), 6061173 (s43).
+- **P1 (Pflicht):** `[cam_full(2048), mean(patches_full), max(patches_full)]`
+  = 6144, mit Cs MLP-Encoder. Headline-Vergleich P1 gegen C, eine Variable.
+- **Alle weiteren Arme** werden gegen P1 gerankt, aber gegen C auf die
+  PR-Schwelle geprueft.
+- **Eingefroren:** alle Trainings-Hyperparameter. **Frei:** Adapter *und*
+  Encoder. Harte Bedingung: jeder Arm enthaelt die Frame-Haelfte.
+- **PR ab Mittel +0.10**, Bestaetigung auf Seed 43 Pflicht.
+
+## Vorgeschichte
+
+- `../2026-07-27/` - Duell 1: der pooled Arm schlaegt hybrid und pointmap.
+- `../2026-07-27-r2/` - Duell 2: kv200k + prefill 1024 + train_ratio 128 +
+  act_entropy 0.1 ist der bestaetigte Sieger (Mittel +0.0546, unter der
+  Schwelle, kein PR). Sieben Erkenntnisse und die offenen Faeden dort sind
+  Pflichtlektuere - P3 stammt daraus.

--- a/prototyp/duell-vggt-integration/2026-07-29-r3/RULES.md
+++ b/prototyp/duell-vggt-integration/2026-07-29-r3/RULES.md
@@ -1,0 +1,261 @@
+# Regeln - Duell 3: Frame-Tokens und Kamera-Tokens
+
+Diese Datei ist bindend. Bei Zweifelsfaellen gilt der Wortlaut hier, nicht die
+eigene Einschaetzung.
+
+## 1. Zeit
+
+- **Drei Stunden Gesamtzeit**, Wall-Clock, ab dem ersten Tool-Call.
+- Es zaehlt **alles**: Nachdenken, Code schreiben, SLURM-Queue-Wartezeit,
+  Laufzeit der Jobs, Auswertung, PR-Erstellung.
+- Nach drei Stunden ist Schluss. Was dann nicht ausgewertet ist, zaehlt nicht.
+- **Die letzte Welle wird spaetestens bei T+1:45 abgesetzt.** Darin liegen der
+  Bestaetigungslauf auf Seed 43 und der Kontrolllauf. Was danach noch startet,
+  wird nicht mehr fertig und ist verlorene Queue-Zeit.
+- **Architektur wird nur gebaut, waehrend GPUs rechnen.** Die Queue steht nie
+  still, weil noch Code entsteht. Einzige Ausnahme ist P1: der muss vor
+  Welle 1 existieren.
+
+## 2. Eingefrorene Zone (harte Grenze)
+
+### 2.1 Pfade
+
+Folgende Pfade duerfen **nicht veraendert** werden:
+
+```
+src/environments/**
+data/curriculum/**
+src/shared/wandb_utils.py
+prototyp/duell-vggt-integration/verify.sh
+```
+
+Damit sind eingefroren: `GOAL_RADIUS`, `_is_success_distance`, die
+Done-Bedingung, `max_episode_steps = 500`, das Rolling-100-Fenster der
+Metrik-Aggregation, das Curriculum-JSON und die SR-Berechnung in
+`EpisodeTracker`. `verify.sh` steht mit auf der Liste: ein Gate, das man
+unterwegs aufbohrt, ist kein Gate.
+
+### 2.2 Trainings-Hyperparameter
+
+Anders als in Duell 2 sind die Trainingsknobs **eingefroren**. Jeder gewertete
+Lauf faehrt Cs Config:
+
+| Knob | Wert | Herkunft |
+|---|---|---|
+| Curriculum | `L3` | Duell-Vorgabe |
+| Seed | `42` (Bestaetigung `43`, siehe Abschnitt 7) | Duell-Vorgabe |
+| `prefill` | `1024` | `duell2_l3_aggpool_b200k_tr128.yaml` |
+| `train_ratio` | `128` | dito |
+| `act_entropy` | `0.1` | dito |
+| KV `total_budget` | `200_000` | `AggregatorPooledAdapter.EXTRACTOR_KWARGS` |
+| `compute_heads` | `False` | dito |
+| `batch_size` / `seq_len` | `16` / `64` | `_base.yaml` |
+| Lernrate | Default | `_base.yaml` |
+
+`aggregator_pooled_b200k` ist seit Commit `43f5a1c` nur noch ein **Alias** von
+`aggregator_pooled` - das 200k-Budget ist der Default. Ein Adapter, der von
+`AggregatorPooledAdapter` erbt, bekommt ihn automatisch.
+
+**Der Camera-Head bleibt aus.** "Kamera-Tokens" meint Token 0 der Frame-Haelfte
+und Token 0 der globalen Haelfte, beide latent und gratis. Der echte
+Camera-Head (`camera_pose`) braeuchte `compute_heads=True` und kostet ms/Step;
+der Geometrie-Arm hat in r2 mit -0.5829 verloren.
+
+### 2.3 Messung
+
+Die Definition der Messung, die Wertungsmatrix und die paarweise
+Seed-Zuordnung (siehe `GOAL.md`).
+
+## 3. Freies Spielfeld
+
+Alles andere ist erlaubt und ausdruecklich erwuenscht:
+
+- **Der Adapter.** Neue Adapter-Module, Zusammensetzung des Beobachtungs-
+  vektors, Pooling-Verfahren, Aufteilung in mehrere `AdapterField`s,
+  `src/adapters/**`.
+- **Der Encoder.** Eigene Encoder-Module unter `src/r2dreamer/encoders/`, neue
+  `Encoder`-Enum-Mitglieder, Routing in `routed_composite.py`, `mlp_hidden` /
+  `mlp_layers`, `src/r2dreamer/**`, `src/vggt/**`.
+- Neue Run-Ids und neue YAMLs unter `scripts/slurm/configs/`.
+
+Neue Varianten folgen dem Muster aus `src/r2dreamer/AGENTS.md:44-56`: Adapter +
+`ADAPTERS`-Registrierung + Encoder-Routing + Branch unter `encoders/` +
+Verdrahtung in `routed_composite.py` + `RUN_CONFIGS`-Eintrag + SLURM-YAML.
+Kein neuer Python-Shim. Eine Variante, die sich nur in einer Konstante
+unterscheidet, ist eine Subklasse, keine Kopie der Pipeline.
+
+### 3.1 Harte Bedingung: die Frame-Haelfte
+
+**Jeder gewertete Arm enthaelt die Frame-Haelfte der Aggregator-Tokens.** Ein
+Arm, der nur die globale Haelfte anders poolt oder kodiert, beantwortet die
+Frage dieses Duells nicht und wird nicht gewertet.
+
+### 3.2 Speicherdeckel
+
+`buffer_capacity` ist frei, aber die **Vorbelegung ist auf 32 GB gedeckelt**:
+
+```
+buffer_capacity * Zeilengroesse <= 32 GB
+```
+
+Jeder Arm traegt **Zeilengroesse und Kapazitaet ins Ledger**.
+
+Gemessene Grundlage: SLURM fordert `mem: 64G` pro Job (`_base.yaml:14`), und
+der C-Lauf 6060404 hat davon 13.20 GB benutzt
+(`slurm-6060404.out:104`). 64 - 13 Grundlast - 32 Replay laesst rund 19 GB
+Puffer. `mem` wird **nicht** hochgesetzt: ein groesserer Request verlaengert die
+Queue-Wartezeit, und die ist im Drei-Stunden-Fenster teurer als der Speicher.
+
+Was der Deckel praktisch bedeutet:
+
+| Arm | Zeile | max. Kapazitaet |
+|---|---|---|
+| C (Referenz) | 3072 fp32 = 12 KB | 500 000 (= 6 GB), unveraendert |
+| P1 | 6144 fp32 = 24 KB | 500 000 (= 12 GB) |
+| P2 | 4096 fp32 = 16 KB | 500 000 (= 8 GB) |
+| volle Sequenz | 1374 x 2048 fp16 = 5.6 MB | **~5 700 Zeilen** |
+
+Ein Sequenz-Arm bekommt also ein Replay-Fenster von ~5 700 Schritten, waehrend
+ein gepoolter Arm bei 500 000 bleibt, und zahlt zusaetzlich ueber `ms/Step`.
+Das ist die ehrliche Kostenwahrheit der Sequenz-Arme, keine Abschreckung: wer
+sie fahren will, faehrt sie und schreibt das Ergebnis ins Ledger.
+
+## 4. Compute
+
+- Partition: **ausschliesslich `gpu_h100_short`**.
+  - **`dev_gpu_h100` ist tabu.** Die Partition bleibt Luca vorbehalten.
+  - `uc3n089` immer per `--exclude` ausschliessen (bricht bei habitat GL-Reads ab).
+- **Maximal 4 parallele GPU-Jobs.**
+- Ein gewerteter Lauf ist **30 Minuten Walltime im `--prod`-Modus**:
+
+  ```bash
+  bash scripts/slurm/launch.sh <variante> --prod --time 00:30:00 \
+      --partition gpu_h100_short --exclude uc3n089 --env SEED=42
+  ```
+
+  `--smoke` ist fuer gewertete Laeufe **verboten**. Es deckelt bei 1500 Steps
+  statt bei 30 Minuten und setzt eigene JAX-Speicheroptionen
+  (`launch.py:236-243`), die das Laufzeitverhalten veraendern. Fuer schnelle
+  Syntax- und Startchecks bleibt `--smoke` erlaubt; ein Absturz dort sagt
+  nichts ueber die Aenderung aus.
+- GPU-Code niemals auf dem Login-Node ausfuehren, immer ueber `srun` bzw.
+  `sbatch`.
+- **Jobs um ~1 Minute gestaffelt absetzen.** In r2 hat ein uv-sync-Race
+  parallel startender Jobs aus demselben Worktree die geteilte `.venv`
+  zerlegt und Slot B gekostet (6060403, exit 2 nach 31 s).
+
+## 5. Wellenplan
+
+| Welle | spaetestens | Slots |
+|---|---|---|
+| **1** | T+0:45 | **P1 gesetzt** (mit Cs MLP-Encoder, unveraendert) + drei Arme nach Wahl |
+| **2** | T+1:45 | Seed-43-Bestaetigung des Fuehrenden, **Kontrolllauf C auf Seed 42**, zwei Arme aus den Erkenntnissen von Welle 1 |
+
+Der Kontrolllauf ist eine frische Ziehung von Cs unveraenderter Config. Er
+wird nicht gewertet; er misst, wie viel des beobachteten Abstands blosse
+Ziehungsvarianz ist (r2: ~+/-0.04 Score).
+
+## 6. Berichtspflicht
+
+Keine Gegenseite, keine Blindheit. Nach jeder Welle meldet der Agent Luca in
+drei Zeilen: was lief, welche Scores kamen heraus, was als naechstes losgeht.
+
+## 7. Verifikation und der zweite Seed
+
+Vor jedem PR und am Ende des Duells laeuft
+`bash prototyp/duell-vggt-integration/verify.sh`. Das Script prueft die
+eingefrorene Zone, die Curriculum-Pruefsumme und den Seed. Schlaegt es fehl,
+ist der Lauf ungueltig.
+
+**Der Bestaetigungslauf nutzt dieselbe Config wie der Gewinner** und setzt den
+Seed ueber die Kommandozeile:
+
+```bash
+bash scripts/slurm/launch.sh <variante> --prod --time 00:30:00 \
+    --partition gpu_h100_short --exclude uc3n089 --env SEED=43
+```
+
+Der Grund ist mechanisch: `verify.sh:95` verlangt von **jeder** geaenderten
+oder neuen SLURM-Config ein literales `SEED: "42"`. Eine eigene YAML mit
+`SEED: "43"` wuerde das Gate reissen, nachdem der Lauf schon 30 Minuten
+gerechnet hat. Der CLI-Override ist in `_base.yaml:27` vorgesehen.
+
+Der Seed-43-Lauf wird **gegen 6061173** gewertet, nicht gegen 6060404
+(`GOAL.md`, Abschnitt "Referenz").
+
+## 8. Branch und Pull Request
+
+- Branch: `duell/2026-07-29-r3-<kurzbeschreibung>`.
+- Ein PR wird **nur geoeffnet, wenn der Score der Schwelle genuegt**:
+  Mittelwert aus Seed 42 und Seed 43 **>= +0.10**, gegen C gewertet.
+- Es gibt **genau einen PR**, den des bestaetigten Besten. Alle anderen Arme
+  ueber der Schwelle stehen nur als Ledger-Zeile mit dem Vermerk
+  "ueber Schwelle, unbestaetigt".
+- Der Agent oeffnet den PR. **Gemerged wird ausschliesslich von Luca.**
+- Niemals auf `main` pushen, niemals force-pushen.
+- Kein Agent-Name als Co-Author in Commit-Messages (`CLAUDE.md:6`).
+
+### PR-Body (Pflichtformat)
+
+```markdown
+## Ergebnis
+- Referenz:                     6060404 (s42) / 6061173 (s43), Duell-2-Sieger C
+- Score Seed 42 / Seed 43 / Mittel:   +X.XX / +X.XX / +X.XX
+- Schwelle:                     +0.10
+- Headline (P1 vs C):           +X.XX
+- SLURM Job-Ids:                XXXXXXX (s42), XXXXXXX (s43)
+- W&B Run-Ids:                  xxxxxxxx, xxxxxxxx
+- Replay-Zeile / Kapazitaet:    XX KB / XXX XXX (= XX GB)
+
+| Metrik   | Ref s42 | Seed 42 | Ref s43 | Seed 43 | Gewicht | Beitrag |
+|----------|---------|---------|---------|---------|---------|---------|
+| Treffer  | 1       |         | 1       |         | 0.45    |         |
+| softspl  | 0.0866  |         | 0.0539  |         | 0.15    |         |
+| dtg      | 6.379   |         | 4.975   |         | 0.15    |         |
+| spl      | 0.0119  |         | 0.0062  |         | 0.10    |         |
+| ms/Step  | 66.8    |         | 69.1    |         | 0.10    |         |
+| Episoden | 44      |         | 41      |         | 0.05    |         |
+| (sr)     | 0.0227  |         | 0.0244  |         | Bericht |         |
+
+## Was geaendert wurde
+<knappe Zusammenfassung des Diffs>
+
+## Warum das den Score verbessert
+<Begruendung, keine Spekulation ohne Zahl>
+
+## Verifikation
+- `bash prototyp/duell-vggt-integration/verify.sh` : PASS
+- Was bewusst nicht getan wurde: <...>
+```
+
+## 9. Wohin alles geschrieben wird
+
+Saemtliche Logs, Notizen, Zwischenstaende und Findings gehen in den
+Durchlauf-Ordner `prototyp/duell-vggt-integration/2026-07-29-r3/`.
+**Nichts davon geht nach `docs/notes/`.**
+
+- Jeder Agent schreibt ausschliesslich in `<ordner>/agents/<sein-name>/NOTES.md`.
+  Fremde Agent-Ordner sind lesend offen, schreibend tabu.
+- Das zentrale `<ordner>/LEDGER.md` pflegt nur der Orchestrator.
+- Logs, `metrics.csv` und gerenderte sbatch-Skripte nach `<ordner>/runs/`
+  kopieren.
+- Jede Zahl braucht eine Quelle: SLURM-Job-Id, Run-Verzeichnis, W&B-Id oder
+  `datei.py:zeile`.
+- Die Ordner der ersten beiden Duelle, `2026-07-27/` und `2026-07-27-r2/`,
+  sind lesend offen und ausdruecklich empfohlen. `2026-07-27-r2/LEDGER.md`
+  listet sechs ausgewertete Laeufe, sieben Erkenntnisse und die offenen
+  Faeden, aus denen P3 stammt.
+
+## 10. Besetzung
+
+Wie in r2: Orchestrator, Launcher, Analyst, Hypothesist, dazu die Personas
+`danijar-hafner` (RL, Actor-Entropie, Replay) und `jianyuan-wang` (VGGT,
+Token-Layout, Kostenzerlegung). Letzterer ist hier besonders einschlaegig: das
+Token-Layout und der Pose-Delta-Faden P3 stammen aus seinen r2-Notizen.
+
+## 11. Nach Ablauf
+
+Der Agent uebergibt `2026-07-29-r3/LEDGER.md` mit allen Score-Zeilen, dem
+Headline-Vergleich P1 gegen C, der internen Rangliste gegen P1, den Sackgassen
+und den offenen Faeden. Ob und was davon spaeter in die Thesis-Dokumentation
+wandert, entscheidet Luca danach.


### PR DESCRIPTION
Dritter Durchlauf des VGGT-Integrationsduells. Frage: bringen die Frame-Haelfte der Aggregator-Tokens und beide Kamera-Tokens etwas, und wie kodiert man sie am besten?

Was sich gegenueber Duell 2 aendert:

- Latte ist der bestaetigte r2-Sieger C statt 6057641, und sie wird paarweise pro Seed gewertet: Seed 42 gegen 6060404, Seed 43 gegen
  6061173. Cs beide Seeds liegen 60 % in softspl und 22 % in dtg auseinander, ein fester s42-Vektor wuerde die Bestaetigung entwerten.
- Trainings-Hyperparameter sind eingefroren auf Cs Config. In r2 ist der Grossteil des Budgets in Lotterie-Knobs statt in die Integration geflossen.
- Adapter und Encoder sind freies Spielfeld. ms/Step und Episoden bleiben deshalb in der Matrix, dort aber als Strafklausel gegen teure Encoder statt als Hebel.
- buffer_capacity ist frei mit hartem Deckel: Vorbelegung <= 32 GB. Grundlage sind mem 64G (_base.yaml:14) und die gemessenen 13.20 GB Grundlast des C-Laufs (slurm-6060404.out:104).
- Zwei Vergleichsebenen: P1 gegen C beantwortet "bringen Frame-Tokens etwas" mit einer Variablen, alle weiteren Arme werden gegen P1 gerankt. Die PR-Entscheidung laeuft weiterhin nur gegen C.

Wertungsmatrix, Schwelle +0.10, Zeitrahmen, Compute-Regeln und PR-Format bleiben unveraendert aus r2. Referenzzahlen im Ledger sind aus den r2-metrics.csv nachgerechnet.

GOAL.md und RULES.md liegen bewusst im Durchlaufordner statt im Elternordner; die Elternversionen bleiben das Duell-2-Protokoll.