### PR TITLE
feat(prototyp): add cross-level complexity analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,8 @@ coverage.json
 
 # Gate state (attempt counters, last check summary, PR body drafts)
 .gate/
+
+# Generated class/package diagrams dropped at the repo root (pyreverse,
+# graphviz). Scoped to the root on purpose: thesis figures under docs/ are
+# tracked and must stay visible to git.
+/*.svg

--- a/prototyp/complexity-analysis/GOAL.md
+++ b/prototyp/complexity-analysis/GOAL.md
@@ -1,0 +1,68 @@
+# Goal
+
+Cross function-level complexity with architecture-level complexity, so that
+"this code is complex" and "a lot depends on this code" can be read as one
+number instead of two separate tool outputs.
+
+## Hypothesis
+
+Neither axis alone ranks refactoring targets correctly. A function with high
+cyclomatic complexity in a leaf module is cheap to rework, while a moderately
+complex module that half the package imports is expensive to touch. Only the
+product identifies where complexity actually hurts.
+
+## Approach
+
+`complexity_report.py` does both passes over `src` in one AST walk per file:
+
+- **Function level**: radon `cc_visit`, the same cyclomatic numbers as
+  `radon cc` and `ruff --select C901`. Per module it aggregates decision
+  points (sum of complexity - 1), the maximum, and the worst function.
+- **Architecture level**: a static import graph over package-internal imports,
+  giving afferent coupling (Ca), efferent coupling (Ce), Martin instability
+  I = Ce / (Ca + Ce), Tarjan strongly connected components for import cycles,
+  and the blast radius, i.e. the transitive dependent count.
+
+Risk = decision points x (1 + blast radius), normalised to 100. Quadrants come
+from the top third of each axis:
+
+| Quadrant | Meaning |
+|---|---|
+| hotspot | complex and widely depended upon - refactor here first |
+| contained | complex but few dependents - safe to rework in isolation |
+| hub | simple but widely depended upon - keep it that way |
+| ok | neither |
+
+## Class level
+
+`class_metrics.py` adds the third granularity, between function and module,
+using the CK metric suite:
+
+- **CBO** (coupling between objects): distinct other project classes a class
+  references. Outward coupling, the "how hard is this to move or test" number.
+- **LCOM4** (lack of cohesion of methods): connected components of the method
+  graph, where two methods are linked when they share an instance attribute or
+  one calls the other. Inward decoupling: LCOM4 = n means n unrelated
+  responsibilities share a namespace, and each component is its own candidate
+  class.
+- Supporting: WMC (sum of method complexities), DIT, NOC.
+
+LCOM4 only means something once the constructs that are isolated *by
+construction* are removed, otherwise the metric is dominated by false
+positives. Excluded are `__init__`/`__post_init__`, staticmethods and
+classmethods, methods reading no instance state, and declaration-only classes
+(Protocol, ABC, Enum, TypedDict, NamedTuple, stub-only bodies).
+
+## Run
+
+```bash
+uvx --with radon python prototyp/complexity-analysis/complexity_report.py
+```
+
+```bash
+uvx --with radon python prototyp/complexity-analysis/class_metrics.py
+```
+
+radon comes through `uvx --with`, following the repo convention that tools
+which only read the code never re-sync the shared `.venv`. The reports are
+written to `outputs/prototype/complexity-analysis/`.

--- a/prototyp/complexity-analysis/HANDOFF.md
+++ b/prototyp/complexity-analysis/HANDOFF.md
@@ -1,0 +1,45 @@
+# Handoff
+
+## State (2026-07-29)
+
+Working. `complexity_report.py` runs clean over 97 modules / 498 functions and
+writes `outputs/prototype/complexity-analysis/report.md`.
+
+## Findings so far
+
+- The import graph is a **DAG**, zero cycles. Architecturally clean.
+- 8 hotspots, 6 of them the vendored JAX VGGT port under `src/vggt/jax/`.
+- The two genuinely authored hotspots are
+  `src.buffer.replay_buffer` (34 decisions, blast 21) and
+  `src.environments.habitat` (48 decisions, `__init__` at CC 18, blast 6).
+- `src.main` is the single most complex module (98 decisions, `run_loop` at
+  CC 31) but has **blast radius 0** and instability 1.00, so it is a leaf.
+  Splitting `run_loop` is the cheapest large complexity win in the repo.
+- `src.adapters.contract` is the sharpest hub: Ca 10, blast 16, only 16
+  decisions. Worth keeping thin.
+
+## Class level (class_metrics.py)
+
+107 classes, 23 of them declaration-only. Mean LCOM4 0.71, mean CBO 1.58.
+
+- **Cohesion is a non-issue.** After filtering the constructs that are isolated
+  by construction (see PROBLEMS.md), exactly one LCOM4 finding survives, and it
+  is cosmetic. No class in `src` needs splitting on cohesion grounds.
+- **CBO is the metric that carries information.** Four classes sit at or above
+  the 90th percentile: `R2DreamerAgent` (CBO 11), `RoutedCompositeEncoder` (8),
+  `JAXVGGTFeatureExtractor` (8), `HouseVoxelsAdapter` (6).
+- `JAXVGGTFeatureExtractor` is the heaviest class in the repo at WMC 89 across
+  31 methods, but cohesive (LCOM4 1). It is big, not tangled.
+- Inheritance is flat: DIT is 0 or 1 everywhere. No deep hierarchies.
+
+## Next steps if resumed
+
+1. Add a `--exclude src.vggt` flag to see the ranking of authored code alone.
+2. Weight import edges by imported-name count (see PROBLEMS.md).
+3. Add git churn as a third axis for a true Tornhill hotspot map.
+
+## Not done
+
+No test under `tests/prototyp/complexity-analysis/`. The script is read-only
+analysis with no consumers, so it was not worth a test yet. If it graduates to
+`scripts/` or a CI gate, it needs one.

--- a/prototyp/complexity-analysis/PROBLEMS.md
+++ b/prototyp/complexity-analysis/PROBLEMS.md
@@ -1,0 +1,54 @@
+# Open problems and caveats
+
+- **Vendored code dominates the ranking.** Six of the eight hotspots are the
+  JAX VGGT port under `src/vggt/jax/`, which is a transcription of an upstream
+  PyTorch model. Its complexity is inherited, not authored, and its high blast
+  radius is an artefact of a deep single-purpose import chain
+  (`attention <- block <- aggregator <- feature_extractor`). Deciding whether
+  to exclude `src/vggt/` is a judgement call, not a bug.
+
+- **Blast radius counts modules, not calls.** A module importing another for a
+  single constant weighs the same as one built entirely on top of it. Weighting
+  edges by the number of imported names would sharpen this.
+
+- **Static imports only.** Dynamic imports, `importlib` and plugin-style
+  lookups are invisible to the AST pass. The repo uses absolute `src.x.y`
+  imports throughout, so this is currently not a practical gap.
+
+- **Cyclomatic complexity is a path count, not a readability measure.**
+  `complexipy` rates `run_loop` at 82 cognitive against 31 cyclomatic, because
+  nesting is weighted. Adding cognitive complexity as a third axis is the
+  obvious next step; complexipy is a Rust CLI, so it would have to be shelled
+  out to and parsed rather than imported.
+
+- **Git churn is missing.** The classic hotspot formula is complexity x change
+  frequency (Tornhill). Blast radius is a structural proxy for the same idea.
+  Adding `git log --numstat` churn per module would give the empirical version.
+
+## LCOM4 false positives, and what removing them cost
+
+Textbook LCOM4 flagged 8 classes here. Every one was an artefact, and the
+filters had to be added one at a time against real examples:
+
+| Construct | Why it is isolated by construction | Example |
+|---|---|---|
+| `Protocol` / ABC / stub bodies | methods share no state on purpose | `ExperienceSource` scored LCOM4 9 of 9 methods |
+| `@classmethod` | binds `cls`, never `self` | `R2DreamerAgent.from_checkpoint` |
+| constant-returning properties | read no instance state at all | `JAXVGGTFeatureExtractor.image_size`, `HabitatObjectNavEnv.num_actions` |
+| `__init__` | touches every attribute, fuses all components | would drive nearly every LCOM4 to 1 |
+
+After filtering, one finding survives repo-wide, and it is cosmetic
+(`ExperienceCollector.diagnostics`, a one-line pass-through to an injected
+`diagnostics_fn` that nothing else reads). The honest conclusion is that LCOM4
+has no purchase on this codebase; CBO is the class-level metric that carries
+information here.
+
+- **CBO matches on bare names.** Two project classes sharing a name are
+  conflated, and a class referenced only in a type annotation weighs the same
+  as one that is instantiated and driven. Resolving imports per module would
+  fix the first, weighting by reference kind the second.
+
+- **Flax modules distort WMC and DIT.** `nn.Module` subclasses declare
+  attributes as class-level annotations and implement in `setup`/`__call__`,
+  so their method graph looks different from a plain Python class. DIT counts
+  project bases only, so every Flax class reads DIT 0.

--- a/prototyp/complexity-analysis/class_metrics.py
+++ b/prototyp/complexity-analysis/class_metrics.py
@@ -1,0 +1,528 @@
+"""Class-level coupling and cohesion metrics for `src` (CK metric suite).
+
+Two directions are measured, because "decoupling" at class level means both:
+
+- **CBO** (coupling between objects): how many other project classes a class
+  references. High CBO means the class is hard to move, test or reuse.
+- **LCOM4** (lack of cohesion of methods): the number of connected components
+  in the method graph, where two methods are connected when they share an
+  instance attribute or one calls the other. LCOM4 = 1 is a cohesive class,
+  LCOM4 = n means the class is n unrelated classes sharing a namespace.
+
+Supporting metrics are WMC (sum of method complexities, from radon), DIT
+(depth of inheritance) and NOC (number of children).
+
+`__init__` and `__post_init__` are excluded from the LCOM4 graph. A constructor
+touches every attribute by definition and would collapse every class to a
+single component, hiding exactly what the metric is supposed to expose.
+Staticmethods are excluded too, since they never touch `self` and would show up
+as isolated components regardless of how well the class hangs together.
+
+Run it with radon injected, so the shared .venv is never re-synced:
+
+    uvx --with radon python prototyp/complexity-analysis/class_metrics.py
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from radon.complexity import cc_visit
+from radon.visitors import Class as RadonClass
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = REPO_ROOT / "src"
+PACKAGE_NAME = "src"
+REPORT_PATH = (
+    REPO_ROOT / "outputs" / "prototype" / "complexity-analysis" / "class_report.md"
+)
+
+EXCLUDED_FROM_COHESION = {"__init__", "__post_init__"}
+
+# Bases that make a class a declaration rather than an implementation. Their
+# methods share no state by design, so LCOM4 would flag every single one.
+INTERFACE_BASES = {
+    "Protocol",
+    "ABC",
+    "ABCMeta",
+    "Enum",
+    "IntEnum",
+    "StrEnum",
+    "Flag",
+    "IntFlag",
+    "TypedDict",
+    "NamedTuple",
+}
+
+
+@dataclass
+class ClassInfo:
+    """Measured facts about one class definition.
+
+    Attributes:
+        name: Bare class name.
+        module: Dotted module name it is defined in.
+        lineno: Line of the `class` statement.
+        bases: Bare names of its base classes.
+        methods: Names of the methods that entered the cohesion graph.
+        stateless: Methods that read no instance state, excluded from LCOM4.
+        wmc: Weighted methods per class, the sum of method complexities.
+        max_cc: Cyclomatic complexity of its most complex method.
+        components: Connected components of the method graph, largest first.
+        cbo: Number of distinct other project classes it references.
+        noc: Number of direct subclasses inside the project.
+        interface: True when the class only declares an API and implements
+            nothing, so its cohesion is not meaningful.
+    """
+
+    name: str
+    module: str
+    lineno: int
+    bases: list[str] = field(default_factory=list)
+    methods: list[str] = field(default_factory=list)
+    stateless: list[str] = field(default_factory=list)
+    wmc: int = 0
+    max_cc: int = 0
+    components: list[list[str]] = field(default_factory=list)
+    cbo: int = 0
+    noc: int = 0
+    interface: bool = False
+
+    @property
+    def qualified(self) -> str:
+        """Module-qualified class name."""
+        return f"{self.module}.{self.name}"
+
+    @property
+    def lcom4(self) -> int:
+        """Lack of cohesion: the number of connected method components."""
+        return len(self.components)
+
+    @property
+    def islands(self) -> list[list[str]]:
+        """Components beyond the largest one, i.e. the detachable method sets."""
+        return self.components[1:]
+
+
+def module_name_for(path: Path) -> str:
+    """Map a source path to its dotted module name.
+
+    Args:
+        path: Path to a `.py` file inside the package root.
+
+    Returns:
+        The dotted module name, with `__init__.py` collapsing to its package.
+    """
+    relative = path.relative_to(PACKAGE_ROOT).with_suffix("")
+    parts = list(relative.parts)
+    if parts[-1] == "__init__":
+        parts.pop()
+    return ".".join([PACKAGE_NAME, *parts])
+
+
+def source_files() -> list[Path]:
+    """List every analysable source file in the package.
+
+    Returns:
+        Sorted paths, excluding bytecode caches.
+    """
+    return sorted(
+        path
+        for path in PACKAGE_ROOT.rglob("*.py")
+        if "__pycache__" not in path.parts
+    )
+
+
+def base_name(node: ast.expr) -> str | None:
+    """Reduce a base-class expression to its bare name.
+
+    Args:
+        node: Expression node from a `ClassDef.bases` entry.
+
+    Returns:
+        The bare name, e.g. `Module` for `nn.Module`, or None if not a name.
+    """
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def self_references(method: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    """Collect every `self.<name>` touched inside a method.
+
+    Args:
+        method: The method definition to inspect.
+
+    Returns:
+        Names accessed on `self`, whether attributes or method calls.
+    """
+    names: set[str] = set()
+    for node in ast.walk(method):
+        if (
+            isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "self"
+        ):
+            names.add(node.attr)
+    return names
+
+
+def is_unbound(method: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """Report whether a method never binds the instance.
+
+    Both `@staticmethod` and `@classmethod` receive no `self`, so they cannot
+    participate in instance-attribute cohesion and would otherwise register as
+    isolated components no matter how well the class is designed.
+
+    Args:
+        method: The method definition to inspect.
+
+    Returns:
+        True when the method is a staticmethod or a classmethod.
+    """
+    return any(
+        isinstance(dec, ast.Name) and dec.id in ("staticmethod", "classmethod")
+        for dec in method.decorator_list
+    )
+
+
+def is_stub(method: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """Report whether a method body is a placeholder rather than an implementation.
+
+    Args:
+        method: The method definition to inspect.
+
+    Returns:
+        True when the body is only a docstring, `pass` and/or `...`.
+    """
+    for statement in method.body:
+        if isinstance(statement, ast.Pass):
+            continue
+        if isinstance(statement, ast.Expr) and isinstance(
+            statement.value, ast.Constant
+        ):
+            continue
+        return False
+    return True
+
+
+def is_interface(node: ast.ClassDef) -> bool:
+    """Report whether a class declares an API instead of implementing one.
+
+    Protocols, ABCs, enums and typed containers share no instance state between
+    their methods by construction, which LCOM4 would otherwise read as a total
+    lack of cohesion.
+
+    Args:
+        node: The class definition to inspect.
+
+    Returns:
+        True for declaration-only classes.
+    """
+    if any(base_name(base) in INTERFACE_BASES for base in node.bases):
+        return True
+    methods = [
+        child
+        for child in node.body
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+    return bool(methods) and all(is_stub(method) for method in methods)
+
+
+def compute_lcom4(node: ast.ClassDef) -> tuple[list[list[str]], list[str]]:
+    """Compute the LCOM4 components and the method names they were built from.
+
+    Two methods are connected when they share a `self` attribute or one calls
+    the other. LCOM4 is the number of connected components of that graph;
+    returning the components themselves makes the number actionable, since each
+    component is a candidate for its own class.
+
+    Args:
+        node: The class definition to inspect.
+
+    Returns:
+        A tuple of the components, largest first, and the method names that
+        touch no instance state at all.
+    """
+    definitions = [
+        child
+        for child in node.body
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+    all_names = {child.name for child in definitions}
+    bound = [
+        child
+        for child in definitions
+        if child.name not in EXCLUDED_FROM_COHESION and not is_unbound(child)
+    ]
+
+    # A method that never reads `self` trivially forms its own component, which
+    # says nothing about the class. Constant-returning properties are the
+    # common case. They are reported separately instead of inflating LCOM4.
+    references = {child.name: self_references(child) for child in bound}
+    stateless = sorted(name for name, used in references.items() if not used)
+    considered = [child for child in bound if references[child.name]]
+    if not considered:
+        return [], stateless
+
+    touched = {child.name: references[child.name] for child in considered}
+    parent = {child.name: child.name for child in considered}
+
+    def find(name: str) -> str:
+        while parent[name] != name:
+            parent[name] = parent[parent[name]]
+            name = parent[name]
+        return name
+
+    def union(left: str, right: str) -> None:
+        root_left, root_right = find(left), find(right)
+        if root_left != root_right:
+            parent[root_right] = root_left
+
+    names = list(touched)
+    for i, left in enumerate(names):
+        # A direct call to a sibling method is an edge on its own.
+        for called in touched[left] & all_names:
+            if called in parent:
+                union(left, called)
+        for right in names[i + 1 :]:
+            shared = (touched[left] & touched[right]) - all_names
+            if shared:
+                union(left, right)
+
+    grouped: dict[str, list[str]] = {}
+    for name in names:
+        grouped.setdefault(find(name), []).append(name)
+    components = sorted(grouped.values(), key=len, reverse=True)
+    return components, stateless
+
+
+def collect_classes() -> tuple[dict[str, ClassInfo], dict[str, list[ast.ClassDef]]]:
+    """Parse the package and build a ClassInfo per class definition.
+
+    Returns:
+        A tuple of the qualified-name to ClassInfo mapping and, per module, the
+        raw ClassDef nodes, so a second pass can resolve cross-class references.
+    """
+    classes: dict[str, ClassInfo] = {}
+    nodes_by_module: dict[str, list[ast.ClassDef]] = {}
+
+    for path in source_files():
+        module = module_name_for(path)
+        source = path.read_text(encoding="utf-8")
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError as exc:
+            print(f"skipping {module}: {exc}", file=sys.stderr)
+            continue
+
+        radon_classes = {
+            (block.name, block.lineno): block
+            for block in cc_visit(source)
+            if isinstance(block, RadonClass)
+        }
+        definitions = [node for node in tree.body if isinstance(node, ast.ClassDef)]
+        nodes_by_module[module] = definitions
+
+        for node in definitions:
+            components, stateless = compute_lcom4(node)
+            radon_block = radon_classes.get((node.name, node.lineno))
+            method_complexities = (
+                [method.complexity for method in radon_block.methods]
+                if radon_block
+                else []
+            )
+            info = ClassInfo(
+                name=node.name,
+                module=module,
+                lineno=node.lineno,
+                bases=[b for b in (base_name(base) for base in node.bases) if b],
+                methods=[name for component in components for name in component],
+                stateless=stateless,
+                wmc=sum(method_complexities),
+                max_cc=max(method_complexities, default=0),
+                components=components,
+                interface=is_interface(node),
+            )
+            classes[info.qualified] = info
+
+    return classes, nodes_by_module
+
+
+def compute_coupling(
+    classes: dict[str, ClassInfo], nodes_by_module: dict[str, list[ast.ClassDef]]
+) -> None:
+    """Fill in CBO and NOC for every class.
+
+    CBO counts distinct other project classes named anywhere in the class body.
+    Names are matched bare, so two project classes sharing a name are conflated;
+    that is accepted here in exchange for not needing to resolve imports.
+
+    Args:
+        classes: All measured classes, mutated in place.
+        nodes_by_module: Raw ClassDef nodes keyed by module.
+    """
+    by_bare_name: dict[str, list[str]] = {}
+    for qualified, info in classes.items():
+        by_bare_name.setdefault(info.name, []).append(qualified)
+
+    for module, definitions in nodes_by_module.items():
+        for node in definitions:
+            info = classes[f"{module}.{node.name}"]
+            referenced: set[str] = set()
+            for child in ast.walk(node):
+                candidate = None
+                if isinstance(child, ast.Name):
+                    candidate = child.id
+                elif isinstance(child, ast.Attribute):
+                    candidate = child.attr
+                if candidate and candidate != node.name and candidate in by_bare_name:
+                    referenced.update(by_bare_name[candidate])
+            info.cbo = len(referenced)
+
+    for info in classes.values():
+        for base in info.bases:
+            for qualified in by_bare_name.get(base, []):
+                classes[qualified].noc += 1
+
+
+def inheritance_depth(info: ClassInfo, classes: dict[str, ClassInfo]) -> int:
+    """Compute the depth of inheritance tree, counting project bases only.
+
+    Args:
+        info: The class to measure.
+        classes: All measured classes.
+
+    Returns:
+        Number of project superclasses above it; 0 for a project-level root.
+    """
+    by_bare_name: dict[str, ClassInfo] = {}
+    for other in classes.values():
+        by_bare_name.setdefault(other.name, other)
+
+    depth = 0
+    seen = {info.qualified}
+    frontier = list(info.bases)
+    while frontier:
+        base = frontier.pop()
+        parent = by_bare_name.get(base)
+        if parent is None or parent.qualified in seen:
+            continue
+        seen.add(parent.qualified)
+        depth += 1
+        frontier.extend(parent.bases)
+    return depth
+
+
+def verdict(info: ClassInfo, cbo_cut: int) -> str:
+    """Classify a class from its cohesion and coupling.
+
+    Args:
+        info: The measured class.
+        cbo_cut: CBO value at which coupling counts as high.
+
+    Returns:
+        One of `interface`, `split candidate`, `god class`, `highly coupled`,
+        `ok`.
+    """
+    if info.interface:
+        return "interface"
+    incohesive = info.lcom4 >= 2 and len(info.methods) >= 4
+    coupled = info.cbo >= cbo_cut
+    if incohesive and coupled:
+        return "god class"
+    if incohesive:
+        return "split candidate"
+    if coupled:
+        return "highly coupled"
+    return "ok"
+
+
+def render(classes: dict[str, ClassInfo]) -> str:
+    """Render the class-level markdown report.
+
+    Args:
+        classes: All measured classes.
+
+    Returns:
+        The report as a markdown string.
+    """
+    measured = [info for info in classes.values() if not info.interface]
+    interfaces = len(classes) - len(measured)
+    cbo_values = sorted(info.cbo for info in measured if info.cbo)
+    cbo_cut = cbo_values[int(len(cbo_values) * 0.9)] if cbo_values else 0
+
+    ranked = sorted(
+        measured,
+        key=lambda info: (info.lcom4, info.cbo, info.wmc),
+        reverse=True,
+    )
+    verdicts: dict[str, list[ClassInfo]] = {}
+    for info in classes.values():
+        verdicts.setdefault(verdict(info, cbo_cut), []).append(info)
+
+    lines = [
+        "# Class-level coupling and cohesion (CK metrics)",
+        "",
+        f"- Classes: {len(classes)} ({interfaces} declaration-only, not measured)",
+        f"- Mean LCOM4: {sum(i.lcom4 for i in measured) / max(len(measured), 1):.2f}",
+        f"- Mean CBO: {sum(i.cbo for i in measured) / max(len(measured), 1):.2f}",
+        f"- High-coupling cut-off (90th percentile): CBO >= {cbo_cut}",
+        "",
+        "LCOM4 counts connected components of the method graph, so 1 is a",
+        "cohesive class and n means n unrelated responsibilities share a",
+        "namespace. CBO counts distinct other project classes referenced.",
+        "",
+        "Excluded from LCOM4, because each would register as an isolated",
+        "component regardless of how well the class is designed: `__init__` and",
+        "`__post_init__` (they touch every attribute), staticmethods and",
+        "classmethods (no `self`), and methods that read no instance state at",
+        "all. Protocols, ABCs, enums and stub-only classes are dropped whole.",
+        "",
+        "## Least cohesive / most coupled classes",
+        "",
+        "| Class | Module | Methods | LCOM4 | CBO | WMC | Max CC | DIT | NOC | Verdict |",
+        "|---|---|---:|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for info in ranked[:25]:
+        lines.append(
+            f"| `{info.name}` | `{info.module}` | {len(info.methods)} | {info.lcom4} | "
+            f"{info.cbo} | {info.wmc} | {info.max_cc} | "
+            f"{inheritance_depth(info, classes)} | {info.noc} | {verdict(info, cbo_cut)} |"
+        )
+
+    lines += ["", "## Verdicts", ""]
+    for key in ("god class", "split candidate", "highly coupled", "ok", "interface"):
+        group = verdicts.get(key, [])
+        lines.append(f"- **{key}** ({len(group)})")
+        if key not in ("ok", "interface"):
+            for info in sorted(group, key=lambda i: (-i.lcom4, -i.cbo)):
+                lines.append(
+                    f"  - `{info.qualified}` (LCOM4 {info.lcom4}, CBO {info.cbo}, "
+                    f"WMC {info.wmc})"
+                )
+                for island in info.islands:
+                    members = ", ".join(f"`{name}`" for name in sorted(island))
+                    lines.append(f"    - detachable: {members}")
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    """Measure every class, write the report and echo it to stdout."""
+    classes, nodes_by_module = collect_classes()
+    compute_coupling(classes, nodes_by_module)
+    report = render(classes)
+    REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    REPORT_PATH.write_text(report, encoding="utf-8")
+    print(report)
+    print(f"written to {REPORT_PATH.relative_to(REPO_ROOT)}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/prototyp/complexity-analysis/complexity_report.py
+++ b/prototyp/complexity-analysis/complexity_report.py
@@ -1,0 +1,413 @@
+"""Combined function-level and architecture-level complexity report for `src`.
+
+Function complexity comes from radon (cyclomatic / McCabe, same numbers as
+`radon cc`). Architecture complexity is derived from a static import graph
+built with `ast`, giving per-module afferent/efferent coupling, instability,
+import cycles and - the metric that matters most here - the blast radius, i.e.
+how many modules transitively depend on a module.
+
+The two axes are crossed into a risk score, so that a module is only called a
+hotspot when it is both internally complex and widely depended upon.
+
+Run it with radon injected, so the shared .venv is never re-synced:
+
+    uvx --with radon python prototyp/complexity-analysis/complexity_report.py
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from radon.complexity import cc_visit
+from radon.visitors import Function
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = REPO_ROOT / "src"
+PACKAGE_NAME = "src"
+REPORT_PATH = REPO_ROOT / "outputs" / "prototype" / "complexity-analysis" / "report.md"
+
+# A module counts as "high" on an axis when it sits in the top third of that
+# axis. Crossing the two thirds is what separates a hotspot from contained
+# complexity.
+HIGH_PERCENTILE = 2 / 3
+
+
+@dataclass
+class Module:
+    """Static facts about one Python module inside the package.
+
+    Attributes:
+        name: Dotted module name, e.g. `src.buffer.replay_buffer`.
+        path: Absolute path of the source file.
+        imports: Dotted names of package-internal modules it imports.
+        functions: Radon function records for every function and method in it.
+        importers: Dotted names of package-internal modules importing it.
+    """
+
+    name: str
+    path: Path
+    imports: set[str] = field(default_factory=set)
+    functions: list[Function] = field(default_factory=list)
+    importers: set[str] = field(default_factory=set)
+
+    @property
+    def decisions(self) -> int:
+        """Total decision points in the module (sum of complexity - 1)."""
+        return sum(fn.complexity - 1 for fn in self.functions)
+
+    @property
+    def max_complexity(self) -> int:
+        """Cyclomatic complexity of the most complex single function."""
+        return max((fn.complexity for fn in self.functions), default=0)
+
+    @property
+    def worst_function(self) -> Function | None:
+        """The most complex function in the module, or None if it has none."""
+        return max(self.functions, key=lambda fn: fn.complexity, default=None)
+
+    @property
+    def efferent(self) -> int:
+        """Fan-out: number of internal modules this module depends on."""
+        return len(self.imports)
+
+    @property
+    def afferent(self) -> int:
+        """Fan-in: number of internal modules depending on this module."""
+        return len(self.importers)
+
+    @property
+    def instability(self) -> float:
+        """Martin instability Ce / (Ca + Ce); 0.0 when the module is isolated."""
+        total = self.afferent + self.efferent
+        return self.efferent / total if total else 0.0
+
+
+def module_name_for(path: Path) -> str:
+    """Map a source path to its dotted module name.
+
+    Args:
+        path: Path to a `.py` file inside the package root.
+
+    Returns:
+        The dotted module name, with `__init__.py` collapsing to its package.
+    """
+    relative = path.relative_to(PACKAGE_ROOT).with_suffix("")
+    parts = list(relative.parts)
+    if parts[-1] == "__init__":
+        parts.pop()
+    return ".".join([PACKAGE_NAME, *parts])
+
+
+def discover_modules() -> dict[str, Module]:
+    """Collect every module in the package, skipping caches and vendored trees.
+
+    Returns:
+        Mapping of dotted module name to a Module with path set.
+    """
+    modules: dict[str, Module] = {}
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        name = module_name_for(path)
+        modules[name] = Module(name=name, path=path)
+    return modules
+
+
+def resolve_target(raw: str, known: set[str]) -> str | None:
+    """Resolve an imported dotted name to the nearest known module.
+
+    `from src.buffer import replay_buffer` names a submodule, while
+    `from src.buffer import SomeClass` names an attribute of the package. Both
+    arrive here as candidate dotted names, so the longest known prefix wins.
+
+    Args:
+        raw: Dotted name as written in the import statement.
+        known: All module names in the package.
+
+    Returns:
+        The matching module name, or None if the import leaves the package.
+    """
+    parts = raw.split(".")
+    while parts:
+        candidate = ".".join(parts)
+        if candidate in known:
+            return candidate
+        parts.pop()
+    return None
+
+
+def collect_imports(module: Module, tree: ast.AST, known: set[str]) -> None:
+    """Record every package-internal import of a module on the module itself.
+
+    Args:
+        module: The module being analysed; mutated in place.
+        tree: Parsed AST of that module.
+        known: All module names in the package.
+    """
+    package = module.name.rsplit(".", 1)[0] if "." in module.name else module.name
+    for node in ast.walk(tree):
+        candidates: list[str] = []
+        if isinstance(node, ast.Import):
+            candidates = [alias.name for alias in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:
+                base_parts = package.split(".")
+                trimmed = base_parts[: len(base_parts) - node.level + 1]
+                base = ".".join(trimmed)
+            else:
+                base = node.module or ""
+            if not base:
+                continue
+            candidates = [base, *(f"{base}.{alias.name}" for alias in node.names)]
+
+        for raw in candidates:
+            if not raw.startswith(PACKAGE_NAME):
+                continue
+            target = resolve_target(raw, known)
+            if target and target != module.name:
+                module.imports.add(target)
+
+
+def analyse(modules: dict[str, Module]) -> None:
+    """Fill in imports and function complexity for every module.
+
+    Args:
+        modules: Discovered modules, mutated in place.
+    """
+    known = set(modules)
+    for module in modules.values():
+        source = module.path.read_text(encoding="utf-8")
+        try:
+            tree = ast.parse(source, filename=str(module.path))
+        except SyntaxError as exc:
+            print(f"skipping {module.name}: {exc}", file=sys.stderr)
+            continue
+        collect_imports(module, tree, known)
+        module.functions = [
+            block for block in cc_visit(source) if isinstance(block, Function)
+        ]
+
+    for module in modules.values():
+        for target in module.imports:
+            modules[target].importers.add(module.name)
+
+
+def blast_radius(modules: dict[str, Module]) -> dict[str, int]:
+    """Count how many modules transitively depend on each module.
+
+    Args:
+        modules: Fully analysed modules.
+
+    Returns:
+        Mapping of module name to the size of its transitive dependent set.
+    """
+    radius: dict[str, int] = {}
+    for name in modules:
+        seen: set[str] = set()
+        queue = [name]
+        while queue:
+            current = queue.pop()
+            for importer in modules[current].importers:
+                if importer not in seen:
+                    seen.add(importer)
+                    queue.append(importer)
+        radius[name] = len(seen)
+    return radius
+
+
+def find_cycles(modules: dict[str, Module]) -> list[list[str]]:
+    """Find import cycles as strongly connected components of size > 1.
+
+    Args:
+        modules: Fully analysed modules.
+
+    Returns:
+        Sorted list of cycles, each a sorted list of module names.
+    """
+    index: dict[str, int] = {}
+    low: dict[str, int] = {}
+    on_stack: set[str] = set()
+    stack: list[str] = []
+    counter = 0
+    components: list[list[str]] = []
+
+    def strong_connect(name: str) -> None:
+        nonlocal counter
+        index[name] = low[name] = counter
+        counter += 1
+        stack.append(name)
+        on_stack.add(name)
+        for target in sorted(modules[name].imports):
+            if target not in index:
+                strong_connect(target)
+                low[name] = min(low[name], low[target])
+            elif target in on_stack:
+                low[name] = min(low[name], index[target])
+        if low[name] == index[name]:
+            component = []
+            while True:
+                node = stack.pop()
+                on_stack.discard(node)
+                component.append(node)
+                if node == name:
+                    break
+            if len(component) > 1:
+                components.append(sorted(component))
+
+    sys.setrecursionlimit(max(sys.getrecursionlimit(), 10 * len(modules) + 1000))
+    for name in sorted(modules):
+        if name not in index:
+            strong_connect(name)
+    return sorted(components, key=len, reverse=True)
+
+
+def threshold(values: list[float]) -> float:
+    """Return the cut-off separating the top third of a distribution.
+
+    Args:
+        values: Observed values on one axis.
+
+    Returns:
+        The value at the HIGH_PERCENTILE position, or 0.0 for an empty input.
+    """
+    positives = sorted(v for v in values if v > 0)
+    if not positives:
+        return 0.0
+    position = min(int(len(positives) * HIGH_PERCENTILE), len(positives) - 1)
+    return positives[position]
+
+
+def classify(decisions: int, radius: int, cut_dec: float, cut_rad: float) -> str:
+    """Assign a module to a quadrant of the complexity/reach plane.
+
+    Args:
+        decisions: Total decision points in the module.
+        radius: Number of modules transitively depending on it.
+        cut_dec: Complexity cut-off for "high".
+        cut_rad: Blast-radius cut-off for "high".
+
+    Returns:
+        One of `hotspot`, `contained`, `hub`, `ok`.
+    """
+    complex_enough = decisions >= cut_dec and decisions > 0
+    central_enough = radius >= cut_rad and radius > 0
+    if complex_enough and central_enough:
+        return "hotspot"
+    if complex_enough:
+        return "contained"
+    if central_enough:
+        return "hub"
+    return "ok"
+
+
+def render(modules: dict[str, Module]) -> str:
+    """Render the full markdown report.
+
+    Args:
+        modules: Fully analysed modules.
+
+    Returns:
+        The report as a markdown string.
+    """
+    radius = blast_radius(modules)
+    cycles = find_cycles(modules)
+    cut_dec = threshold([float(m.decisions) for m in modules.values()])
+    cut_rad = threshold([float(r) for r in radius.values()])
+
+    rows = []
+    for module in modules.values():
+        risk = module.decisions * (1 + radius[module.name])
+        rows.append((risk, module, radius[module.name]))
+    rows.sort(key=lambda row: row[0], reverse=True)
+    peak = rows[0][0] if rows and rows[0][0] else 1
+
+    total_functions = sum(len(m.functions) for m in modules.values())
+    total_edges = sum(m.efferent for m in modules.values())
+
+    lines = [
+        "# Complexity report: function level x architecture level",
+        "",
+        f"- Modules: {len(modules)}",
+        f"- Functions and methods: {total_functions}",
+        f"- Internal import edges: {total_edges}",
+        f"- Import cycles: {len(cycles)}",
+        "",
+        "Risk = decision points in the module x (1 + blast radius), normalised",
+        "to 100. A module scores high only when complex code sits behind a wide",
+        "set of dependents. Quadrant thresholds are the top third of each axis:",
+        f"decisions >= {cut_dec:.0f}, blast radius >= {cut_rad:.0f}.",
+        "",
+        "## Top 20 by risk",
+        "",
+        "| Risk | Module | Decisions | Max CC | Worst function | Ca | Ce | I | Blast | Quadrant |",
+        "|---:|---|---:|---:|---|---:|---:|---:|---:|---|",
+    ]
+
+    for risk, module, reach in rows[:20]:
+        worst = module.worst_function
+        worst_label = (
+            f"`{worst.name}` ({worst.complexity})" if worst and worst.complexity > 1 else "-"
+        )
+        quadrant = classify(module.decisions, reach, cut_dec, cut_rad)
+        lines.append(
+            f"| {100 * risk / peak:.0f} | `{module.name}` | {module.decisions} | "
+            f"{module.max_complexity} | {worst_label} | {module.afferent} | "
+            f"{module.efferent} | {module.instability:.2f} | {reach} | {quadrant} |"
+        )
+
+    lines += ["", "## Quadrants", ""]
+    buckets: dict[str, list[str]] = defaultdict(list)
+    for _, module, reach in rows:
+        buckets[classify(module.decisions, reach, cut_dec, cut_rad)].append(module.name)
+    labels = {
+        "hotspot": "complex and widely depended upon - refactor here first",
+        "contained": "complex but few dependents - safe to rework in isolation",
+        "hub": "simple but widely depended upon - keep it that way",
+        "ok": "neither complex nor central",
+    }
+    for key in ("hotspot", "contained", "hub", "ok"):
+        names = buckets[key]
+        lines.append(f"- **{key}** ({len(names)}): {labels[key]}")
+        if key != "ok":
+            for name in names:
+                lines.append(f"  - `{name}`")
+
+    lines += ["", "## Import cycles", ""]
+    if cycles:
+        for cycle in cycles:
+            lines.append(f"- {' -> '.join(f'`{name}`' for name in cycle)}")
+    else:
+        lines.append("None. The import graph is a DAG.")
+
+    lines += ["", "## Dependency graph of the top 10 risk modules", "", "```mermaid", "graph LR"]
+    top_names = [module.name for _, module, _ in rows[:10]]
+    aliases = {name: f"n{i}" for i, name in enumerate(top_names)}
+    for name in top_names:
+        short = name.removeprefix(f"{PACKAGE_NAME}.")
+        lines.append(f"  {aliases[name]}[\"{short}\"]")
+    for name in top_names:
+        for target in sorted(modules[name].imports):
+            if target in aliases:
+                lines.append(f"  {aliases[name]} --> {aliases[target]}")
+    lines += ["```", ""]
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    """Build the report, write it to disk and print a short summary."""
+    modules = discover_modules()
+    analyse(modules)
+    report = render(modules)
+    REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    REPORT_PATH.write_text(report, encoding="utf-8")
+    print(report)
+    print(f"\nwritten to {REPORT_PATH.relative_to(REPO_ROOT)}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds `prototyp/complexity-analysis/`, a read-only analysis of `src` at three
granularities: function, class and module. Nothing in `src` is touched.

## Why

Ranking by function complexity alone is misleading. `ruff --select C901` and
`radon cc` both put `src/main.py` first, because `run_loop` scores CC 31. But
nothing imports `src.main`, so splitting that function cannot break anything
downstream. Meanwhile modules with moderate complexity sit under half the
package and are expensive to touch. The two axes have to be crossed to rank
refactoring targets.

## What it adds

**`complexity_report.py`** - radon cyclomatic complexity per module, crossed
with a static import graph built from `ast`: afferent/efferent coupling, Martin
instability, Tarjan strongly connected components for cycles, and transitive
fan-in ("blast radius"). Combined into a risk score and four quadrants.

**`class_metrics.py`** - CK metrics per class: CBO, LCOM4, WMC, DIT, NOC. The
LCOM4 method graph excludes constructs that are isolated by construction:
Protocols, ABCs and stub-only bodies, classmethods, staticmethods, `__init__`,
and methods that read no instance state. All eight raw findings were artefacts
of those; the filters are documented with their triggering example in
`PROBLEMS.md`.

Both run through `uvx --with radon`, so the shared `.venv` is never re-synced.
Reports are written to `outputs/`, which is gitignored.

## Findings

| | |
|---|---|
| Import graph | DAG, zero cycles |
| Modules / functions / classes | 97 / 498 / 107 |
| Mean cyclomatic complexity | 2.75 (rank A) |
| Module hotspots | 8, of which 6 are the vendored JAX VGGT port |
| Authored hotspots | `buffer.replay_buffer`, `environments.habitat` |
| Highest CBO | `R2DreamerAgent` (11) |
| Cohesion | one surviving LCOM4 finding, cosmetic |
| Inheritance | DIT 0-1 everywhere |

The reranking works: `src.main` holds the largest complexity concentration in
the repo (98 decision points) and lands at rank 17, because its blast radius is
0. That makes splitting `run_loop` the cheapest large complexity win available.

## How to run

```bash
uvx --with radon python prototyp/complexity-analysis/complexity_report.py
```

```bash
uvx --with radon python prototyp/complexity-analysis/class_metrics.py
```

## What not to read into it

The risk score multiplies two quantities with different units and no shared
scale. It is a sort key for one snapshot of one repo, not a measurement - sum
or percentile ranks would reorder it. The quadrant split it feeds is the robust
part. The LCOM4 result is inconclusive rather than clean, since four exclusion
filters had to be tuned before it stopped reporting artefacts. And none of it
was regressed against plain LOC, which is the control that would show whether
any of this beats "how long is the file".

## Second commit

`chore: ignore generated diagrams at the repo root` adds `/*.svg` to
`.gitignore`, for pyreverse and graphviz output dropped at the root. Scoped to
the root on purpose: four thesis figures under `docs/` are tracked and must
stay visible to git.
